### PR TITLE
Cats changes

### DIFF
--- a/HardwareObjects/sample_changer/Cats90.py
+++ b/HardwareObjects/sample_changer/Cats90.py
@@ -3,23 +3,81 @@ CATS sample changer hardware object.
 
 Implements the abstract interface of the GenericSampleChanger for the CATS
 sample changer model.
+
 Derived from Alexandre Gobbo's implementation for the EMBL SC3 sample changer.
 Derived from Michael Hellmig's implementation for the BESSY CATS sample changer
- -fix the Abort Bug
- -enable setondiff for the catsmaint object 
- -fix the bug of MD2 jam during exchange or unload
+
+History:
+   - adds support for ISARA Model
+
+Know Catalog of MXCuBE sites and CATS
+   BESSY - 
+       BL14. (CATS) 3lid * 3puck (SPINE) * 10 = 90 samples  
+   ALBA - 
+       XALOC. (CATS) 3lid * 3puck (UNIPUCK) * 16 = 144 samples 
+   MAXIV -
+       BIOMAX. (ISARA) 1 lid * 10puck (SPINE) * 10 + 19puck (UNIPUCK) * 16 = 404 samples
+   SOLEIL
+       PX1. (CATS)
+       PX2. (CATS)
 """
-from .GenericSampleChanger import *
+from GenericSampleChanger import *
+
 import time
-import qt
+import PyTango
+import logging
 
-__author__ = "Jie Nan"
-__credits__ = ["The MxCuBE collaboration"]
+__author__ = "Michael Hellmig, Jie Nan, Bixente Rey"
+__credits__ = ["The MXCuBE collaboration"]
 
-__email__ = "jie.nan@maxlab.lu.se"
-__status__ = "Alpha"
+__email__ = "txo@txolutions.com"
 
-class Pin(Sample):        
+#  
+# Attention. Numbers here correspond to values returned by CassetteType of device server
+#  
+BASKET_UNKNOWN, BASKET_SPINE, BASKET_UNIPUCK = (0,1,2)
+
+#
+# Number of samples per puck type
+#
+SAMPLES_SPINE = 10
+SAMPLES_UNIPUCK = 16
+
+TOOL_FLANGE, TOOL_UNIPUCK, TOOL_SPINE, TOOL_PLATE, \
+    TOOL_LASER, TOOL_DOUBLE_GRIPPER = (0,1,2,3,4,5)
+
+class Basket(Container):
+    __TYPE__ = "Puck"
+
+    def __init__(self, container, number, samples_num=10, name="Puck"):
+        super(Basket, self).__init__(self.__TYPE__,container,Basket.getBasketAddress(number),True)
+
+        self.samples_num = samples_num
+
+        for i in range(samples_num):
+            slot = Pin(self,number,i+1)
+            self._addComponent(slot)
+
+    @staticmethod
+    def getBasketAddress(basket_number):
+        return str(basket_number)
+
+    def getNumberOfSamples(self):
+        return self.samples_num
+
+    def clearInfo(self):
+        #self.getContainer()._reset_basket_info(self.getIndex()+1)
+        self.getContainer()._triggerInfoChangedEvent()
+
+class SpineBasket(Basket):
+    def __init__(self, container, number, name="SpinePuck"):
+        super(SpineBasket, self).__init__(container,Basket.getBasketAddress(number), SAMPLES_SPINE, True)
+
+class UnipuckBasket(Basket):
+    def __init__(self, container, number, name="UniPuck"):
+        super(UnipuckBasket, self).__init__(container,Basket.getBasketAddress(number), SAMPLES_UNIPUCK, True)
+
+class Pin(Sample):
     STD_HOLDERLENGTH = 22.0
 
     def __init__(self,basket,basket_no,sample_no):
@@ -34,97 +92,355 @@ class Pin(Sample):
 
     @staticmethod
     def getSampleAddress(basket_number, sample_number):
-        return str(basket_number) + ":" + "%02d" % (sample_number)
-
-
-class Basket(Container):
-    __TYPE__ = "Puck"    
-    NO_OF_SAMPLES_PER_PUCK = 10
-
-    def __init__(self,container,number):
-        super(Basket, self).__init__(self.__TYPE__,container,Basket.getBasketAddress(number),True)
-        for i in range(Basket.NO_OF_SAMPLES_PER_PUCK):
-            slot = Pin(self,number,i+1)
-            self._addComponent(slot)
-                            
-    @staticmethod
-    def getBasketAddress(basket_number):
-        return str(basket_number)
-
-    def clearInfo(self):
-	self.getContainer()._reset_basket_info(self.getIndex()+1)
-        self.getContainer()._triggerInfoChangedEvent()
+        if basket_number is not None and sample_number is not None:
+            return str(basket_number) + ":" + "%02d" % (sample_number)
+        else:
+            return ""
 
 
 class Cats90(SampleChanger):
     """
+
     Actual implementation of the CATS Sample Changer,
-    BESSY BL14.1 installation with 3 lids and 90 samples
+       BESSY BL14.1 installation with 3 lids and 90 samples
+
     """    
     __TYPE__ = "CATS"    
-    NO_OF_LIDS = 3
-    NO_OF_BASKETS = 9
+
+    default_no_lids = 3
+    baskets_per_lid = 3
+
+    default_basket_type = BASKET_SPINE
 
     def __init__(self, *args, **kwargs):
         super(Cats90, self).__init__(self.__TYPE__,False, *args, **kwargs)
             
     def init(self):      
+
+        #  
+        # DO NOT CALL SampleChanger.init()
+        #  If SampleChanger.init() is called reception of signals at connection time is not done.  
+        #
+        #  In the case of Cats90 we do not use an update_timer... update is done by signals from Tango channels 
+        #  
+
         self._selected_sample = None
         self._selected_basket = None
         self._scIsCharging = None
-        self._startLoad =False # add flag to disable Load or UnLoad/Exchange Button immediately after 1 click (Avoid Click multiple times)
+
+        self.read_datamatrix = False
+        self.unipuck_tool = TOOL_UNIPUCK
+
+        self.former_loaded = None
+        self.cats_device = None
+
+        self.cats_datamatrix = ""
+        self.cats_loaded_lid = None
+        self.cats_loaded_num = None
+
+        # Default values
+        self.cats_powered = False
+        self.cats_status = ""
+        self.cats_running = False
+        self.cats_state = PyTango.DevState.UNKNOWN
+        self.cats_lids_closed = False
+
+        self.basket_types = None
+        self.number_of_baskets = None
 
         # add support for CATS dewars with variable number of lids
-        # assumption: each lid provides access to three baskets
-        self._propNoOfLids = self.getProperty('no_of_lids')
-        if self._propNoOfLids is not None:
-            try:
-                Cats90.NO_OF_LIDS = int(self._propNoOfLids)
-            except ValueError:
-                pass
-            else:
-                Cats90.NO_OF_BASKETS = 3 * Cats90.NO_OF_LIDS
-        
-        # initialize the sample changer components, moved here from __init__ after allowing
-        # variable number of lids
-        for i in range(Cats90.NO_OF_BASKETS):
-            basket = Basket(self,i+1)
-            self._addComponent(basket)
+
+        # Create channels from XML
+
+        self.cats_device = PyTango.DeviceProxy(self.getProperty("tangoname"))
+
+        no_of_lids = self.getProperty('no_of_lids')
+        if no_of_lids is None:
+            self.number_of_lids = self.default_no_lids
+        else:
+            self.number_of_lids = int(no_of_lids)
+
+        # Create channels
+        self._chnState = self.getChannelObject("_chnState")
+        if self._chnState is None:
+            self._chnState = self.addChannel({
+                    "type": "tango", "name": "_chnState",
+                    "tangoname": self.tangoname, "polling": 300,
+                }, "State")
+
+        self._chnStatus = self.getChannelObject("_chnStatus")
+        if self._chnStatus is None:
+            self._chnStatus = self.addChannel({
+                    "type": "tango", "name": "_chnStatus",
+                    "tangoname": self.tangoname, "polling": 300,
+                }, "Status")
+
+        self._chnPowered = self.getChannelObject("_chnPowered")
+        if self._chnPowered is None:
+            self._chnPowered = self.addChannel({
+                    "type": "tango", "name": "_chnPowered",
+                    "tangoname": self.tangoname, "polling": 300,
+                }, "Powered")
+
+        self._chnPathRunning = self.getChannelObject("_chnPathRunning")
+        if self._chnPathRunning is None:
+            self._chnPathRunning = self.addChannel({
+                    "type": "tango", "name": "_chnPathRunning",
+                    "tangoname": self.tangoname, "polling": 1000,
+                }, "PathRunning")
+
+        self._chnNumLoadedSample = self.getChannelObject("_chnNumLoadedSample")
+        if self._chnNumLoadedSample is None:
+            self._chnNumLoadedSample = self.addChannel({
+                    "type": "tango", "name": "_chnNumLoadedSample",
+                    "tangoname": self.tangoname, "polling": 1000,
+                }, "NumSampleOnDiff")
+
+        self._chnLidLoadedSample = self.getChannelObject("_chnLidLoadedSample")
+        if self._chnLidLoadedSample is None:
+            self._chnLidLoadedSample = self.addChannel({
+                    "type": "tango", "name": "_chnLidLoadedSample",
+                    "tangoname": self.tangoname, "polling": 1000,
+                }, "LidSampleOnDiff")
+
+        self._chnSampleBarcode = self.getChannelObject("_chnSampleBarcode")
+        if self._chnSampleBarcode is None:
+            self._chnSampleBarcode = self.addChannel({
+                    "type": "tango", "name": "_chnSampleBarcode",
+                    "tangoname": self.tangoname, "polling": 1000,
+                }, "Barcode")
+
+        self._chnSampleIsDetected = self.getChannelObject("_chnSampleIsDetected")
+        if self._chnSampleIsDetected is None:
+            self._chnSampleIsDetected = self.addChannel({
+                    "type": "tango", "name": "_chnSampleIsDetected",
+                    "tangoname": self.tangoname, 
+                }, "di_PRI_SOM")
+
+        self._chnAllLidsClosed = self.getChannelObject("_chnTotalLidState")
+        if self._chnAllLidsClosed is None:
+            self._chnAllLidsClosed = self.addChannel({
+                    "type": "tango", "name": "_chnAllLidsClosed",
+                    "tangoname": self.tangoname, "polling": 1000,
+                }, "di_AllLidsClosed")
+
+        # commands
+        self._cmdLoad = self.getCommandObject("_cmdLoad")
+        if self._cmdLoad is None:
+            self._cmdLoad = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdLoad",
+                    "tangoname": self.tangoname,
+                }, "put")
+
+        self._cmdUnload = self.getCommandObject("_cmdUnload")
+        if self._cmdUnload is None:
+            self._cmdUnload = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdUnload",
+                    "tangoname": self.tangoname,
+                }, "get")
+
+        self._cmdChainedLoad = self.getCommandObject("_cmdChainedLoad")
+        if self._cmdChainedLoad is None:
+            self._cmdChainedLoad = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdChainedLoad",
+                    "tangoname": self.tangoname,
+                }, "getput")
+
+        self._cmdAbort = self.getCommandObject("_cmdAbort")
+        if self._cmdAbort is None:
+            self._cmdAbort = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdAbort",
+                    "tangoname": self.tangoname,
+                }, "abort")
+
+        self._cmdLoadBarcode = self.getCommandObject("_cmdLoadBarcode")
+        if self._cmdLoadBarcode is None:
+            self._cmdLoadBarcode = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdLoadBarcode",
+                    "tangoname": self.tangoname,
+                }, "put_bcrd")
+
+        self._cmdChainedLoadBarcode = self.getCommandObject("_cmdChainedLoadBarcode")
+        if self._cmdChainedLoadBarcode is None:
+            self._cmdChainedLoadBarcode = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdChainedLoadBarcode",
+                    "tangoname": self.tangoname,
+                }, "getput_bcrd")
+
+        self._cmdScanSample = self.getCommandObject("_cmdScanSample")
+        if self._cmdScanSample is None:
+            self._cmdScanSample = self.addCommand({
+                    "type": "tango",
+                    "name": "_cmdScanSample",
+                    "tangoname": self.tangoname,
+                }, "barcode")
+
+
+        # see if we can find model from devserver. Otherwise... CATS
+        try:
+            self.cats_model = self.cats_device.read_attribute("CatsModel").value
+        except PyTango.DevError:
+            self.cats_model = "CATS"
             
-        for channel_name in ("_chnState", "_chnPowered", "_chnNumLoadedSample", "_chnLidLoadedSample", "_chnSampleBarcode", "_chnPathRunning", "_chnSampleIsDetected","_chnCurrentPhase", "_chnTransferMode"):
-            setattr(self, channel_name, self.getChannelObject(channel_name))
-           
-        for command_name in ("_cmdAbort", "_cmdLoad", "_cmdUnload", "_cmdChainedLoad","_cmdRestartMD2"):
-            setattr(self, command_name, self.getCommandObject(command_name))
+        # see if the device server can return CassetteTypes (and then number of cassettes/baskets)
+        try:
+            self.basket_types = self.cats_device.read_attribute("CassetteType").value
+            self.number_of_baskets = len(self.basket_types)
+        except PyTango.DevError:
+            pass
 
-        for basket_index in range(Cats90.NO_OF_BASKETS):            
-            channel_name = "_chnBasket%dState" % (basket_index + 1)
-            setattr(self, channel_name, self.getChannelObject(channel_name))
+        # find number of baskets and number of samples per basket 
+        if self.number_of_baskets is not None: 
+            if self.is_cats():
+                # if CATS... uniform type of baskets. the first number in CassetteType is used for all
+                basket_type = self.basket_types[0]
+                if basket_type is BASKET_UNIPUCK:
+                    self.samples_per_basket = SAMPLES_UNIPUCK
+                else:
+                    self.samples_per_basket = SAMPLES_SPINE
+            else:
+                self.samples_per_basket = None
+        else:
+            # ok. it does not. use good old way (xml or default) to find nb baskets and samples
+            no_of_baskets = self.getProperty('no_of_baskets')
+            samples_per_basket = self.getProperty('samples_per_basket')
 
-        self._lidStatus = self.getChannelObject("_chnTotalLidState")
-        if self._lidStatus is not None:
-            self._lidStatus.connectSignal("update", self._updateOperationMode)
+            if no_of_baskets is None:
+                self.number_of_baskets = self.baskets_per_lid * self.number_of_lids
+            else:
+                self.number_of_baskets = int(no_of_baskets)
 
-        # maintenance commands and status attributes
-        self._powerOn = self.addCommand({"type":"tango", "name":"powerOn", "tangoname": self.tangoname}, "powerOn")
-        self._powerOff = self.addCommand({"type":"tango", "name":"powerOff", "tangoname": self.tangoname}, "powerOff")
-        self._openLid1 = self.addCommand({"type":"tango", "name":"openlid1", "tangoname": self.tangoname}, "openlid1")
-        self._closeLid1 = self.addCommand({"type":"tango", "name":"closelid1", "tangoname": self.tangoname}, "closelid1")
-        self._openLid2 = self.addCommand({"type":"tango", "name":"openlid2", "tangoname": self.tangoname}, "openlid2")
-        self._closeLid2 = self.addCommand({"type":"tango", "name":"closelid2", "tangoname": self.tangoname}, "closelid2")
-        self._openLid3 = self.addCommand({"type":"tango", "name":"openlid3", "tangoname": self.tangoname}, "openlid3")
-        self._closeLid3 = self.addCommand({"type":"tango", "name":"closelid3", "tangoname": self.tangoname}, "closelid3")
-        self._back = self.addCommand({"type":"tango", "name":"back", "tangoname": self.tangoname}, "back")
-        self._safe = self.addCommand({"type":"tango", "name":"safe", "tangoname": self.tangoname}, "safe")
-        self._lid1State = self.addChannel({"type":"tango", "name":"di_Lid1Open", "tangoname": self.tangoname, "polling": "events"}, "Lid1Open")
-        self._lid2State = self.addChannel({"type":"tango", "name":"di_Lid2Open", "tangoname": self.tangoname, "polling": "events"}, "Lid2Open")
-        self._lid3State = self.addChannel({"type":"tango", "name":"di_Lid3Open", "tangoname": self.tangoname, "polling": "events"}, "Lid3Open")
+            self.basket_types = [None,] * self.number_of_baskets
 
+            if samples_per_basket is None:
+                self.samples_per_basket = SAMPLES_SPINE
+            else:
+                self.samples_per_basket = int(samples_per_basket)
+
+        # declare channels to detect basket presence changes
+        if self.is_isara():
+            self.basket_channels = None
+            self._chnBasketPresence = self.getChannelObject("_chnBasketPresence")
+            if self._chnBasketPresence is None:
+                self._chnBasketPresence = self.addChannel({
+                        "type": "tango", "name": "_chnBasketPresence",
+                        "tangoname": self.tangoname, "polling": 1000,
+                    }, "CassettePresence")
+            self.samples_per_basket = None
+        else:
+            self.basket_channels = [None,] * self.number_of_baskets
+
+            for basket_index in range(self.number_of_baskets):            
+                channel_name = "_chnBasket%dState" % (basket_index + 1)
+                chan = self.getChannelObject(channel_name)
+                if chan is None:
+                   chan = self.addChannel({
+                        "type": "tango", "name": channel_name,
+                        "tangoname": self.tangoname, "polling": 1000,
+                      }, "Cassette%dPresence" % (basket_index+1))
+                self.basket_channels[basket_index] = chan
+
+        #
+        # determine Cats geometry and prepare objects
+        #
         self._initSCContents()
 
-        # SampleChanger.init must be called _after_ initialization of the Cats because it starts the update methods which access
-        # the device server's status attributes
-        SampleChanger.init(self)   
+        #
+        # connect channel signals to update info
+        #
+
+        self.use_update_timer = False  # do not use update_timer for Cats 
+
+        self._chnState.connectSignal("update", self.cats_state_changed)
+        self._chnStatus.connectSignal("update", self.cats_status_changed)
+        self._chnPathRunning.connectSignal("update", self.cats_pathrunning_changed) 
+        self._chnPowered.connectSignal("update", self.cats_powered_changed) 
+        self._chnAllLidsClosed.connectSignal("update", self.cats_lids_closed_changed)
+        self._chnLidLoadedSample.connectSignal("update", self.cats_loaded_lid_changed)
+        self._chnNumLoadedSample.connectSignal("update", self.cats_loaded_num_changed)
+        self._chnSampleBarcode.connectSignal("update", self.cats_barcode_changed)
+
+        # connect presence channels
+        if self.basket_channels is not None:  # old device server
+            for basket_index in range(self.number_of_baskets):
+                channel = self.basket_channels[basket_index]                 
+                channel.connectSignal("update", lambda value, \
+                     this=self,idx=basket_index:Cats90.cats_basket_presence_changed(this,idx,value))
+        else: # new device server with global CassettePresence attribute
+            self._chnBasketPresence.connectSignal("update", self.cats_baskets_changed)
+
+        # Read other XML properties
+        read_datamatrix = self.getProperty("read_datamatrix")
+        if read_datamatrix: 
+            self.setReadBarcode(True)
+         
+        unipuck_tool = self.getProperty("unipuck_tool")
+        try:
+            unipuck_tool = int(unipuck_tool)
+            if unipuck_tool:
+               self.setUnipuckTool(unipuck_tool) 
+        except:
+            pass
+ 
+        self.updateInfo()
+
+    def is_isara(self):
+        return self.cats_model == "ISARA"
+
+    def is_cats(self):
+        return self.cats_model != "ISARA"
+
+    def _initSCContents(self):
+        """
+        Initializes the sample changer content with default values.
+
+        :returns: None
+        :rtype: None
+        """
+        logging.getLogger("HWR").warning("Cats90:  initializing contents")
+
+        self.basket_presence = [None,] * self.number_of_baskets
+        
+        for i in range(self.number_of_baskets):
+            if self.basket_types[i] == BASKET_SPINE:
+                basket = SpineBasket(self,i+1)
+            elif self.basket_types[i] == BASKET_UNIPUCK:
+                basket = UnipuckBasket(self,i+1)
+            else:
+                basket = Basket(self,i+1, samples_num=self.samples_per_basket)
+
+            self._addComponent(basket)
+
+        # write the default basket information into permanent Basket objects 
+        for basket_index in range(self.number_of_baskets):            
+            basket=self.getComponents()[basket_index]
+            datamatrix = None
+            present = scanned = False
+            basket._setInfo(present, datamatrix, scanned)
+
+        # create temporary list with default sample information and indices
+        sample_list=[]
+        for basket_index in range(self.number_of_baskets):            
+            basket = self.getComponents()[basket_index]
+            for sample_index in range(basket.getNumberOfSamples()):
+                sample_list.append(("", basket_index+1, sample_index+1, 1, Pin.STD_HOLDERLENGTH)) 
+
+        # write the default sample information into permanent Pin objects 
+        for spl in sample_list:
+            sample = self.getComponentByAddress(Pin.getSampleAddress(spl[1], spl[2]))
+            datamatrix = None
+            present = scanned = loaded = has_been_loaded = False
+            sample._setInfo(present, datamatrix, scanned)
+            sample._setLoaded(loaded, has_been_loaded)
+            sample._setHolderLength(spl[4])    
+
+        logging.getLogger("HWR").warning("Cats90:  initializing contents done")
 
     def getSampleProperties(self):
         """
@@ -142,7 +458,27 @@ class Cats90(SampleChanger):
                 basket_list.append(basket)
         return basket_list
 
-        
+    def isPowered(self):
+        return self._chnPowered.getValue()
+
+    def isPathRunning(self):
+        return self._chnPathRunning.getValue()
+
+    def setReadBarcode(self, value):
+        """
+        Activates reading of barcode during load or chained load trajectory
+        Internally it will use put() or put_bcrd() in PyCats dev. server
+
+        :value:  boolean argument
+        """
+        self.read_datamatrix = value
+
+    def setUnipuckTool(self, value):
+        if value in [TOOL_UNIPUCK, TOOL_DOUBLE_GRIPPER]:
+            self.unipuck_tool = value
+        else:
+            logging.warning("wrong unipuck tool selected %s (valid: %s/%s). Selection IGNORED" % (value, TOOL_UNIPUCK, TOOL_DOUBLE_GRIPPER))
+
     #########################           TASKS           #########################
 
     def _doUpdateInfo(self):       
@@ -152,12 +488,12 @@ class Cats90(SampleChanger):
         :returns: None
         :rtype: None
         """
-        self._updateSCContents()
-        # periodically updating the selection is not needed anymore, because each call to _doSelect
-        # updates the selected component directly:
-        # self._updateSelection()
-        self._updateState()               
-        self._updateLoadedSample()
+        logging.info("doUpdateInfo should not be called for cats. only for update timer type of SC")
+        return
+
+        self._doUpdateCatsContents()
+        self._doUpdateState()               
+        self._doUpdateLoadedSample()
                     
     def _doChangeMode(self,mode):
         """
@@ -172,9 +508,9 @@ class Cats90(SampleChanger):
         basket = None
         sample = None
         try:
-          if basket_no is not None and basket_no>0 and basket_no <=Cats90.NO_OF_BASKETS:
+          if basket_no is not None and basket_no>0 and basket_no <=self.number_of_baskets:
             basket = self.getComponentByAddress(Basket.getBasketAddress(basket_no))
-            if sample_no is not None and sample_no>0 and sample_no <=Basket.NO_OF_SAMPLES_PER_PUCK:
+            if sample_no is not None and sample_no>0 and sample_no <= basket.getNumberOfSamples():
                 sample = self.getComponentByAddress(Pin.getSampleAddress(basket_no, sample_no))            
         except:
           pass
@@ -189,75 +525,19 @@ class Cats90(SampleChanger):
         :returns: None
         :rtype: None
         """
+        logging.info("selecting component %s / type=%s" % (str(component), type(component)))
+
         if isinstance(component, Sample):
             selected_basket_no = component.getBasketNo()
             selected_sample_no = component.getIndex()+1
         elif isinstance(component, Container) and ( component.getType() == Basket.__TYPE__):
             selected_basket_no = component.getIndex()+1
             selected_sample_no = None
+        elif isinstance(component,tuple) and len(component) == 2:
+            selected_basket_no = component[0]
+            selected_sample_no = component[1]
         self._directlyUpdateSelectedComponent(selected_basket_no, selected_sample_no)
 
-# JN 20150324, load for CATS GUI, no timer and the window will not freeze
-    def load_cats(self, sample=None, wait=True):
-        """
-        Load a sample. 
-        """
-        sample = self._resolveComponent(sample)
-        self.assertNotCharging()
-        logging.info("call load without a timer")
-        if not self._chnPowered.getValue():
-#            raise Exception("CATS power is not enabled. Please switch on arm power before transferring samples.")
-            #logging.getLogger("HWR").error("CATS power is not enabled. Please switch on arm power before transferring samples.")
-            qt.QMessageBox.warning(None,"Error", "CATS power is not enabled. Please switch on arm power before transferring samples.")
-            return
-
-        # JN, 20150512, make sure MD2 TransferMode is "SAMPLE_CHANGER"
-        if not self._chnTransferMode.getValue()=="SAMPLE_CHANGER":
-            qt.QMessageBox.warning(None,"Error", "TransferMode is %s. Please set the value to SAMPLE_CHANGER in MD2 software." % str(self._chnTransferMode.getValue()))
-            return
-       
-        return self._executeTask(SampleChangerState.Loading,wait,self._doLoad,sample)
-
-# JN 20150324, add load for queue mount, sample centring can start after MD2 in Centring phase instead of waiting for CATS finishes completely
-    def load(self, sample=None, wait=True):
-        """
-        Load a sample. 
-         """
-        if not self._chnPowered.getValue():
-#            raise Exception("CATS power is not enabled. Please switch on arm power before transferring samples.")
-            #logging.getLogger("HWR").error("CATS power is not enabled. Please switch on arm power before transferring samples.")
-            qt.QMessageBox.warning(None,"Error", "CATS power is not enabled. Please switch on arm power before transferring samples.")
-            raise Exception("CATS power is not enabled. Please switch on arm power before transferring samples.")
-            return 
-
-        # JN, 20150512, make sure MD2 TransferMode is "SAMPLE_CHANGER"
-        if not self._chnTransferMode.getValue()=="SAMPLE_CHANGER":
-            qt.QMessageBox.warning(None,"Error", "TransferMode is %s. Please set the value to SAMPLE_CHANGER in MD2 software." % str(self._chnTransferMode.getValue()))
-            raise Exception("TransferMode is %s. Please set the value to SAMPLE_CHANGER in MD2 software." % str(self._chnTransferMode.getValue()))
-            return 
-
-        sample = self._resolveComponent(sample)
-        self.assertNotCharging()
-        #Do a chained load in this case
-        #if self.hasLoadedSample():    
-            #Do a chained load in this case
-            #raise Exception("A sample is loaded")
-            #if self.getLoadedSample() == sample:
-            #    raise Exception("The sample " + sample.getAddress() + " is already loaded")
-
-        #return self._executeTask(SampleChangerState.Loading,wait,self._doLoad,sample)
-        logging.info("call load with a timer")
-        self._executeTask(SampleChangerState.Loading,False,self._doLoad,sample)
-        timeout=0
-        time.sleep(20) # in case MD2 starts with Centring phase before loading the new sample
-        while self._chnCurrentPhase.getValue() != 'Centring':
-            if timeout > 60:
-                logging.info("waited for too long, change to centring mode manually")
-		return
-            time.sleep(1)
-            timeout+=1
-            logging.info("current phase is " + self._chnCurrentPhase.getValue())
-   
     def _doScan(self,component,recursive):
         """
         Scans the barcode of a single sample, puck or recursively even the complete sample changer.
@@ -266,36 +546,59 @@ class Cats90(SampleChanger):
         :rtype: None
         """
         selected_basket = self.getSelectedComponent()
+
         if isinstance(component, Sample):            
             # scan a single sample
             if (selected_basket is None) or (selected_basket != component.getContainer()):
                 self._doSelect(component)            
+
             selected=self.getSelectedSample()            
+
             # self._executeServerTask(self._scan_samples, [component.getIndex()+1,])
-            lid = ((selected.getBasketNo() - 1) / 3) + 1
-            sample = (((selected.getBasketNo() - 1) % 3) * 10) + selected.getVialNo()
+            lid, sample = self.basketsample_to_lidsample(selected.getBasketNo(), selected.getVialNo())
             argin = ["2", str(lid), str(sample), "0", "0"]
             self._executeServerTask(self._cmdScanSample, argin)
             self._updateSampleBarcode(component)
         elif isinstance(component, Container) and ( component.getType() == Basket.__TYPE__):
             # component is a basket
+            basket = component
             if recursive:
                 pass
             else:
-                if (selected_basket is None) or (selected_basket != component):
-                    self._doSelect(component)            
-                # self._executeServerTask(self._scan_samples, (0,))                
+                if (selected_basket is None) or (selected_basket != basket):
+                    self._doSelect(basket)            
+
                 selected=self.getSelectedSample()            
-                for sample_index in range(Basket.NO_OF_SAMPLES_PER_PUCK):
-                    lid = ((selected.getBasketNo() - 1) / 3) + 1
-                    sample = (((selected.getBasketNo() - 1) % 3) * 10) + (sample_index+1)
+
+                for sample_index in range(basket.getNumberOfSamples()):
+                    basket = selected.getBasketNo()
+                    num = sample_index+1
+                    lid, sample = self.basketsample_to_lidsample(basket,num)
                     argin = ["2", str(lid), str(sample), "0", "0"]
                     self._executeServerTask(self._cmdScanSample, argin)
-        elif isinstance(component, Container) and ( component.getType() == SC3.__TYPE__):
-            for basket in self.getComponents():
-                self._doScan(basket, True)
     
-    def _doLoad(self,sample=None):
+    def load(self, sample=None, wait=True):
+        """
+        Load a sample. 
+            overwrite original load() from GenericSampleChanger to allow finer decision 
+            on command to use (with or without barcode / or allow for wash in some cases)
+            Implement that logic in _doLoad()
+            Add initial verification about the Powered:
+            (NOTE) In fact should be already as the power is considered in the state handling
+        """
+        if not self._chnPowered.getValue():
+            raise Exception("CATS power is not enabled. Please switch on arm power before transferring samples.")
+            return 
+
+        self._updateState() # remove software flags like Loading.
+        logging.getLogger("HWR").debug("  ***** ISARA *** load cmd .state is:  %s " % (self.state))
+
+        sample = self._resolveComponent(sample)
+        self.assertNotCharging()
+
+        self._executeTask(SampleChangerState.Loading, wait, self._doLoad, sample)
+
+    def _doLoad(self,sample=None, shifts=None):
         """
         Loads a sample on the diffractometer. Performs a simple put operation if the diffractometer is empty, and 
         a sample exchange (unmount of old + mount of new sample) if a sample is already mounted on the diffractometer.
@@ -317,24 +620,52 @@ class Cats90(SampleChanger):
             else:
                raise Exception("No sample selected")
 
-        # calculate CATS specific lid/sample number
-        lid = ((selected.getBasketNo() - 1) / 3) + 1
-        sample = (((selected.getBasketNo() - 1) % 3) * 10) + selected.getVialNo()
-        argin = ["2", str(lid), str(sample), "0", "0", "0", "0", "0"]
+        basketno = selected.getBasketNo()
+        sampleno = selected.getVialNo() 
+
+        lid, sample = self.basketsample_to_lidsample(basketno,sampleno)
+
+        if self.is_isara():
+            stype = "1"
+        else:
+            stype = "0"
+
+        tool = self.tool_for_basket(basketno)
+
+        # we should now check basket type on diffr to see if tool is different... then decide what to do
+     
+        if shifts is None:
+            xshift, yshift, zshift = ["0", "0", "0" ]
+        else:
+            xshift, yshift, zshift = map(str,shifts)
+
+        # prepare argin values
+        argin = [str(tool), str(lid), str(sample), stype, "0", xshift, yshift, zshift]
+        logging.getLogger("HWR").debug("  ***** ISARA *** doLoad argin:  %s / %s:%s" % (argin, basketno, sampleno))
             
         if self.hasLoadedSample():
             if selected==self.getLoadedSample():
                 raise Exception("The sample " + str(self.getLoadedSample().getAddress()) + " is already loaded")
             else:
-                self._startLoad = True
-                self._cmdRestartMD2(0) # fix the bug of waiting for MD2 by a hot restart, JN,20140708
-                time.sleep(5) # wait for the MD2 restart
-                self._startLoad = False
-                self._executeServerTask(self._cmdChainedLoad, argin)
+                if self.read_datamatrix and self._cmdChainedLoadBarcode is not None:
+                    logging.getLogger("HWR").warning("  ==========CATS=== chained load sample (brcd), sending to cats:  %s" % argin)
+                    self._executeServerTask(self._cmdChainedLoadBarcode, argin)
+                else:
+                    logging.getLogger("HWR").warning("  ==========CATS=== chained load sample, sending to cats:  %s" % argin)
+                    self._executeServerTask(self._cmdChainedLoad, argin)
         else:
-            self._executeServerTask(self._cmdLoad, argin)
+            if self.cats_sample_on_diffr():
+                logging.getLogger("HWR").warning("  ==========CATS=== trying to load sample, but sample detected on diffr. aborting") 
+                self._updateState() # remove software flags like Loading.
+            else:
+                if self.read_datamatrix and self._cmdLoadBarcode is not None:
+                    logging.getLogger("HWR").warning("  ==========CATS=== load sample (bcrd), sending to cats:  %s" % argin)
+                    self._executeServerTask(self._cmdLoadBarcode, argin)
+                else:
+                    logging.getLogger("HWR").warning("  ==========CATS=== load sample, sending to cats:  %s" % argin)
+                    self._executeServerTask(self._cmdLoad, argin)
 
-    def _doUnload(self,sample_slot=None):
+    def _doUnload(self,sample_slot=None, shifts=None):
         """
         Unloads a sample from the diffractometer.
 
@@ -344,14 +675,26 @@ class Cats90(SampleChanger):
         if not self._chnPowered.getValue():
             raise Exception("CATS power is not enabled. Please switch on arm power before transferring samples.")
             
+        if not self.hasLoadedSample() or not self._chnSampleIsDetected.getValue():
+            logging.getLogger("HWR").warning("  Trying do unload sample, but it does not seem to be any on diffr:  %s" % argin)
+
         if (sample_slot is not None):
             self._doSelect(sample_slot)
-        argin = ["2", "0", "0", "0", "0"]
-        self._startLoad = True
+
+        if shifts is None:
+            xshift, yshift, zshift = ["0", "0", "0" ]
+        else:
+            xshift, yshift, zshift = map(str,shifts)
+
+        loaded_lid = self._chnLidLoadedSample.getValue()
+        loaded_num = self._chnNumLoadedSample.getValue()
+        loaded_basket, loaded_sample = self.lidsample_to_basketsample(loaded_lid, loaded_num)
         
-        self._cmdRestartMD2(0) # fix the bug of waiting for MD2 by a hot restart, JN,20140703
-        time.sleep(5) # wait for the MD2 restart
-        self._startLoad = False
+        tool = self.tool_for_basket(loaded_basket)
+
+        argin = [str(tool), "0", xshift, yshift, zshift]
+
+        logging.getLogger("HWR").warning("  ==========CATS=== unload sample, sending to cats:  %s" % argin)
         self._executeServerTask(self._cmdUnload, argin)
 
     def clearBasketInfo(self, basket):
@@ -367,14 +710,89 @@ class Cats90(SampleChanger):
         :rtype: None
         """
         self._cmdAbort()            
+        self._updateState() # remove software flags like Loading.. reflects current hardware state 
 
     def _doReset(self):
         pass
 
-    #########################           PRIVATE           #########################        
+    #########################           CATS EVENTS           #########################        
 
-    def _updateOperationMode(self, value):
-        self._scIsCharging = not value
+    def cats_state_changed(self, value):
+
+        # hack for transient states
+        trials = 0
+        while value in [PyTango.DevState.ALARM, PyTango.DevState.ON]:
+            time.sleep(0.1)
+            trials += 1
+            logging.getLogger("HWR").warning("SAMPLE CHANGER could be in transient state. trying again")
+            value = self._chnState.getValue()
+            if trials > 4:
+               break
+
+        self.cats_state = value
+        self._updateState()
+
+    def cats_status_changed(self, value):
+        self.cats_status = value
+        self._updateState()
+
+    def cats_pathrunning_changed(self, value):
+        self.cats_running = value
+        self._updateState()
+        self.emit('runningStateChanged', (value, ))
+
+    def cats_powered_changed(self, value):
+        self.cats_powered = value
+        self._updateState()
+        self.emit('powerStateChanged', (value, ))
+
+    def cats_lids_closed_changed(self, value):
+        self.cats_lids_closed = value
+        self._updateState()
+    
+    def cats_basket_presence_changed(self,basket_index,value):
+        self.basket_presence[basket_index] = value
+        self._updateCatsContents()
+
+    def cats_baskets_changed(self,value):
+        logging.getLogger("HWR").warning("Baskets changed. %s" % value)
+        for idx,val in enumerate(value):
+            self.basket_presence[idx] = val
+        self._updateCatsContents()
+        self._updateLoadedSample()
+
+    def cats_loaded_lid_changed(self,value):
+        self.cats_loaded_lid = value
+        self.cats_loaded_num = self._chnNumLoadedSample.getValue()
+        self._updateLoadedSample() 
+
+    def cats_loaded_num_changed(self, value):
+        self.cats_loaded_lid = self._chnLidLoadedSample.getValue()
+        self.cats_loaded_num = value
+        self._updateLoadedSample() 
+
+    def cats_barcode_changed(self, value):
+
+        self.cats_datamatrix = value
+
+        scanned = (len(value) != 0)
+
+        lid_on_tool = self.cats_device.read_attribute("LidSampleOnTool").value
+        sample_on_tool = self.cats_device.read_attribute("NumSampleOnTool").value
+
+        if -1 in [lid_on_tool, sample_on_tool]: 
+            return
+
+        basketno, sampleno = self.lidsample_to_basketsample(lid_on_tool,sample_on_tool)
+        logging.getLogger("HWR").warning("Barcode %s read. Assigning it to sample %s:%s" % (value, basketno, sampleno))
+
+        sample = self.getComponentByAddress(Pin.getSampleAddress(basketno, sampleno))
+        sample._setInfo(sample.isPresent(), value, scanned)
+
+    def cats_sample_on_diffr(self):
+        return self._chnSampleIsDetected.getValue()
+
+    #########################           PRIVATE           #########################        
 
     def _executeServerTask(self, method, *args):
         """
@@ -385,7 +803,7 @@ class Cats90(SampleChanger):
         """
         self._waitDeviceReady(3.0)
         task_id = method(*args)
-        print "Cats90._executeServerTask", task_id
+        
         ret=None
         if task_id is None: #Reset
             while self._isDeviceBusy():
@@ -399,31 +817,29 @@ class Cats90(SampleChanger):
             ret = True
         return ret
 
-    def _updateState(self):
+    def _doUpdateState(self):
         """
         Updates the state of the hardware object
 
         :returns: None
         :rtype: None
         """
-        try:
-          state = self._readState()
-        except:
-          state = SampleChangerState.Unknown
-        if state == SampleChangerState.Moving and self._isDeviceBusy(self.getState()):
-            #print "*** _updateState return"
-            return          
+        self.cats_running = self._chnPathRunning.getValue()
+        self.cats_powered = self._chnPowered.getValue()
+        self.cats_lids_closed = self._chnAllLidsClosed.getValue() 
+        self.cats_status = self._chnStatus.getValue()
+        self.cats_state = self._chnState.getValue()
 
-        #_chnSampleIsDetected does not exist in our CATS. 
-        if self.hasLoadedSample() ^ self._chnSampleIsDetected.getValue():
-            # go to Unknown state if a sample is detected on the gonio but not registered in the internal database
-            # or registered but not on the gonio anymore
-            state = SampleChangerState.Unknown 
-        elif self._chnPathRunning.getValue() and not (state in [SampleChangerState.Loading, SampleChangerState.Unloading]):
-            state = SampleChangerState.Moving
-        elif self._scIsCharging and not (state in [SampleChangerState.Alarm, SampleChangerState.Moving, SampleChangerState.Loading, SampleChangerState.Unloading]):
-            state = SampleChangerState.Charging
-        self._setState(state)
+    def _updateState(self):
+
+        has_loaded = self.hasLoadedSample()
+        on_diff = self._chnSampleIsDetected.getValue()
+
+
+        state = self._decideState(self.cats_state, self.cats_powered, self.cats_lids_closed, has_loaded, on_diff)
+
+        status = SampleChangerState.tostring(state)
+        self._setState(state, status)
        
     def _readState(self):
         """
@@ -432,18 +848,53 @@ class Cats90(SampleChanger):
         :returns: Sample changer state
         :rtype: GenericSampleChanger.SampleChangerState
         """
-        state = self._chnState.getValue()
-        #print "*** _readState: ", state
-        if state is not None:
-            stateStr = str(state).upper()
-        else:
-            stateStr = ""
-        #state = str(self._state.getValue() or "").upper()
-        state_converter = { "ALARM": SampleChangerState.Alarm,
-                            "ON": SampleChangerState.Ready,
-                            "RUNNING": SampleChangerState.Moving }
-        return state_converter.get(stateStr, SampleChangerState.Unknown)
+        _state = self._chnState.getValue()
+        _powered = self._chnPowered.getValue()
+        _lids_closed = self._chnAllLidsClosed.getValue()
+        _has_loaded = self.hasLoadedSample()
+        _on_diff = self._chnSampleIsDetected.getValue()
+
+        # hack for transient states
+        trials = 0
+        while  _state in [PyTango.DevState.ALARM, PyTango.DevState.ON]:
+            time.sleep(0.1)
+            trials += 1
+            logging.getLogger("HWR").warning("SAMPLE CHANGER could be in transient state. trying again")
+            _state = self._chnState.getValue()
+            if trials > 2:
+               break
+
+        state =  self._decideState(_state, _powered, _lids_closed, _has_loaded, _on_diff)
+      
+        return state
                         
+    def _decideState(self, dev_state, powered, lids_closed, has_loaded, on_diff):
+
+        if dev_state == PyTango.DevState.ALARM: 
+            _state = SampleChangerState.Alarm 
+        elif not powered:
+            _state = SampleChangerState.Disabled
+        elif dev_state == PyTango.DevState.RUNNING: 
+            if self.state not in [SampleChangerState.Loading, SampleChangerState.Unloading]: 
+               _state = SampleChangerState.Moving 
+            else:
+               _state = self.state
+        elif dev_state == PyTango.DevState.UNKNOWN: 
+            _state = SampleChangerState.Unknown
+        elif has_loaded ^ on_diff:
+            # go to Unknown state if a sample is detected on the gonio but not registered in the internal database
+            # or registered but not on the gonio anymore
+            logging.getLogger("HWR").warning("SAMPLE CHANGER Unknown 2 (hasLoaded: %s / detected: %s)" % (self.hasLoadedSample(), self._chnSampleIsDetected.getValue()))
+            _state = SampleChangerState.Unknown 
+        #elif not lids_closed: 
+            #_state = SampleChangerState.Charging
+        elif dev_state == PyTango.DevState.ON:
+            _state = SampleChangerState.Ready
+        else:
+            _state = SampleChangerState.Unknown 
+
+        return _state
+
     def _isDeviceBusy(self, state=None):
         """
         Checks whether Sample changer HO is busy.
@@ -453,6 +904,7 @@ class Cats90(SampleChanger):
         """
         if state is None:
             state = self._readState()
+
         return state not in (SampleChangerState.Ready, SampleChangerState.Loaded, SampleChangerState.Alarm, 
                              SampleChangerState.Disabled, SampleChangerState.Fault, SampleChangerState.StandBy)
 
@@ -473,40 +925,11 @@ class Cats90(SampleChanger):
         :returns: None
         :rtype: None
         """
-
         with gevent.Timeout(timeout, Exception("Timeout waiting for device ready")):
             while not self._isDeviceReady():
                 gevent.sleep(0.01)
             
-    def _updateSelection(self):    
-        """
-        Updates the selected basket and sample. NOT USED ANYMORE FOR THE CATS.
-        Legacy method left from the implementation of the SC3 where the currently selected sample
-        is always read directly from the SC3 Tango DS
-
-        :returns: None
-        :rtype: None
-        """
-        #import pdb; pdb.set_trace()
-        basket=None
-        sample=None
-        # print "_updateSelection: saved selection: ", self._selected_basket, self._selected_sample
-        try:
-          basket_no = self._selected_basket
-          if basket_no is not None and basket_no>0 and basket_no <=Cats90.NO_OF_BASKETS:
-            basket = self.getComponentByAddress(Basket.getBasketAddress(basket_no))
-            sample_no = self._selected_sample
-            if sample_no is not None and sample_no>0 and sample_no <=Basket.NO_OF_SAMPLES_PER_PUCK:
-                sample = self.getComponentByAddress(Pin.getSampleAddress(basket_no, sample_no))            
-        except:
-          pass
-        #if basket is not None and sample is not None:
-        #    print "_updateSelection: basket: ", basket, basket.getIndex()
-        #    print "_updateSelection: sample: ", sample, sample.getIndex()
-        self._setSelectedComponent(basket)
-        self._setSelectedSample(sample)
-
-    def _updateLoadedSample(self):
+    def _doUpdateLoadedSample(self):
         """
         Reads the currently mounted sample basket and pin indices from the CATS Tango DS,
         translates the lid/sample notation into the basket/sample notation and marks the 
@@ -515,36 +938,72 @@ class Cats90(SampleChanger):
         :returns: None
         :rtype: None
         """
-        loadedSampleLid = self._chnLidLoadedSample.getValue()
-        loadedSampleNum = self._chnNumLoadedSample.getValue()
-        if loadedSampleLid != -1 or loadedSampleNum != -1:
-            lidBase = (loadedSampleLid - 1) * 3
-            lidOffset = ((loadedSampleNum - 1) / 10) + 1
-            samplePos = ((loadedSampleNum - 1) % 10) + 1
-            basket = lidBase + lidOffset
-        else:
-            basket = None
-            samplePos = None
- 
-        if basket is not None and samplePos is not None:
-            new_sample = self.getComponentByAddress(Pin.getSampleAddress(basket, samplePos))
-        else:
-            new_sample = None
+        self.cats_loaded_lid = self._chnLidLoadedSample.getValue()
+        self.cats_loaded_num = self._chnNumLoadedSample.getValue()
+        self.cats_datamatrix = str(self._chnSampleBarcode.getValue())
+        self._updateLoadedSample()
 
+    def lidsample_to_basketsample(self, lid, num):
+        if self.is_isara():
+            return lid,num
+        else:
+           lid_base = (lid - 1) * self.baskets_per_lid
+           lid_offset = ((num - 1) / self.samples_per_basket) + 1
+           sample_pos = ((num - 1) % self.samples_per_basket) + 1
+           basket = lid_base + lid_offset
+           return basket, sample_pos
+
+    def basketsample_to_lidsample(self, basket, num):
+        if self.is_isara():
+           return basket,num
+        else:
+           lid = ((basket - 1) / self.baskets_per_lid) + 1
+           sample = (((basket - 1) % self.basket_per_lid) * self.samples_per_basket) + num
+           return lid,sample
+
+    def tool_for_basket(self, basketno):
+
+        basket_type = self.basket_types[basketno-1]
+
+        if basket_type == BASKET_SPINE:
+            tool = TOOL_SPINE
+        elif basket_type == BASKET_UNIPUCK:
+            tool = self.unipuck_tool # configurable (xml and command setUnipuckTool()  
+        return tool
+
+    def _updateLoadedSample(self):
+      
+        loadedSampleLid = self.cats_loaded_lid
+        loadedSampleNum = self.cats_loaded_num
+
+        logging.getLogger("HWR").info("Updating loaded sample %s:%s" % (loadedSampleLid, loadedSampleNum)) 
+
+        if -1 not in [loadedSampleLid, loadedSampleNum]:
+            basket, sample = self.lidsample_to_basketsample(loadedSampleLid,loadedSampleNum)
+            new_sample = self.getComponentByAddress(Pin.getSampleAddress(basket, sample))
+        else:
+            basket, sample = None, None
+            new_sample = None
+ 
         if self.getLoadedSample() != new_sample:
-            # import pdb; pdb.set_trace()
             # remove 'loaded' flag from old sample but keep all other information
             old_sample = self.getLoadedSample()
+
             if old_sample is not None:
                 # there was a sample on the gonio
                 loaded = False
                 has_been_loaded = True
                 old_sample._setLoaded(loaded, has_been_loaded)
+
             if new_sample is not None:
-                self._updateSampleBarcode(new_sample)
                 loaded = True
                 has_been_loaded = True
                 new_sample._setLoaded(loaded, has_been_loaded)
+                logging.getLogger("HWR").info("  setting sample %s (%s) as currently loaded. %s" % (new_sample.getAddress(), id(new_sample), new_sample.isLoaded()))
+
+            if (old_sample is None) or (new_sample is None) or (old_sample.getAddress()!=new_loaded.getAddress()):
+                self._triggerLoadedSampleChangedEvent(new_sample)
+
 
     def _updateSampleBarcode(self, sample):
         """
@@ -555,43 +1014,17 @@ class Cats90(SampleChanger):
         :rtype: None
         """
         # update information of recently scanned sample
-        datamatrix = str(self._chnSampleBarcode.getValue())
-        scanned = (len(datamatrix) != 0)
+        if sample is None:
+            return 
+
+        scanned = (len(self.cats_datamatrix) != 0)
         if not scanned:    
            datamatrix = '----------'   
+        else:
+           datamatrix = self.cats_datamatrix
         sample._setInfo(sample.isPresent(), datamatrix, scanned)
 
-    def _initSCContents(self):
-        """
-        Initializes the sample changer content with default values.
-
-        :returns: None
-        :rtype: None
-        """
-        # create temporary list with default basket information
-        basket_list= [('', 4)] * Cats90.NO_OF_BASKETS
-        # write the default basket information into permanent Basket objects 
-        for basket_index in range(Cats90.NO_OF_BASKETS):            
-            basket=self.getComponents()[basket_index]
-            datamatrix = None
-            present = scanned = False
-            basket._setInfo(present, datamatrix, scanned)
-
-        # create temporary list with default sample information and indices
-        sample_list=[]
-        for basket_index in range(Cats90.NO_OF_BASKETS):            
-            for sample_index in range(Basket.NO_OF_SAMPLES_PER_PUCK):
-                sample_list.append(("", basket_index+1, sample_index+1, 1, Pin.STD_HOLDERLENGTH)) 
-        # write the default sample information into permanent Pin objects 
-        for spl in sample_list:
-            sample = self.getComponentByAddress(Pin.getSampleAddress(spl[1], spl[2]))
-            datamatrix = None
-            present = scanned = loaded = has_been_loaded = False
-            sample._setInfo(present, datamatrix, scanned)
-            sample._setLoaded(loaded, has_been_loaded)
-            sample._setHolderLength(spl[4])    
-
-    def _updateSCContents(self):
+    def _doUpdateCatsContents(self):
         """
         Updates the sample changer content. The state of the puck positions are
         read from the respective channels in the CATS Tango DS.
@@ -601,17 +1034,26 @@ class Cats90(SampleChanger):
         :returns: None
         :rtype: None
         """
-        for basket_index in range(Cats90.NO_OF_BASKETS):            
+
+        for basket_index in range(self.number_of_baskets):            
             # get presence information from the device server
-            newBasketPresence = getattr(self, "_chnBasket%dState" % (basket_index + 1)).getValue()
+            channel = self.basket_channels[basket_index]
+            is_present = channel.getValue()
+            self.basket_presence[basket_index] = is_present
+
+        self._updateCatsContents()
+           
+    def _updateCatsContents(self):
+ 
+        for basket_index in range(self.number_of_baskets):            
             # get saved presence information from object's internal bookkeeping
             basket=self.getComponents()[basket_index]
-           
-            # check if the basket was newly mounted or removed from the dewar
-            if newBasketPresence ^ basket.isPresent():
-                # import pdb; pdb.set_trace()
+            is_present = self.basket_presence[basket_index]
+
+            # check if the basket presence has changed
+            if is_present ^ basket.isPresent():
                 # a mounting action was detected ...
-                if newBasketPresence:
+                if is_present:
                     # basket was mounted
                     present = True
                     scanned = False
@@ -623,8 +1065,9 @@ class Cats90(SampleChanger):
                     scanned = False
                     datamatrix = None
                     basket._setInfo(present, datamatrix, scanned)
+
                 # set the information for all dependent samples
-                for sample_index in range(Basket.NO_OF_SAMPLES_PER_PUCK):
+                for sample_index in range(basket.getNumberOfSamples()):
                     sample = self.getComponentByAddress(Pin.getSampleAddress((basket_index + 1), (sample_index + 1)))
                     present = sample.getContainer().isPresent()
                     if present:
@@ -633,7 +1076,32 @@ class Cats90(SampleChanger):
                         datamatrix = None
                     scanned = False
                     sample._setInfo(present, datamatrix, scanned)
+
                     # forget about any loaded state in newly mounted or removed basket)
                     loaded = has_been_loaded = False
                     sample._setLoaded(loaded, has_been_loaded)
 
+        self._triggerContentsUpdatedEvent()
+
+def test_hwo(hwo):
+    basket_list = hwo.getBasketList()
+    sample_list = hwo.getSampleList()
+    print("Baskets/Samples in CATS: %s/%s" % ( len(basket_list), len(sample_list)))
+    gevent.sleep(2)
+    sample_list = hwo.getSampleList()
+
+    for s in sample_list:
+        if s.isLoaded():
+            print "Sample %s loaded" % s.getAddress()
+            break
+
+    if hwo.hasLoadedSample():
+        print "Currently loaded (%s): %s" % (hwo.hasLoadedSample(),hwo.getLoadedSample().getAddress())
+    print "CATS state is: ", hwo.state
+    print "Sample on Magnet : ", hwo.cats_sample_on_diffr()
+    print "All lids closed: ", hwo._chnAllLidsClosed.getValue()
+    
+    print "Sample Changer State is: ", hwo.getStatus()
+    for basketno in range(hwo.number_of_baskets):
+        no = basketno +1
+        print "Tool for basket %d is: %d" % (no, hwo.tool_for_basket(no))

--- a/HardwareObjects/sample_changer/CatsMaint.py
+++ b/HardwareObjects/sample_changer/CatsMaint.py
@@ -3,16 +3,23 @@ CATS maintenance commands hardware object.
 
 Functionality in addition to sample-transfer functionality: power control,
 lid control, error-recovery commands, ...
+
 Derived from Michael Hellmig's implementation for the BESSY CATS sample changer
  -add more controls, including Regulation Off, Gripper Dry/Open/Close, Reset Memory, Set Sample On Diff
  -add CATS dewar layout
+
+Vicente Rey - add support for ISARA Model
+
 """
 import logging
+
 from HardwareRepository.TaskUtils import *
 from HardwareRepository.BaseHardwareObjects import Equipment
+
 import gevent
 import time
-import Cats90
+
+from PyTango import DeviceProxy
 
 __author__ = "Jie Nan"
 __credits__ = ["The MxCuBE collaboration"]
@@ -20,7 +27,20 @@ __credits__ = ["The MxCuBE collaboration"]
 __email__ = "jie.nan@maxlab.lu.se"
 __status__ = "Alpha"
 
+TOOL_FLANGE, TOOL_UNIPUCK, TOOL_SPINE, TOOL_PLATE, \
+    TOOL_LASER, TOOL_DOUBLE_GRIPPER = (0,1,2,3,4,5)
+
+TOOL_TO_STR = {
+       "Flange": TOOL_FLANGE,
+       "Unipuck": TOOL_UNIPUCK,
+       "Rotat": TOOL_SPINE,
+       "Plate": TOOL_PLATE,
+       "Laser": TOOL_LASER,
+       "Double": TOOL_DOUBLE_GRIPPER,
+   }
+
 class CatsMaint(Equipment):
+
     __TYPE__ = "CATS"    
     NO_OF_LIDS = 3
 
@@ -30,29 +50,156 @@ class CatsMaint(Equipment):
     """    
     def __init__(self, *args, **kwargs):
         Equipment.__init__(self, *args, **kwargs)
+
+        self._state = None
+        self._running = None
+        self._powered = None
+        self._toolopen = None
+        self._message = None
+        self._regulating = None
+        self._lid1state = None
+        self._lid2state = None
+        self._lid3state = None
+        self._charging = None
             
     def init(self):      
-        self._chnPathRunning = self.getChannelObject("_chnPathRunning")
+
+        self.cats_device = DeviceProxy(self.tangoname)
+
+        try:
+            self.cats_model = self.cats_device.read_attribute("CatsModel").value
+        except:
+            self.cats_model = "CATS"
+
+        if self.is_isara:
+            self.nb_of_lids = 1
+        else:
+            self.nb_of_lids = 3
+
+        self._chnState = self.addChannel({ "type": "tango", 
+            "name": "_chnState", "tangoname": self.tangoname, 
+            "polling": 1000, }, "State")
+
+        self._chnPathRunning = self.addChannel({ "type": "tango", 
+            "name": "_chnPathRunning", "tangoname": self.tangoname, 
+            "polling": 1000, }, "PathRunning")
+        self._chnPowered = self.addChannel({ "type": "tango", 
+            "name": "_chnPowered", "tangoname": self.tangoname, 
+            "polling": 1000, }, "Powered")
+        self._chnMessage = self.addChannel({ "type": "tango", 
+            "name": "_chnMessage", "tangoname": self.tangoname, 
+            "polling": 1000, }, "Message")
+        self._chnToolOpenClose = self.addChannel({ "type": "tango", 
+            "name": "_chnToolOpenClose", "tangoname": self.tangoname, 
+            "polling": 1000, }, "di_ToolOpen")
+        self._chnLN2Regulation = self.addChannel({ "type": "tango", 
+            "name": "_chnLN2Regulation", "tangoname": self.tangoname, 
+            "polling": 1000, }, "LN2Regulating")
+
+        self._chnLid1State = self.addChannel({ "type": "tango", 
+            "name": "_chnLid1State", "tangoname": self.tangoname, 
+            "polling": 1000, }, "di_Lid1Open")
+        self._chnLid1State.connectSignal("update", self._updateLid1State)
+
+        if self.nb_of_lids > 1:
+            self._chnLid2State = self.addChannel({ "type": "tango", 
+                "name": "_chnLid2State", "tangoname": self.tangoname, 
+                "polling": 1000, }, "di_Lid2Open")
+            self._chnLid2State.connectSignal("update", self._updateLid2State)
+
+        if self.nb_of_lids > 2:
+            self._chnLid3State = self.addChannel({ "type": "tango", 
+                "name": "_chnLid3State", "tangoname": self.tangoname, 
+                "polling": 1000, }, "di_Lid3Open")
+            self._chnLid3State.connectSignal("update", self._updateLid3State)
+
+        self._chnState.connectSignal("update", self._updateState)
         self._chnPathRunning.connectSignal("update", self._updateRunningState)
-        self._chnPowered = self.getChannelObject("_chnPowered")
         self._chnPowered.connectSignal("update", self._updatePoweredState)
-        self._chnToolOpenClose = self.getChannelObject("_chnToolOpenClose")
         self._chnToolOpenClose.connectSignal("update", self._updateToolState)
-        self._chnMessage = self.getChannelObject("_chnMessage")
         self._chnMessage.connectSignal("update", self._updateMessage)
-        self._chnLN2Regulation = self.getChannelObject("_chnLN2RegulationDewar1")
         self._chnLN2Regulation.connectSignal("update", self._updateRegulationState)
            
-        for command_name in ("_cmdReset","_cmdDry","_cmdOpenTool","_cmdCloseTool", "_cmdCalibration","_cmdSetOnDiff", "_cmdClearMemory","_cmdResetParameters","_cmdBack", "_cmdSafe", "_cmdPowerOn", "_cmdPowerOff", \
-                             "_cmdOpenLid1", "_cmdCloseLid1", "_cmdOpenLid2", "_cmdCloseLid2", "_cmdOpenLid3", "_cmdCloseLid3", \
-                             "_cmdRegulOn"):
-            setattr(self, command_name, self.getCommandObject(command_name))
+        # 
+        self._cmdPowerOn = self.addCommand({ "type": "tango", 
+            "name": "_cmdPowerOn", "tangoname": self.tangoname, }, "powerOn")
+        self._cmdPowerOff = self.addCommand({ "type": "tango", 
+            "name": "_cmdPowerOff", "tangoname": self.tangoname, }, "powerOff")
+        self._cmdOpenTool = self.addCommand({ "type": "tango", 
+            "name": "_cmdOpenTool", "tangoname": self.tangoname, }, "opentool")
+        self._cmdCloseTool = self.addCommand({ "type": "tango", 
+            "name": "_cmdCloseTool", "tangoname": self.tangoname, }, "closetool")
+        self._cmdMagnetOn = self.addCommand({ "type": "tango", 
+            "name": "_cmdMagnetOn", "tangoname": self.tangoname, }, "magnetOn")
+        self._cmdMagnetOff = self.addCommand({ "type": "tango", 
+            "name": "_cmdMagnetOff", "tangoname": self.tangoname, }, "magnetOff")
 
-        for lid_index in range(CatsMaint.NO_OF_LIDS):            
-            channel_name = "_chnLid%dState" % (lid_index + 1)
-            setattr(self, channel_name, self.getChannelObject(channel_name))
-            if getattr(self, channel_name) is not None:
-                getattr(self, channel_name).connectSignal("update", getattr(self, "_updateLid%dState" % (lid_index + 1)))
+        # LIDs
+        self._cmdOpenLid1 = self.addCommand({ "type": "tango", 
+            "name": "_cmdOpenLid1", "tangoname": self.tangoname, }, "openlid1")
+        self._cmdCloseLid1 = self.addCommand({ "type": "tango", 
+            "name": "_cmdCloseLid1", "tangoname": self.tangoname, }, "closelid1")
+
+        if self.nb_of_lids > 1:
+            self._cmdOpenLid2 = self.addCommand({ "type": "tango", 
+                "name": "_cmdOpenLid1", "tangoname": self.tangoname, }, "openlid2")
+            self._cmdCloseLid2 = self.addCommand({ "type": "tango", 
+                "name": "_cmdCloseLid1", "tangoname": self.tangoname, }, "closelid2")
+
+        if self.nb_of_lids > 2:
+            self._cmdOpenLid3 = self.addCommand({ "type": "tango", 
+                "name": "_cmdOpenLid1", "tangoname": self.tangoname, }, "openlid3")
+            self._cmdCloseLid3 = self.addCommand({ "type": "tango", 
+                "name": "_cmdCloseLid1", "tangoname": self.tangoname, }, "closelid3")
+
+        self._cmdRegulOn = self.addCommand({ "type": "tango", 
+            "name": "_cmdRegulOn", "tangoname": self.tangoname, }, "regulon")
+
+        # Paths
+        self._cmdAbort = self.addCommand({ "type": "tango", 
+            "name": "_cmdAbort", "tangoname": self.tangoname, }, "abort")
+        self._cmdDry = self.addCommand({ "type": "tango", 
+            "name": "_cmdDry", "tangoname": self.tangoname, }, "dry")
+        self._cmdSafe = self.addCommand({ "type": "tango", 
+            "name": "_cmdSafe", "tangoname": self.tangoname, }, "safe")
+        self._cmdHome = self.addCommand({ "type": "tango", 
+            "name": "_cmdHome", "tangoname": self.tangoname, }, "home")
+        self._cmdSoak = self.addCommand({ "type": "tango", 
+            "name": "_cmdSoak", "tangoname": self.tangoname, }, "soak")
+        self._cmdBack = self.addCommand({ "type": "tango", 
+            "name": "_cmdBack", "tangoname": self.tangoname, }, "back")
+        self._cmdCalibration = self.addCommand({ "type": "tango", 
+            "name": "_cmdCalibration", "tangoname": self.tangoname, }, "toolcalibration")
+
+        self._cmdClearMemory = self.addCommand({ "type": "tango", 
+            "name": "_cmdClearMemory", "tangoname": self.tangoname, }, "clear_memory")
+        self._cmdReset = self.addCommand({ "type": "tango", 
+            "name": "_cmdReset", "tangoname": self.tangoname, }, "reset")
+        self._cmdResetParameters = self.addCommand({ "type": "tango", 
+            "name": "_cmdResetParameters", "tangoname": self.tangoname, }, "reset_parameters")
+
+        self._cmdSetOnDiff = self.addCommand({ "type": "tango", 
+            "name": "_cmdSetOnDiff", "tangoname": self.tangoname, }, "setondiff")
+        self._cmdSetOnTool = self.addCommand({ "type": "tango", 
+            "name": "_cmdSetOnTool", "tangoname": self.tangoname, }, "settool")
+        self._cmdSetOnTool2 = self.addCommand({ "type": "tango", 
+            "name": "_cmdSetOnTool2", "tangoname": self.tangoname, }, "settool2")
+
+        self.state_actions = {
+             "power": {"in_open": self._cmdPowerOn, "out_close": self._cmdPowerOff, 
+                       "state": self._chnPowered},
+        }
+
+    def is_isara(self):
+        return self.cats_model == "ISARA"
+
+    def is_cats(self):
+        return self.cats_model != "ISARA"
+
+    def get_current_tool(self):
+        val = self.cats_device.read_attribute("Tool").value
+        tool = TOOL_TO_STR.get(val, None)
+        return tool
 
     ################################################################################
 
@@ -132,7 +279,6 @@ class CatsMaint(Equipment):
         :rtype: None
         """
         self._cmdDry(2)
-      
 
     def _doSetOnDiff(self, sample):
         """
@@ -185,6 +331,8 @@ class CatsMaint(Equipment):
             self._cmdPowerOn()
         else:
             self._cmdPowerOff()
+
+        self.do_state_action("power",state)
 
     def _doEnableRegulation(self):
         """
@@ -264,35 +412,160 @@ class CatsMaint(Equipment):
     #########################           PRIVATE           #########################        
 
     def _updateRunningState(self, value):
+        self._running = value
         self.emit('runningStateChanged', (value, ))
+        self._updateGlobalState()
 
     def _updatePoweredState(self, value):
+        self._powered = value
         self.emit('powerStateChanged', (value, ))
+        self._updateGlobalState()
     
     def _updateToolState(self,value):
+        self._toolopen = value
         self.emit('toolStateChanged', (value, ))
+        self._updateGlobalState()
 
     def _updateMessage(self, value):
+        self._message = value
         self.emit('messageChanged', (value, ))
+        self._updateGlobalState()
 
     def _updateRegulationState(self, value):
+        self._regulating = value
         self.emit('regulationStateChanged', (value, ))
+        self._updateGlobalState()
+
+    def _updateState(self, value):
+        self._state = value
+        self._updateGlobalState()
 
     def _updateLid1State(self, value):
+        self._lid1state = value
         self.emit('lid1StateChanged', (value, ))
+        self._updateGlobalState()
 
     def _updateLid2State(self, value):
+        self._lid2state = value
         self.emit('lid2StateChanged', (value, ))
+        self._updateGlobalState()
 
     def _updateLid3State(self, value):
+        self._lid3state = value
         self.emit('lid3StateChanged', (value, ))
+        self._updateGlobalState()
 
     def _updateOperationMode(self, value):
-        self._scIsCharging = not value
+        self._charging = not value
 
+    def _updateGlobalState(self):
+        state_dict, cmd_state, message = self.get_global_state()
+        self.emit('globalStateChanged', (state_dict, cmd_state, message))
+
+    def get_global_state(self):
+        """
+           Update clients with a global state that
+           contains different: 
+
+           - first param (state_dict):
+               collection of state bits
+
+           - second param (cmd_state):
+               list of command identifiers and the
+               status of each of them True/False 
+               representing whether the command is 
+               currently available or not
+
+           - message
+               a message describing current state information
+               as a string
+        """
+        _ready = str(self._state) in ("READY", "ON")
+
+        if self._running: 
+            state_str = "MOVING"
+        elif not (self._powered) and _ready:
+            state_str = "DISABLED"
+        elif _ready:
+            state_str = "READY"
+        else:
+            state_str = str(self._state)
+
+        state_dict = {
+           "toolopen": self._toolopen,
+           "powered": self._powered,
+           "running": self._running,
+           "regulating": self._regulating,
+           "lid1": self._lid1state,
+           "lid2": self._lid2state,
+           "lid3": self._lid3state,
+           "state": state_str,
+        }
+
+
+        cmd_state = {
+           "powerOn": (not self._powered) and _ready, 
+           "powerOff": (self._powered) and _ready,
+           "regulon": (not self._regulating) and _ready,
+           "openlid1": (not self._lid1state) and self._powered and _ready,
+           "closelid1": self._lid1state and self._powered and _ready,
+           "dry": (not self._running) and self._powered and _ready,
+           "soak": (not self._running) and self._powered and _ready,
+           "home": (not self._running) and self._powered and _ready,
+           "back": (not self._running) and self._powered and _ready,
+           "safe": (not self._running) and self._powered and _ready,
+           "clear_memory": True,
+           "reset": True,
+           "abort": self._running,
+        }
+
+        message = self._message
+
+        return state_dict, cmd_state, message
+
+    def get_cmd_info(self):
+        """ return information about existing commands for this object 
+           the information is organized as a list 
+           with each element contains
+           [ cmd_name,  display_name, category ]
+        """
+        """ [cmd_id, cmd_display_name, nb_args, cmd_category, description ] """
+        cmd_list = [ 
+              ["Power", [
+                   ["powerOn", "PowerOn", "Switch Power On"], 
+                   ["powerOff", "PowerOff", "Switch Power Off"], 
+                   ["regulon", "Regulation On", "Swich LN2 Regulation On"], 
+                 ] 
+              ], 
+              ["Lid", [
+                   ["openlid1", "Open Lid", "Open Lid"], 
+                   ["closelid1", "Close Lid", "Close Lid"], 
+                 ]
+              ], 
+              ["Actions",  [
+                   ["home", "Home", "Actions", "Home (trajectory)"], 
+                   ["dry", "Dry", "Actions", "Dry (trajectory)"], 
+                   ["soak", "Soak", "Actions", "Soak (trajectory)"], 
+                 ] 
+              ], 
+              ["Recovery",  [
+                   ["clear_memory", "Clear Memory", 
+                       "Clear Info in Robot Memory "
+                       " (includes info about sample on Diffr)"], 
+                   ["reset", "Reset Message", "Reset Cats State" ], 
+                   ["back", "Back", "Reset Cats State" ], 
+                   ["safe", "Safe", "Reset Cats State" ], 
+                 ]
+              ], 
+              ["Abort", [
+                    ["abort", "Abort", "Abort Execution of Command"], 
+                 ]
+              ], 
+           ]
+        return cmd_list
+        
     def _executeServerTask(self, method, *args):
         task_id = method(*args)
-        print "CatsMaint._executeServerTask", task_id
         ret=None
         # introduced wait because it takes some time before the attribute PathRunning is set
         # after launching a transfer
@@ -303,3 +576,47 @@ class CatsMaint(Equipment):
         ret = True
         return ret
 
+    def send_command(self, cmdname, args=None):
+
+        # 
+        lid = 1
+        toolcal = 0
+        tool = self.get_current_tool()
+
+        if cmdname in ["dry", "safe", "home"]:
+           if tool is not None:
+               args = [tool]
+           else:
+               raise Exception ("Cannot detect type of TOOL in Cats. Command ignored")
+
+        if cmdname == "soak":
+           if tool in [TOOL_DOUBLE, TOOL_UNIPUCK]:
+               args = [str(tool), str(lid)]
+           else:
+               raise Exception ("Can SOAK only when UNIPUCK tool is mounted")
+
+        if cmdname == "back":
+           if tool is not None:
+               args = [tool, toolcal]
+           else:
+               raise Exception ("Cannot detect type of TOOL in Cats. Command ignored")
+
+        cmd = getattr(self.cats_device, cmdname)
+
+        try:
+            if args is not None:
+                if len(args) > 1:
+                    ret = cmd(map(str,args))
+                else:
+                    ret = cmd(*args)
+            else:
+                ret = cmd()
+            return ret
+        except Exception,exc:
+            import traceback
+            traceback.print_exc()
+            msg = exc[0].desc
+            raise Exception (msg)
+
+def test_hwo(hwo):
+    print hwo.get_current_tool()

--- a/HardwareObjects/sample_changer/CatsMaint.py
+++ b/HardwareObjects/sample_changer/CatsMaint.py
@@ -71,7 +71,7 @@ class CatsMaint(Equipment):
         except:
             self.cats_model = "CATS"
 
-        if self.is_isara:
+        if self.is_isara():
             self.nb_of_lids = 1
         else:
             self.nb_of_lids = 3

--- a/HardwareObjects/sample_changer/GenericSampleChanger.py
+++ b/HardwareObjects/sample_changer/GenericSampleChanger.py
@@ -76,6 +76,7 @@ class SampleChanger(Container,Equipment):
     LOADED_SAMPLE_CHANGED_EVENT="loadedSampleChanged"
     SELECTION_CHANGED_EVENT="selectionChanged"    
     TASK_FINISHED_EVENT="taskFinished"
+    CONTENTS_UPDATED_EVENT="contentsUpdated"
     
                 
     def __init__(self,type,scannable, *args, **kwargs):
@@ -534,6 +535,7 @@ class SampleChanger(Container,Equipment):
         if cur != component:
             Container._setSelectedComponent(self,component)  
             self._triggerSelectionChangedEvent()      
+
 #########################           PRIVATE           #########################
 
     def _triggerStateChangedEvent(self,former):
@@ -554,3 +556,5 @@ class SampleChanger(Container,Equipment):
     def _triggerTaskFinishedEvent(self,task,ret,exception):
         self.emit(self.TASK_FINISHED_EVENT, (task, ret, exception))
                 
+    def _triggerContentsUpdatedEvent(self):
+        self.emit(self.CONTENTS_UPDATED_EVENT)


### PR DESCRIPTION
Add a new available signal in GenericSampleChanger.py for SampleChanger objects to emit

Modify heavily Cats90.py - NOTE:  the version in the repository previous to this commit is completely forced-adapted for its use in old MaxLab 911 beamline.  It could not be used anywhere else.   This commit tries to restore generality so that code can be used in other sites.  At the same time it introduces support for ISARA models and adapted general state handling for Cats (as it is used already in other beamlines) that takes into account Powered, Lid state and other DS state information

The CatsMaint.py also adds support for ISARA, plus a number of new methods aiming at a generic SampleChanger-Maintenance object to be used in mxcube3.  If this shows to be of general use (with other types of sample changers), it would be advisable to add a generic class for maintenance type hardware objects.