### PR TITLE
[master] 2017.07.28. Reload hardware objects

### DIFF
--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -299,11 +299,14 @@ class HardwareObjectNode:
         """
         return
 
+    def clear_gevent(self):
+        pass
+
 class HardwareObject(HardwareObjectNode, CommandContainer):
     def __init__(self, rootName):
         HardwareObjectNode.__init__(self, rootName)
         CommandContainer.__init__(self)
- 
+        self.connect_dict = {} 
 
     def _init(self):
         #'protected' post-initialization method
@@ -370,6 +373,9 @@ class HardwareObject(HardwareObjectNode, CommandContainer):
         signal = str(signal)
             
         dispatcher.connect(slot, signal, sender)
+
+        self.connect_dict[sender] = {"signal": signal,
+                                     "slot": slot}
  
         if hasattr(sender, "connectNotify"):
             sender.connectNotify(signal)


### PR DESCRIPTION
Added method to reload hardware objects.
Method is based on reimport package (sudo pip install reimport). It detects files that have been changed. Then these hwobj are disconnected from gui, reimported and connected back to gui.
After connection to gui `update_values` method is called to refresh gui.
Before reimporting all gevent greenlets needs to be stoped and in init relaunched.

This needs more testing