### PR TITLE
[2.2] Added missing class OpticalCentring (taken from master) refered to from queue_entry.py

### DIFF
--- a/HardwareObjects/queue_model_objects_v1.py
+++ b/HardwareObjects/queue_model_objects_v1.py
@@ -1272,6 +1272,28 @@ class Crystal(object):
         self.energy_scan_result = EnergyScanResult()
 
 
+class OpticalCentring(TaskNode):
+    """Optical automatic centering with lucid"""
+
+    def __init__(self, user_confirms=False):
+        TaskNode.__init__(self)
+
+        if user_confirms:
+            self.set_name("Optical automatic centring (user confirms)")
+        else:
+            self.set_name("Optical automatic centring")
+        if user_confirms:
+            self.try_count = 3
+        else:
+            self.try_count = 1
+
+    def add_task(self, task_node):
+        pass
+
+    def get_name(self):
+        return self._name
+
+
 class CentredPosition(object):
     """
     Class that represents a centred position.


### PR DESCRIPTION
Hi,

The OpticalCentring class was missing in queue_model_objects_v1.py, I guess its an artifact from a previous merge process. In anyways its the same as for master.

Cheers,
Marcus