### PR TITLE
Improved XMLRPC security.

### DIFF
--- a/HardwareObjects/XMLRPCServer.py
+++ b/HardwareObjects/XMLRPCServer.py
@@ -15,13 +15,16 @@ import socket
 import time
 import json
 import atexit
+import traceback
 
 from HardwareRepository.BaseHardwareObjects import HardwareObject
 if sys.version_info > (3, 0):
-   from xmlrpc.server import SimpleXMLRPCServer
+    from xmlrpc.server import SimpleXMLRPCRequestHandler
+    from xmlrpc.server import SimpleXMLRPCServer
 else:
-   from SimpleXMLRPCServer import SimpleXMLRPCServer
-
+    from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler
+    from SimpleXMLRPCServer import SimpleXMLRPCServer
+    
 
 __author__ = "Marcus Oskarsson, Matias Guijarro"
 __copyright__ = "Copyright 2012, ESRF"
@@ -31,6 +34,87 @@ __version__ = ""
 __maintainer__ = "Marcus Oskarsson"
 __email__ = "marcus.oscarsson@esrf.fr"
 __status__ = "Draft"
+
+
+class SecureXMLRpcRequestHandler(SimpleXMLRPCRequestHandler):
+    """Secure XML-RPC request handler class.
+
+    It it very similar to SimpleXMLRPCRequestHandler but it uses HTTPS for transporting XML data.
+    """
+    __referenceToken = None
+    
+    @staticmethod
+    def setReferenceToken(token):
+        SecureXMLRpcRequestHandler.__referenceToken = token
+        
+    
+    def setup(self):
+        self.connection = self.request
+        self.rfile = socket._fileobject(self.request, "rb", self.rbufsize)
+        self.wfile = socket._fileobject(self.request, "wb", self.wbufsize)
+        
+    def do_POST(self):
+        """Handles the HTTPS POST request.
+
+        It was copied out from SimpleXMLRPCServer.py and modified to shutdown the socket cleanly.
+        """
+        # Check that the path is legal
+        if not self.is_rpc_path_valid():
+            self.report_404()
+            return
+
+        referenceToken = SecureXMLRpcRequestHandler.__referenceToken
+        if referenceToken is not None and "Token" in self.headers and referenceToken == self.headers["Token"]:
+            try:
+                # Get arguments by reading body of request.
+                # We read this in chunks to avoid straining
+                # socket.read(); around the 10 or 15Mb mark, some platforms
+                # begin to have problems (bug #792570).
+                max_chunk_size = 10*1024*1024
+                size_remaining = int(self.headers["content-length"])
+                L = []
+                while size_remaining:
+                    chunk_size = min(size_remaining, max_chunk_size)
+                    chunk = self.rfile.read(chunk_size)
+                    if not chunk:
+                        break
+                    L.append(chunk)
+                    size_remaining -= len(L[-1])
+                data = ''.join(L)
+                # In previous versions of SimpleXMLRPCServer, _dispatch
+                # could be overridden in this class, instead of in
+                # SimpleXMLRPCDispatcher. To maintain backwards compatibility,
+                # check to see if a subclass implements _dispatch and dispatch
+                # using that method if present.
+                response = self.server._marshaled_dispatch(
+                        data, getattr(self, '_dispatch', None)
+                    )
+            except Exception, e: # This should only happen if the module is buggy
+                # internal error, report as HTTP server error
+                self.send_response(500)
+    
+                # Send information about the exception if requested
+                if hasattr(self.server, '_send_traceback_header') and \
+                        self.server._send_traceback_header:
+                    self.send_header("X-exception", str(e))
+                    self.send_header("X-traceback", traceback.format_exc())
+    
+                self.end_headers()
+            else:
+                # got a valid XML RPC response
+                self.send_response(200)
+                self.send_header("Content-type", "text/xml")
+                self.send_header("Content-length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
+    
+                # shut down the connection
+                self.wfile.flush()
+                self.connection.shutdown(1)
+        else:
+            #Unrecognized token - access forbidden
+            self.send_response(403)
+            self.end_headers()
 
 
 class XMLRPCServer(HardwareObject):
@@ -43,6 +127,7 @@ class XMLRPCServer(HardwareObject):
         self.xmlrpc_prefixes = set()
         self.current_entry_task = None
         self.host = None
+        self.doEnforceUseOfToken = False        
 
         atexit.register(self.close)
       
@@ -53,7 +138,7 @@ class XMLRPCServer(HardwareObject):
 
         # Listen on all interfaces if <all_interfaces>True</all_interfaces>
         # otherwise only on the interface corresponding to socket.gethostname()
-        if hasattr(self, "all_interfaces") and self.all_interfaces == True:
+        if hasattr(self, "all_interfaces") and self.all_interfaces.strip().lower() == "true":
             host = ''
         else:
             host = socket.gethostname()
@@ -61,6 +146,9 @@ class XMLRPCServer(HardwareObject):
         #host = "riga.embl-hamburg.de"
        
         self.host = host    
+
+        if hasattr(self, "enforceUseOfToken") and self.enforceUseOfToken.strip().lower() == "true":
+            self.doEnforceUseOfToken = True
 
         #try:
         self.open()
@@ -83,7 +171,11 @@ class XMLRPCServer(HardwareObject):
         if hasattr(self, "_server" ):
           return
         self.xmlrpc_prefixes = set()
-        self._server = SimpleXMLRPCServer((self.host, int(self.port)), logRequests = False, allow_none = True)   
+        if self.doEnforceUseOfToken:
+            self._server = SimpleXMLRPCServer((self.host, int(self.port)), requestHandler=SecureXMLRpcRequestHandler, 
+                                              logRequests = False, allow_none = True)
+        else:
+            self._server = SimpleXMLRPCServer((self.host, int(self.port)), logRequests = False, allow_none = True)
         msg = 'XML-RPC server listening on: %s:%s' % (self.host, self.port)
         logging.getLogger("HWR").info(msg)
 
@@ -531,3 +623,5 @@ class XMLRPCServer(HardwareObject):
                 except StopIteration:
                     pass
 
+    def setToken(self, token):
+        SecureXMLRpcRequestHandler.setReferenceToken(token)


### PR DESCRIPTION
This is the PR for issue #76. It implements secure XMLRPC communication based on a token. 

The security is disabled by default, and can be enabled by adding "`<enforceUseOfToken>True</enforceUseOfToken>`" to the XMLRPC configuration XML file.

The token is passed from the EdnaWorkflow HO to the class SecureXMLRpcRequestHandler via a static call. It's working but maybe can be made more elegantly?

I have tested this code on MASSIF 1 on 2017/09/20, and it's working as expected.

If this PR is accepted I'll add similar PRs for the branches 2.1 and 2.2.