### PR TITLE
Small changes in MultiplePositions Hardware Object

### DIFF
--- a/HardwareObjects/MultiplePositions.py
+++ b/HardwareObjects/MultiplePositions.py
@@ -207,7 +207,8 @@ class MultiplePositions(Equipment):
 
     
     def stateChanged(self, state):
-        self.emit("stateChanged", (state,))
+        self.emit("stateChanged", (self.getState(),))
+        self.checkPosition()
 
  
     def moveToPosition(self, name, wait=False):
@@ -277,6 +278,7 @@ class MultiplePositions(Equipment):
             self.positions[name][role] = pos
             position.setProperty(role, pos)
 
+        self.checkPosition()
         self.commitChanges()
         
 


### PR DESCRIPTION
Not sure why those changes are there, but it seems safer to call getState() instead of
relying on the state in stateChanged callback... It has been changed on our beamlines here
so I suppose it's a good change ?
