### PR TITLE
GenericVideoDevice allows for non-qt encoding

### DIFF
--- a/HardwareObjects/GenericVideoDevice.py
+++ b/HardwareObjects/GenericVideoDevice.py
@@ -73,7 +73,7 @@ class GenericVideoDevice(Device):
         self.default_poll_interval = None
 
     def init(self):
-        modulenames = ['PyQt', 'PyQt5', 'PyQt4']
+        modulenames = ['qt', 'PyQt5', 'PyQt4']
 
         if any(mod in sys.modules for mod in modulenames):
             self.for_qt = True

--- a/HardwareObjects/GenericVideoDevice.py
+++ b/HardwareObjects/GenericVideoDevice.py
@@ -33,6 +33,7 @@ the base class for classes providing access to Video in MXCuBE
 import abc
 
 import os
+import sys
 import time
 import logging
 import gevent
@@ -72,17 +73,13 @@ class GenericVideoDevice(Device):
         self.default_poll_interval = None
 
     def init(self):
-        
+        modulenames = ['PyQt', 'PyQt5', 'PyQt4']
 
-        # Read values from XML
-        #    set useqt in  xml to False if you do not want to use in qt app
-        self.for_qt = self.getProperty("useqt")
-
-        if self.for_qt in [False,"No", "no"]:
-            self.for_qt = False
-        else:
+        if any(mod in sys.modules for mod in modulenames):
             self.for_qt = True
             from QtImport import QImage, QPixmap
+        else:
+            self.for_qt = False
 
         try:
             self.cam_mirror = eval(self.getProperty("mirror"))

--- a/HardwareObjects/GenericVideoDevice.py
+++ b/HardwareObjects/GenericVideoDevice.py
@@ -37,8 +37,7 @@ import time
 import logging
 import gevent
 import numpy as np
-
-from QtImport import *
+from PIL import Image
 
 try:
     import cv2
@@ -52,6 +51,7 @@ class GenericVideoDevice(Device):
     default_cam_encoding = "yuv422p"
     default_poll_interval = 50
     default_cam_type = "basler"
+    default_scale_factor = 1.0
 
     def __init__(self, name):
         Device.__init__(self,name)
@@ -75,6 +75,15 @@ class GenericVideoDevice(Device):
         
 
         # Read values from XML
+        #    set useqt in  xml to False if you do not want to use in qt app
+        self.for_qt = self.getProperty("useqt")
+
+        if self.for_qt in [False,"No", "no"]:
+            self.for_qt = False
+        else:
+            self.for_qt = True
+            from QtImport import QImage, QPixmap
+
         try:
             self.cam_mirror = eval(self.getProperty("mirror"))
         except:
@@ -84,6 +93,18 @@ class GenericVideoDevice(Device):
             self.cam_encoding = self.getProperty("encoding").lower()
         except:
             pass
+
+        scale =  self.getProperty("scale")
+        if scale is None:
+            self.cam_scale_factor = self.default_scale_factor
+        else:
+            try:
+                self.cam_scale_factor = eval(scale)
+            except:
+                logging.getLogger().warning('%s: failed to interpret scale factor for camera.'
+                                            'Using default.', self.name())
+                self.cam_scale_factor = self.default_scale_factor
+  
 
         try:
             self.poll_interval = self.getProperty("interval")
@@ -116,7 +137,7 @@ class GenericVideoDevice(Device):
             self.cam_exposure = self.poll_interval/1000.0
 
         if self.cam_type is None:
-            self.cam_exposure = self.default_cam_type
+            self.cam_type = self.default_cam_type
 
         # Apply values	
 
@@ -133,10 +154,18 @@ class GenericVideoDevice(Device):
             self.set_video_live(True)
             self.change_owner()
 
+            logging.getLogger("HWR").info('Starting polling for camera')
             self.image_polling = gevent.spawn(self.do_image_polling,
                                               self.poll_interval/1000.0)
+            self.image_polling.link_exception(self.polling_ended_exc)
+            self.image_polling.link(self.polling_ended)
 
         self.setIsReady(True)
+
+    def polling_ended(self, gl=None):
+        logging.getLogger("HWR").info('Polling ended for qt4 camera')
+    def polling_ended_exc(self, gl=None):
+        logging.getLogger("HWR").info('Polling ended exception for qt4 camera')
 
     """ Generic methods """
     def get_new_image(self):
@@ -145,7 +174,7 @@ class GenericVideoDevice(Device):
         """
         raw_buffer, width, height = self.get_image()
 
-        if raw_buffer:
+        if raw_buffer is not None and raw_buffer.any():
             if self.cam_type == "basler":
                 raw_buffer = self.decoder(raw_buffer)
                 qimage = QImage(raw_buffer, width, height,
@@ -162,6 +191,25 @@ class GenericVideoDevice(Device):
             self.emit("imageReceived", qpixmap)
             return qimage
 
+    def get_jpg_image(self):
+        """ for now this function allows to deal with prosilica or any RGB encoded video data"""
+        """
+           the signal imageReceived is as expected by mxcube3 
+        """
+        raw_buffer, width, height = self.get_image()
+
+        if raw_buffer is not None and raw_buffer.any():
+            image = Image.frombytes("RGB", (width, height), raw_buffer)
+            from cStringIO import StringIO
+            strbuf = StringIO()
+            image.save(strbuf, "JPEG")
+            jpgimg_str = strbuf.getvalue()
+            if jpgimg_str is not None:
+                self.emit("imageReceived", jpgimg_str, width, height)
+            return jpgimg_str
+        else:
+            return None
+
     def get_cam_type(self):
         return self.cam_type
 
@@ -176,10 +224,18 @@ class GenericVideoDevice(Device):
         return cv2.cvtColor(image, cv2.COLOR_YUV2RGB_UYVY)
 
     def save_snapshot(self, filename, image_type='PNG'):
-        qimage = self.get_new_image() 
-        qimage.save(filename, image_type) 
+        if self.useqt:
+            qimage = self.get_new_image() 
+            qimage.save(filename, image_type) 
+        else:
+            jpgstr = self.get_jpg_image()
+            open(filename,"w").write(jpgstr)
 
     def get_snapshot(self, bw=None, return_as_array=True):
+        if not self.useqt:
+            print "get snapshot not implemented yet for non-qt mode"
+            return None
+
         qimage = self.get_new_image()
         if return_as_array:
             qimage = qimage.convertToFormat(4)
@@ -204,6 +260,8 @@ class GenericVideoDevice(Device):
         Returns   : Scaling factor in float. None if does not exists
         """ 
         return self.cam_scale_factor
+
+    get_image_zoom = get_scaling_factor 
 
     def imageType(self):
         """
@@ -254,7 +312,10 @@ class GenericVideoDevice(Device):
         Descript. :
         """
         while self.get_video_live() == True:
-            self.get_new_image()
+            if self.useqt:
+                self.get_new_image()
+            else:
+                self.get_jpg_image()
             time.sleep(sleep_time)
 
     def connectNotify(self, signal):


### PR DESCRIPTION
Add useqt property from xml to decide whether to use qt (qimage) or not for video encoding

Add scale property from xml so that classes can use on reading of images
Fix a bug where if cam_type was not specified, the wrong variable was assigned the default_cam_type