### PR TITLE
2016.06.19. Added feature to use nested xmls

### DIFF
--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -82,6 +82,7 @@ class __HardwareRepositoryClient:
         self.requiredHardwareObjects = {}
         self.xml_source={}
         self.__connected = False
+        self.server = None
         
     def connect(self):
         if self.__connected:
@@ -92,7 +93,6 @@ class __HardwareRepositoryClient:
 
             if type(self.serverAddress)==bytes:
                 mngr = SpecConnectionsManager.SpecConnectionsManager() 
-
                 self.server = mngr.getConnection(self.serverAddress)
       
                 with gevent.Timeout(3): 
@@ -172,6 +172,8 @@ class __HardwareRepositoryClient:
                     try:
                         #t0 = time.time()
                         ho = self.parseXML(xmldata, hoName)
+                        if type(ho) == str:
+                            return self.loadHardwareObject(ho)  
                     except:
                         logging.getLogger("HWR").exception("Cannot parse XML file for Hardware Object %s", hoName)
                     else:


### PR DESCRIPTION
Added feature to redirect a xml to different xml. Feature allows to define a referemce (**hwr_import href**) to different xml. For example

* detector-mockup.xml:

```
<hwr_import href="/detector-mockup-pilatus"/>
```

* detector-mockup-pilatus.xml:

```
<equipment class = "DetectorMockup">
  <tempThreshold>33.5</tempThreshold>
  <humidityThreshold>20.0</humidityThreshold>
  <tolerance>0.2</tolerance>
  <type>pilatus</type>
  <model>6M_F</model>
  <manufacturer>DECTRIS</manufacturer>
  <px>0.172</px>
  <py>0.172</py>
  <hasShutterless>True</hasShutterless>
  <fileSuffix>cbf</fileSuffix>
</equipment>
 ```

If from the gui or hardware objects a **detector-mockup** is requested then **detector-mockup-pilatus** will be loaded.
This idea came up by switching detectors at beamline. Previously the only way was to rewrite xml or redefine all references. This makes life a little bit easier.