### PR TITLE
Bug fix

### DIFF
--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -78,11 +78,7 @@ class __HardwareRepositoryClient:
         serverAddress needs to be the HWR server address (host:port) or
         a list of paths where to find XML files locally (when server is not in use)
         """
-        if not type(serverAddress) in (list, tuple): 
-            self.serverAddress = [serverAddress]
-        else:
-            self.serverAddress = serverAddress
-        
+        self.serverAddress = serverAddress
         self.requiredHardwareObjects = {}
         self.xml_source={}
         self.__connected = False


### PR DESCRIPTION
the code introduced by commit 3d24e is breaking compatibility with
the Hardware Repository server (still in use on some ESRF beamlines,
mainly because it supports *saving* of XML files when configuration
information is modified modified by hardware objects, eg. when adjusting
beamstop IN position...), so I put back the old code.

By the way I don't understand why self.serverAddress should always be
a list or a tuple ? The documentation says it can be a host:port string
(which is the case when used with Hardware Repository Server).