### PR TITLE
Add wait_ready() function for diffractometers

### DIFF
--- a/HardwareObjects/AbstractMultiCollect.py
+++ b/HardwareObjects/AbstractMultiCollect.py
@@ -818,6 +818,11 @@ class AbstractMultiCollect(object):
                           frame += 1
                           if j == 0:
                             break
+        
+            # Bug fix for MD2/3(UP): diffractometer still has things to do even after the last frame is taken (decelerate motors and
+            # possibly download diagnostics) so we cannot trigger the cleanup (that will send an abort on the diffractometer) as soon as
+            # the last frame is counted
+            self.diffractometer().wait_ready(10)
 
         # data collection done
         self.data_collection_end_hook(data_collect_parameters)

--- a/HardwareObjects/Microdiff.py
+++ b/HardwareObjects/Microdiff.py
@@ -58,6 +58,8 @@ class Microdiff(MiniDiff.MiniDiff):
 
         self.beam_info = self.getObjectByRole('beam_info')
 
+        self.wait_ready = self._wait_ready
+
     def getMotorToExporterNames(self):
         MOTOR_TO_EXPORTER_NAME = {"focus":self.focusMotor.getProperty('motor_name'), "kappa":self.kappaMotor.getProperty('motor_name'),
                                   "kappa_phi":self.kappaPhiMotor.getProperty('motor_name'), "phi": self.phiMotor.getProperty('motor_name'),
@@ -89,13 +91,12 @@ class Microdiff(MiniDiff.MiniDiff):
         return False
 
     def _wait_ready(self, timeout=None):
-        if timeout <= 0:
+        # None means infinite timeout
+        # <=0 means default timeout
+        if timeout is not None and timeout <= 0:
             timeout = self.timeout
-        tt1 = time.time()
-        while time.time() - tt1 < timeout:
-             if self._ready():
-                 break
-             else:
+        with gevent.Timeout(timeout, RuntimeError("Timeout waiting for diffractometer to be ready")):
+             while not self._ready():
                  time.sleep(0.5)
 
     def moveToPhase(self, phase, wait=False, timeout=None):

--- a/HardwareObjects/MiniDiff.py
+++ b/HardwareObjects/MiniDiff.py
@@ -744,3 +744,7 @@ class MiniDiff(Equipment):
 
     def simulateAutoCentring(self,sample_info=None):
         pass
+
+    def wait_ready(self, timeout=None):
+        pass
+


### PR DESCRIPTION
diffractometer.wait_ready() is called by AbstractMultiCollect at the end of a data collection,
this mainly concerns MD2/3(UP).