### PR TITLE
[2.2] Characterization related methods

### DIFF
--- a/HardwareObjects/QueueModel.py
+++ b/HardwareObjects/QueueModel.py
@@ -51,6 +51,7 @@ class QueueModel(HardwareObject):
         You should normaly not need to call this method.
         """
         self.queue_hwobj = self.getObjectByRole("queue")
+        self.queue_hwobj.queue_model_hwobj = self
 
     def select_model(self, name):
         """

--- a/HardwareObjects/queue_entry.py
+++ b/HardwareObjects/queue_entry.py
@@ -1057,6 +1057,7 @@ class CharacterisationQueueEntry(BaseQueueEntry):
                 new_dcg_model.set_enabled(False)
                 new_dcg_model.set_name(new_dcg_name)
                 new_dcg_model.set_number(new_dcg_num)
+                new_dcg_model.set_origin(char._node_id)
                 self.queue_model_hwobj.add_child(sample_data_model,
                                                  new_dcg_model)
 

--- a/HardwareObjects/queue_entry.py
+++ b/HardwareObjects/queue_entry.py
@@ -1105,7 +1105,7 @@ class CharacterisationQueueEntry(BaseQueueEntry):
         self.data_analysis_hwobj = self.beamline_setup.data_analysis_hwobj
         self.diffractometer_hwobj = self.beamline_setup.diffractometer_hwobj
         #should be an other way how to get queue_model_hwobj:
-        self.queue_model_hwobj = self.get_view().listView().parent().queue_model_hwobj
+        self.queue_model_hwobj = self._queue_controller.queue_model_hwobj
         self.session_hwobj = self.beamline_setup.session_hwobj
 
     def post_execute(self):

--- a/HardwareObjects/queue_model_objects_v1.py
+++ b/HardwareObjects/queue_model_objects_v1.py
@@ -26,6 +26,7 @@ class TaskNode(object):
         self._enabled = True
         self._node_id = None
         self._requires_centring = True
+        self._origin = None
 
     def is_enabled(self):
         """
@@ -71,6 +72,24 @@ class TaskNode(object):
         else:
             self._name = str(name)
 
+    def set_origin(self, node_id):
+        """
+        Sets the origin of this node, the node id of the node, if any,
+        that somehow generated this node.
+
+        :param name: node_id
+        :type name: The node id that is the origin of this node
+
+        :returns: none
+        """
+        self._origin = node_id
+
+    def get_origin(self):
+        """
+        :returns: The node id that is the origin of this node.
+        :rtype: int
+        """
+        return self._origin
     def set_number(self, number):
         """
         Sets the number of this node. The number can be used


### PR DESCRIPTION
Hey !

 - Adding a easier way to reference the queue_model

 - Added the possibility to set originating queue_id for nodes that was generated 
by third party software and have another origin than the node directly above it in the tree

Cheers,
Marcus


