### PR TITLE
Encapsulated some internal lists / dicts 

### DIFF
--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -283,7 +283,7 @@ class HardwareObjectNode:
         return self._propertySet.get(str(name), default_value)
 
     def getProperties(self):
-        return self._propertySet
+        return self._propertySet.copy()
             
     def update_values(self):
         """Method called from Qt bricks to ensure that bricks have values

--- a/Command/Pool.py
+++ b/Command/Pool.py
@@ -161,12 +161,12 @@ class PoolChannel(ChannelObject):
 
     def push_event(self, event):
         PoolChannel._eventReceivers[id(event)] = BoundMethodWeakref(self.update)
-	PoolChannel._tangoEventsQueue.put(event)
+        PoolChannel._tangoEventsQueue.put(event)
        
  
     def poll(self):
         try:
-	   value = self.device.read_attribute(self.attributeName).value
+           value = self.device.read_attribute(self.attributeName).value
         except:
            logging.getLogger("HWR").exception("%s: could not poll attribute %s", str(self.name()), self.attributeName)
 

--- a/Command/Spec.py
+++ b/Command/Spec.py
@@ -59,7 +59,7 @@ class SpecCommand(CommandObject, SpecCommandA):
             self.emit('commandFailed', (-1, str(self.name())))
             
         self.emit('disconnected', ())
-	self.statusChanged(ready=False)
+        self.statusChanged(ready=False)
 
     
     def statusChanged(self, ready):

--- a/Command/Tango.py
+++ b/Command/Tango.py
@@ -186,7 +186,7 @@ class TangoChannel(ChannelObject):
           #logging.getLogger("HWR").debug("%s, receiving good event", self.name())
         ev = E(event)
         TangoChannel._eventReceivers[id(ev)] = saferef.safe_ref(self.update)
-	TangoChannel._tangoEventsQueue.put(ev)
+        TangoChannel._tangoEventsQueue.put(ev)
         TangoChannel._tangoEventsProcessingTimer.send()
        
  

--- a/Command/Tine.py
+++ b/Command/Tine.py
@@ -24,17 +24,17 @@ class TineCommand(CommandObject):
         self.commandName = command_name
         self.tineName = tinename
         self.timeout = int(timeout)
-	
+
     def __call__(self, *args, **kwargs):
         self.emit('commandBeginWaitReply', (str(self.name()), ))
         if ( len(args) == 0):
            commandArgument = []     
         else:
-	   commandArgument = args[0]
-	try :
-	   ret = tine.set(self.tineName, self.commandName, commandArgument, self.timeout) 
-	   self.emit('commandReplyArrived', (ret, str(self.name())))
-	except IOError as strerror:
+           commandArgument = args[0]
+        try :
+           ret = tine.set(self.tineName, self.commandName, commandArgument, self.timeout)
+           self.emit('commandReplyArrived', (ret, str(self.name())))
+        except IOError as strerror:
            logging.getLogger("HWR").error("%s" % strerror)
            self.emit('commandFailed', (strerror))
 
@@ -94,7 +94,7 @@ class TineChannel(ChannelObject):
         self.tineName = tinename
         self.timeout = int(timeout)
         self.value = None
-	self.oldvalue = None
+        self.oldvalue = None
  
         self.callback_fail_counter = 0
        
@@ -134,19 +134,19 @@ class TineChannel(ChannelObject):
        
     def tineEventCallback(self, id, cc, data_list):
         if cc == 0:
-	    self.callback_fail_counter = 0
+            self.callback_fail_counter = 0
             self.update(data_list)
         else:
             self.callback_fail_counter = self.callback_fail_counter + 1
             logging.getLogger("HWR").error("Tine event callback error %s, Channel: %s, Server: %s/%s" %(str(cc),self.name(),self.tineName,self.attributeName))
-	    if self.callback_fail_counter >= 3:
-	       logging.getLogger("HWR").error("Repeated tine event callback errors %s, Channel: %s, Server: %s/%s" %(str(cc),self.name(),self.tineName,self.attributeName))
+            if self.callback_fail_counter >= 3:
+               logging.getLogger("HWR").error("Repeated tine event callback errors %s, Channel: %s, Server: %s/%s" %(str(cc),self.name(),self.tineName,self.attributeName))
           
     def update(self, value = None):
         if value is None:
             value = self.getValue()
         self.value = value
-	if value != self.oldvalue:
+        if value != self.oldvalue:
             TineChannel.updates.put((weakref.ref(self), value))
             self.oldvalue = value
 

--- a/HardwareObjects/ALBA/ALBAMachineInfo.py
+++ b/HardwareObjects/ALBA/ALBAMachineInfo.py
@@ -94,24 +94,24 @@ class ALBAMachineInfo(Equipment):
 #        self.values_in_range_dict = {}
         self.chan_mach_current = None
         self.chan_mach_status = None
-	self.chan_topup_remaining = None
+        self.chan_topup_remaining = None
 	
     def init(self):
         """
         Descript. : Inits channels from xml configuration. 
         """
-	try:
-	    self.chan_mach_current = self.getChannelObject('MachCurrent')
-	    if self.chan_mach_current is not None: 
-	        self.chan_mach_current.connectSignal('update', self.mach_current_changed)
+        try:
+            self.chan_mach_current = self.getChannelObject('MachCurrent')
+            if self.chan_mach_current is not None:
+                self.chan_mach_current.connectSignal('update', self.mach_current_changed)
 
-	    self.chan_mach_status = self.getChannelObject('MachStatus')
-	    if self.chan_mach_status is not None:
-	        self.chan_mach_status.connectSignal('update', self.mach_status_changed)
+            self.chan_mach_status = self.getChannelObject('MachStatus')
+            if self.chan_mach_status is not None:
+                self.chan_mach_status.connectSignal('update', self.mach_status_changed)
 
-	    self.chan_topup_remaining = self.getChannelObject('TopUpRemaining')
-	    if self.chan_topup_remaining is not None:
-	        self.chan_topup_remaining.connectSignal('update', self.topup_remaining_changed)
+            self.chan_topup_remaining = self.getChannelObject('TopUpRemaining')
+            if self.chan_topup_remaining is not None:
+                self.chan_topup_remaining.connectSignal('update', self.topup_remaining_changed)
         except KeyError:
             self.logger.warning('%s: cannot read machine info', self.name())
 

--- a/HardwareObjects/ALBA/ALBAMachineInfo.py
+++ b/HardwareObjects/ALBA/ALBAMachineInfo.py
@@ -95,7 +95,7 @@ class ALBAMachineInfo(Equipment):
         self.chan_mach_current = None
         self.chan_mach_status = None
         self.chan_topup_remaining = None
-	
+
     def init(self):
         """
         Descript. : Inits channels from xml configuration. 

--- a/HardwareObjects/ALBA/ALBAMiniDiff.py
+++ b/HardwareObjects/ALBA/ALBAMiniDiff.py
@@ -299,5 +299,5 @@ class ALBAMiniDiff(GenericDiffractometer):
         self.current_motor_positions["focus"] = pos
 
     def start_auto_focus(self):
-	self.cmd_start_auto_focus()
+        self.cmd_start_auto_focus()
 

--- a/HardwareObjects/ALBA/XalocMachineInfo.py
+++ b/HardwareObjects/ALBA/XalocMachineInfo.py
@@ -78,7 +78,7 @@ class XalocMachineInfo(Equipment):
     """
 
     def __init__(self, name):
-	Equipment.__init__(self, name)
+        Equipment.__init__(self, name)
         """
         Descript. : 
         """
@@ -91,24 +91,24 @@ class XalocMachineInfo(Equipment):
 #        self.values_in_range_dict = {}
         self.chan_mach_current = None
         self.chan_mach_status = None
-	self.chan_topup_remaining = None
-	
+        self.chan_topup_remaining = None
+
     def init(self):
         """
         Descript. : Inits channels from xml configuration. 
         """
-	try:
-	    self.chan_mach_current = self.getChannelObject('MachCurrent')
-	    if self.chan_mach_current is not None: 
-	        self.chan_mach_current.connectSignal('update', self.mach_current_changed)
+        try:
+            self.chan_mach_current = self.getChannelObject('MachCurrent')
+            if self.chan_mach_current is not None:
+                self.chan_mach_current.connectSignal('update', self.mach_current_changed)
 
-	    self.chan_mach_status = self.getChannelObject('MachStatus')
-	    if self.chan_mach_status is not None:
-	        self.chan_mach_status.connectSignal('update', self.mach_status_changed)
+            self.chan_mach_status = self.getChannelObject('MachStatus')
+            if self.chan_mach_status is not None:
+                self.chan_mach_status.connectSignal('update', self.mach_status_changed)
 
-	    self.chan_topup_remaining = self.getChannelObject('TopUpRemaining')
-	    if self.chan_topup_remaining is not None:
-	        self.chan_topup_remaining.connectSignal('update', self.topup_remaining_changed)
+            self.chan_topup_remaining = self.getChannelObject('TopUpRemaining')
+            if self.chan_topup_remaining is not None:
+                self.chan_topup_remaining.connectSignal('update', self.topup_remaining_changed)
         except KeyError:
             logging.getLogger().warning('%s: cannot read machine info', self.name())
 

--- a/HardwareObjects/ALBA/XalocMiniDiff.py
+++ b/HardwareObjects/ALBA/XalocMiniDiff.py
@@ -16,7 +16,7 @@ class XalocMiniDiff(GenericDiffractometer):
         if self.centring_hwobj is None:
             logging.getLogger("HWR").debug('EMBLMinidiff: Centring math is not defined')
 
-	self.cmd_start_auto_focus = self.getCommandObject('startAutoFocus')
+        self.cmd_start_auto_focus = self.getCommandObject('startAutoFocus')
 
         self.phi_motor_hwobj = self.getObjectByRole('phi')
         self.phiz_motor_hwobj = self.getObjectByRole('phiz')
@@ -75,7 +75,7 @@ class XalocMiniDiff(GenericDiffractometer):
 
     def get_pixels_per_mm(self):
         px_x, px_y = self.getCalibrationData()
-	return (px_x,px_y)
+        return (px_x,px_y)
             
 
     def update_pixels_per_mm(self, *args):
@@ -240,5 +240,5 @@ class XalocMiniDiff(GenericDiffractometer):
         self.current_motor_positions["focus"] = pos
 
     def start_auto_focus(self):
-	self.cmd_start_auto_focus()
+        self.cmd_start_auto_focus()
 

--- a/HardwareObjects/AbstractMultiCollect.py
+++ b/HardwareObjects/AbstractMultiCollect.py
@@ -639,7 +639,7 @@ class AbstractMultiCollect(object):
         if nframes == 0:
             return
 
-	# data collection
+        # data collection
         self.first_image_timeout = 30+oscillation_parameters["exposure_time"]
         self.data_collection_hook(data_collect_parameters)
 

--- a/HardwareObjects/AbstractXRFSpectrum.py
+++ b/HardwareObjects/AbstractXRFSpectrum.py
@@ -18,7 +18,7 @@ import gevent
 import gevent.event
 import numpy
 import abc
-from HardwareRepository.TaskUtils import cleanup	
+from HardwareRepository.TaskUtils import cleanup
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 

--- a/HardwareObjects/AdscTemperature.py
+++ b/HardwareObjects/AdscTemperature.py
@@ -13,4 +13,4 @@ class AdscTemperature(TacoDevice.TacoDevice):
                 
 
     def valueChanged(self, deviceName, value):
-	self.emit('valueChanged', (value,) )
+        self.emit('valueChanged', (value,) )

--- a/HardwareObjects/ApertureMockup.py
+++ b/HardwareObjects/ApertureMockup.py
@@ -31,7 +31,7 @@ __version__ = "2.2."
 class ApertureMockup(Device):
     """
     Description:	
-    """	
+    """
     POSITIONS = ("BEAM", "OFF", "PARK")
 
     def __init__(self, name):
@@ -83,7 +83,7 @@ class ApertureMockup(Device):
 
     def is_out(self):
         return self.position != "BEAM"
-	   	
+
     def get_diameter_list(self):
         return self.diameter_list
 

--- a/HardwareObjects/Attenuators.py
+++ b/HardwareObjects/Attenuators.py
@@ -91,7 +91,7 @@ class Attenuators(Device):
         Descript. :
         """
         try:
-  	    self.att_value = float(value)
+            self.att_value = float(value)
         except:
             pass
         else:
@@ -115,7 +115,7 @@ class Attenuators(Device):
         if self.chan_att_limits is not None:
             self.att_limits = self.chan_att_limits.getValue()
         return self.att_limits    
-  	      
+
     def is_in(self, attenuator_index):
         """
         Descript. :

--- a/HardwareObjects/BeamInfo.py
+++ b/HardwareObjects/BeamInfo.py
@@ -25,7 +25,7 @@ from HardwareRepository.BaseHardwareObjects import Equipment
 class BeamInfo(Equipment):
     """
     Description:
-    """  	
+    """
 
     def __init__(self, *args):
         """
@@ -170,7 +170,7 @@ class BeamInfo(Equipment):
         """
         self.evaluate_beam_info()
         return self.beam_info_dict["size_x"], \
-	       self.beam_info_dict["size_y"]
+               self.beam_info_dict["size_y"]
 
     def get_beam_shape(self):
         """
@@ -188,7 +188,7 @@ class BeamInfo(Equipment):
         Return    :
         """
         self.evaluate_beam_info()
-        return self.beam_size_slits	
+        return self.beam_size_slits
 
     def evaluate_beam_info(self):
         """
@@ -196,22 +196,22 @@ class BeamInfo(Equipment):
         Return    : dictionary,{size_x:0.1, size_y:0.1, shape:"rectangular"}
         """
         size_x = min(self.beam_size_aperture[0],
-	   	     self.beam_size_slits[0],
-		     self.beam_size_definer[0]) 
+                     self.beam_size_slits[0],
+                     self.beam_size_definer[0])
         size_y = min(self.beam_size_aperture[1],
-  		     self.beam_size_slits[1], 
-		     self.beam_size_definer[1]) 
-	
+                     self.beam_size_slits[1],
+                     self.beam_size_definer[1])
+
         self.beam_info_dict["size_x"] = size_x
         self.beam_info_dict["size_y"] = size_y
 
         # be careful with comparisons!!! both have to be the same type (=tuple)
         if tuple(self.beam_size_aperture) < tuple(self.beam_size_slits):
-	    self.beam_info_dict["shape"] = "ellipse"
-	else:
-	    self.beam_info_dict["shape"] = "rectangular"
-	
-	return self.beam_info_dict	
+            self.beam_info_dict["shape"] = "ellipse"
+        else:
+            self.beam_info_dict["shape"] = "rectangular"
+
+        return self.beam_info_dict
 
     def emit_beam_info_change(self): 
         """
@@ -220,12 +220,12 @@ class BeamInfo(Equipment):
         Return    :
         """
         if self.beam_info_dict["size_x"] != 9999 and \
-           self.beam_info_dict["size_y"] != 9999:		
+           self.beam_info_dict["size_y"] != 9999:
             self.emit("beamSizeChanged", ((self.beam_info_dict["size_x"], \
                  self.beam_info_dict["size_y"]), ))
             self.emit("beamInfoChanged", (self.beam_info_dict, ))
             if self.chan_beam_size_microns:
                 self.chan_beam_size_microns.setValue((self.beam_info_dict["size_x"] * 1000, \
-                     self.beam_info_dict["size_y"] * 1000))	
+                     self.beam_info_dict["size_y"] * 1000))
             if self.chan_beam_shape_ellipse:
                 self.chan_beam_shape_ellipse.setValue(self.beam_info_dict["shape"] == "ellipse") 

--- a/HardwareObjects/BeamInfoMockup.py
+++ b/HardwareObjects/BeamInfoMockup.py
@@ -81,7 +81,7 @@ class BeamInfoMockup(Equipment):
 
     def get_slits_gap(self):
         self.evaluate_beam_info()
-        return self.beam_size_slits	
+        return self.beam_size_slits
 
     def set_slits_gap(self, width_microns, height_microns):
         if self.slits_hwobj:
@@ -99,7 +99,7 @@ class BeamInfoMockup(Equipment):
         size_y = min(self.beam_size_aperture[1],
                      self.beam_size_slits[1], 
                      self.beam_size_definer[1]) 
-	
+
         self.beam_info_dict["size_x"] = size_x
         self.beam_info_dict["size_y"] = size_y
 
@@ -107,11 +107,11 @@ class BeamInfoMockup(Equipment):
             self.beam_info_dict["shape"] = "ellipse"
         else:
             self.beam_info_dict["shape"] = "rectangular"
-        return self.beam_info_dict	
+        return self.beam_info_dict
 
     def emit_beam_info_change(self): 
         if self.beam_info_dict["size_x"] != 9999 and \
-            self.beam_info_dict["size_y"] != 9999:		
+            self.beam_info_dict["size_y"] != 9999:
             self.emit("beamSizeChanged", ((self.beam_info_dict["size_x"],\
                       self.beam_info_dict["size_y"]), ))
             self.emit("beamInfoChanged", (self.beam_info_dict, ))

--- a/HardwareObjects/BeamlineActionsMockup.py
+++ b/HardwareObjects/BeamlineActionsMockup.py
@@ -24,7 +24,7 @@ class ControllerCommand(CommandObject):
     def __init__(self, name, cmd, username=None, klass=SimulatedAction):
         CommandObject.__init__(self, name, username)
         self._cmd = klass()
-	self._cmd_execution = None
+        self._cmd_execution = None
 
         if self.name() == 'Anneal':
             self.addArgument("Time [s]", "float")

--- a/HardwareObjects/BlissMotorWPositions.py
+++ b/HardwareObjects/BlissMotorWPositions.py
@@ -53,7 +53,7 @@ class BlissMotorWPositions(BlissMotor):
             
     def sortPredefinedPositionsList(self):
         self.predefinedPositionsNamesList = self.predefinedPositions.keys()
-	self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y]))) 
+        self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y])))
         
     def updateState(self, state=None):
        prev_state = self.motorState
@@ -77,11 +77,11 @@ class BlissMotorWPositions(BlissMotor):
         try:
             self.move(self.predefinedPositions[positionName])
         except:
-	    logging.getLogger("HWR").exception('Cannot move motor %s: invalid position name.', str(self.userName())) 
+            logging.getLogger("HWR").exception('Cannot move motor %s: invalid position name.', str(self.userName()))
 
     def getCurrentPositionName(self):
         if not self.motorIsMoving(): #self.isReady() and self.getState() == self.READY:
-	    for positionName in self.predefinedPositions:
+            for positionName in self.predefinedPositions:
                 if self.predefinedPositions[positionName] >= self.getPosition()-self.delta and self.predefinedPositions[positionName] <= self.getPosition()+self.delta:
                    return positionName 
         return ''

--- a/HardwareObjects/Camera.py
+++ b/HardwareObjects/Camera.py
@@ -416,8 +416,8 @@ class Camera(BaseHardwareObjects.Device):
                 def setBpm(self, bpmOn):
                     """tango"""
                     if self.bpmDevice is not None:
-                    	if bpmOn: self.bpmDevice.executeCommand('on')
-                    	else: self.bpmDevice.executeCommand('off')
+                            if bpmOn: self.bpmDevice.executeCommand('on')
+                            else: self.bpmDevice.executeCommand('off')
 
                 def getBpmState(self):
                     """tango"""
@@ -812,7 +812,7 @@ class Camera(BaseHardwareObjects.Device):
                             self.setLive(True)
 
             self.__class__ = TacoCamera
-	    self._TacoDevice__dc= False
+            self._TacoDevice__dc= False
             self._init()
 
 

--- a/HardwareObjects/CentringMath.py
+++ b/HardwareObjects/CentringMath.py
@@ -17,7 +17,7 @@ class CentringMath(Procedure):
         self.gonioAxes = []
         for axis in self['gonioAxes']:
           self.gonioAxes.append({'type':axis.type,'direction':eval(axis.direction),\
-	      		         'motor_name':axis.motorname,'motor_HO':
+                                       'motor_name':axis.motorname,'motor_HO':
                                   HardwareRepository.HardwareRepository().getHardwareObject(axis.motorHO) })      
         
 
@@ -205,7 +205,7 @@ class CentringMath(Procedure):
         # finds a projection of camera vector {"X":x,"Y":y} onto a motor axis of a motor_HO
         for axis in self.gonioAxes:
             if axis['type'] == "translation" and motor_HO is axis['motor_HO']:
-	       res = 0.0
+               res = 0.0
                for camaxis in self.cameraAxes:
                    res = res + numpy.dot(axis['direction'],camaxis['direction'])*camxy[camaxis['axis_name']]
                return res

--- a/HardwareObjects/DiffractometerMockup.py
+++ b/HardwareObjects/DiffractometerMockup.py
@@ -172,7 +172,7 @@ class DiffractometerMockup(GenericDiffractometer):
         """
         return
 
-    def get_omega_axis_position(self):	
+    def get_omega_axis_position(self):
         """
         Descript. :
         """

--- a/HardwareObjects/EMBL/EMBLBeamFocusing.py
+++ b/HardwareObjects/EMBL/EMBLBeamFocusing.py
@@ -59,7 +59,7 @@ class EMBLBeamFocusing(HardwareObject):
                   'diverg': eval(focus_mode.divergence)})
         self.focus_motors_dict = {}
 
-        focus_motors = []
+        # focus_motors = []
         focus_motors = eval(self.getProperty('focusMotors'))
 
         for focus_motor in focus_motors:

--- a/HardwareObjects/EMBL/EMBLBeamInfo.py
+++ b/HardwareObjects/EMBL/EMBLBeamInfo.py
@@ -49,7 +49,7 @@ __category__ = "General"
 class EMBLBeamInfo(Equipment):
     """
     Description:
-    """  	
+    """
 
     def __init__(self, *args):
         """
@@ -165,8 +165,8 @@ class EMBLBeamInfo(Equipment):
         """
         if self.chan_beam_position_hor and self.chan_beam_position_ver:
             self.beam_position = [self.chan_beam_position_hor.getValue(), \
-	                          self.chan_beam_position_ver.getValue()]
-        return self.beam_position	
+                                  self.chan_beam_position_ver.getValue()]
+        return self.beam_position
 
     def set_beam_position(self, beam_x, beam_y):
         """
@@ -233,7 +233,7 @@ class EMBLBeamInfo(Equipment):
         """
         self.evaluate_beam_info()
         return (self.beam_info_dict["size_x"], \
-	        self.beam_info_dict["size_y"])
+                self.beam_info_dict["size_y"])
 
     def get_beam_shape(self):
         """
@@ -254,7 +254,7 @@ class EMBLBeamInfo(Equipment):
         if self.beam_size_slits == [9999, 9999]:
             return [None, None]
         else: 
-            return self.beam_size_slits	
+            return self.beam_size_slits
 
     def set_slits_gap(self, width_microns, height_microns):
         if self.slits_hwobj:
@@ -267,17 +267,17 @@ class EMBLBeamInfo(Equipment):
         Return    : dictionary,{size_x:0.1, size_y:0.1, shape:"rectangular"}
         """
         size_x = min(self.beam_size_aperture[0],
-	   	     self.beam_size_slits[0],
-		     self.beam_size_focusing[0]) 
+                     self.beam_size_slits[0],
+                     self.beam_size_focusing[0])
         size_y = min(self.beam_size_aperture[1],
-  		     self.beam_size_slits[1], 
-		     self.beam_size_focusing[1]) 
+                     self.beam_size_slits[1],
+                     self.beam_size_focusing[1])
 
         if size_x == 9999 or size_y == 9999:
             #fix this
             return
         if (abs(size_x - self.beam_info_dict.get("size_x", 0)) > 1e-3 or
-            abs(size_y - self.beam_info_dict.get("size_y", 0)) > 1e-3):	
+            abs(size_y - self.beam_info_dict.get("size_y", 0)) > 1e-3):
             self.beam_info_dict["size_x"] = size_x
             self.beam_info_dict["size_y"] = size_y
 
@@ -292,7 +292,7 @@ class EMBLBeamInfo(Equipment):
             if self.chan_beam_shape_ellipse:
                 self.chan_beam_shape_ellipse.setValue(self.beam_info_dict["shape"] == "ellipse")
 
-        return self.beam_info_dict	
+        return self.beam_info_dict
 
     def emit_beam_info_change(self): 
         """
@@ -301,7 +301,7 @@ class EMBLBeamInfo(Equipment):
         Return    :
         """
         if (self.beam_info_dict["size_x"] != 9999 and \
-            self.beam_info_dict["size_y"] != 9999):		
+            self.beam_info_dict["size_y"] != 9999):
             self.emit("beamSizeChanged", ((self.beam_info_dict["size_x"] * 1000, \
                                            self.beam_info_dict["size_y"] * 1000), ))
             self.emit("beamInfoChanged", (self.beam_info_dict, ))

--- a/HardwareObjects/EMBL/EMBLBeamlineTest.py
+++ b/HardwareObjects/EMBL/EMBLBeamlineTest.py
@@ -1576,7 +1576,7 @@ class EMBLBeamlineTest(HardwareObject):
 
     def get_available_tests(self):
         """Returns a list with available tests"""
-        return self.available_tests_dict
+        return self.available_tests_dict.copy()
 
     def get_startup_test_list(self):
         """Returns a list with tests defined at startup"""

--- a/HardwareObjects/EMBL/EMBLEnergyScan.py
+++ b/HardwareObjects/EMBL/EMBLEnergyScan.py
@@ -461,7 +461,10 @@ class EMBLEnergyScan(AbstractEnergyScan, HardwareObject):
         """Returns energy scan data.
            List contains tuples of (energy, counts)
         """
-        return self.scan_data
+        if self.scan_data is None:
+            return None
+        else:
+            return list(self.scan_data)
 
     def store_energy_scan(self):
         if self.db_connection_hwobj:

--- a/HardwareObjects/EMBL/EMBLEnergyScan.py
+++ b/HardwareObjects/EMBL/EMBLEnergyScan.py
@@ -123,7 +123,7 @@ class EMBLEnergyScan(AbstractEnergyScan, HardwareObject):
                 y = values[-1][1]
                 if not (x == 0 and y == 0):
                     # if x is in keV, transform into eV otherwise let it like it is
-	            # if point larger than previous point (for chooch)
+                    # if point larger than previous point (for chooch)
                     if len(self.scan_data) > 0:
                         if x > self.scan_data[-1][0]:
                             self.scan_data.append([(x < 1000 and x*1000.0 or x), y])

--- a/HardwareObjects/EMBL/EMBLExporterClient.py
+++ b/HardwareObjects/EMBL/EMBLExporterClient.py
@@ -30,7 +30,7 @@ __category__ = "General"
 class EMBLExporterClient(HardwareObject):
     """
     Description:
-    """  	
+    """
 
     def __init__(self, *args):
         """

--- a/HardwareObjects/EMBL/EMBLMachineInfo.py
+++ b/HardwareObjects/EMBL/EMBLMachineInfo.py
@@ -94,7 +94,7 @@ class EMBLMachineInfo(HardwareObject):
         self.flux_area = None
         self.last_transmission = None
 
-	#Intensity current ranges
+        #Intensity current ranges
         self.values_list = []
         temp_dict = {}
         temp_dict['value'] = 0
@@ -392,7 +392,7 @@ class EMBLMachineInfo(HardwareObject):
         """Returns current"""
         return self.values_list[0]['value']
 
-    def	get_message(self):
+    def get_message(self):
         """Returns synchrotron state text"""
         return self.state_text
 

--- a/HardwareObjects/EMBL/EMBLMiniDiff.py
+++ b/HardwareObjects/EMBL/EMBLMiniDiff.py
@@ -44,7 +44,7 @@ __category__ = "General"
 class EMBLMiniDiff(GenericDiffractometer):
     """
     Description:
-    """	
+    """
 
     AUTOMATIC_CENTRING_IMAGES = 6
 

--- a/HardwareObjects/EMBL/EMBLPPUControl.py
+++ b/HardwareObjects/EMBL/EMBLPPUControl.py
@@ -11,7 +11,7 @@ __category__ = "General"
 class EMBLPPUControl(Device):    
 
     def __init__(self, name):
-        Device.__init__(self, name)	
+        Device.__init__(self, name)
 
         self.all_status = None
         self.status_result = None
@@ -29,7 +29,7 @@ class EMBLPPUControl(Device):
       
         self.status_running = None
         self.restart_running = None
-	
+
     def init(self):
         self.all_status = ""
         self.status_result = ""

--- a/HardwareObjects/EMBL/TINEMotor.py
+++ b/HardwareObjects/EMBL/TINEMotor.py
@@ -35,10 +35,10 @@ def energyConverter(wavelength):
     """
     Descript. :
     """
-    if wavelength != 0:	
+    if wavelength != 0:
         energy = float(12.398425 / wavelength)
     else:
-        energy = 0	
+        energy = 0
     return energy
 
 class TINEMotor(Device):    
@@ -52,7 +52,7 @@ class TINEMotor(Device):
         """
         Descript. :
         """
-        Device.__init__(self, name)	
+        Device.__init__(self, name)
         self.objName = name  
         self.motorState = READY
         self.motorState2 = 'noninit'
@@ -74,7 +74,7 @@ class TINEMotor(Device):
         self.maxMotorPosition = None
         self.moveConditions = None
         #self.moveHOSignals = None
-	
+
     def init(self):
         """
         Descript. :

--- a/HardwareObjects/ESRF/ESRFMultiCollect.py
+++ b/HardwareObjects/ESRF/ESRFMultiCollect.py
@@ -613,6 +613,7 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
                 nkey = key[:-9]
                 all_gaps[nkey] = _gaps[key]
             else:
+                # TODO FIXME ERROR this cannot possibly be right:
                 all_gaps = _gaps
         return all_gaps
 

--- a/HardwareObjects/ESRF/ESRFSC3.py
+++ b/HardwareObjects/ESRF/ESRFSC3.py
@@ -64,7 +64,7 @@ class ESRFSC3(SC3.SC3):
         loaded = False
 
         with error_cleanup(functools.partial(self.emit, "stateChanged", SC3.SampleChangerState.Alarm), failureCallback):
-	  with cleanup(functools.partial(self.emit, "stateChanged", SC3.SampleChangerState.Ready)):
+          with cleanup(functools.partial(self.emit, "stateChanged", SC3.SampleChangerState.Ready)):
             with cleanup(self.unlockMinidiffMotors, wait=True, timeout=3):
                 loaded = self.__loadSample(holderLength, sample_id, sample_location)
         

--- a/HardwareObjects/ESRF/ID231BeamInfo.py
+++ b/HardwareObjects/ESRF/ID231BeamInfo.py
@@ -42,7 +42,7 @@ class BeamInfo(Equipment):
            self.aperture_HO = HardwareRepository.HardwareRepository().getHardwareObject(self.getProperty("aperture"))
 	   self.connect(self.aperture_HO, "apertureChanged", self.aperture_pos_changed)
 	except:
-	   logging.getLogger("HWR").debug('BeamInfo: aperture not defined correctly') 
+	   logging.getLogger("HWR").debug('BeamInfo: aperture not defined correctly')
         try:
            self.slits_HO = HardwareRepository.HardwareRepository().getHardwareObject(self.getProperty("slits"))
            self.connect(self.slits_HO, "gapSizeChanged", self.slits_gap_changed)
@@ -58,59 +58,59 @@ class BeamInfo(Equipment):
         self.beam_position_hor.connectSignal("update", self.beam_pos_hor_changed)
         self.beam_position_ver = self.getChannelObject("beam_position_ver")
         self.beam_position_ver.connectSignal("update", self.beam_pos_ver_changed)
-	self.chan_beam_size_microns = self.getChannelObject("beam_size_microns")
+        self.chan_beam_size_microns = self.getChannelObject("beam_size_microns")
         self.chan_beam_shape_ellipse  = self.getChannelObject("beam_shape_ellipse")
   
     def beam_pos_hor_changed(self, value):
-	self.beam_position[0] = value
-	self.emit("beamPosChanged", (self.beam_position, ))
+        self.beam_position[0] = value
+        self.emit("beamPosChanged", (self.beam_position, ))
 
     def beam_pos_ver_changed(self, value):
         self.beam_position[1] = value 
-	self.emit("beamPosChanged", (self.beam_position, ))
+        self.emit("beamPosChanged", (self.beam_position, ))
 
     def get_beam_position(self):
-	return self.beam_position	
+        return self.beam_position
 
     def set_beam_position(self, beam_x, beam_y):
-	self.beam_position = [beam_x, beam_y]
-	self.beam_position_hor.setValue(int(beam_x))
-	self.beam_position_ver.setValue(int(beam_y))
+        self.beam_position = [beam_x, beam_y]
+        self.beam_position_hor.setValue(int(beam_x))
+        self.beam_position_ver.setValue(int(beam_y))
 
     def aperture_pos_changed(self, nameList, name, size):
         self.beam_size_aperture = size
         self.evaluate_beam_info() 
-	self.emit_beam_info_change()
+        self.emit_beam_info_change()
 
     def slits_gap_changed(self, size):
         self.beam_size_slits = size
         self.evaluate_beam_info()
-	self.emit_beam_info_change()
+        self.emit_beam_info_change()
 
     def definer_pos_changed(self, name, size):
         self.beam_size_definer = size
         self.evaluate_beam_info()
-	self.emit_beam_info_change()
+        self.emit_beam_info_change()
 
     def get_beam_info(self):
         return self.evaluate_beam_info()
         
     def get_beam_size(self):
-	"""
-	Description: returns beam size in microns
-	Resturns: list with two integers
-	"""
-	self.evaluate_beam_info()
+        """
+        Description: returns beam size in microns
+        Returns: list with two integers
+        """
+        self.evaluate_beam_info()
         return int(self.beam_info_dict["size_x"] *1000), \
-	       int(self.beam_info_dict["size_y"] * 1000)
+               int(self.beam_info_dict["size_y"] * 1000)
 
     def get_beam_shape(self):
-	self.evaluate_beam_info()
+        self.evaluate_beam_info()
         return self.beam_info_dict["shape"]
 
     def get_slits_gap(self):
-	self.evaluate_beam_info()
-	return self.beam_size_slits	
+        self.evaluate_beam_info()
+        return self.beam_size_slits
 
     def evaluate_beam_info(self):
         """
@@ -128,20 +128,20 @@ class BeamInfo(Equipment):
         self.beam_info_dict["size_y"] = size_y
 
         if self.beam_size_aperture < self.beam_size_slits:
-	    self.beam_info_dict["shape"] = "ellipse"
-	else:
-	    self.beam_info_dict["shape"] = "rectangular"
+            self.beam_info_dict["shape"] = "ellipse"
+        else:
+            self.beam_info_dict["shape"] = "rectangular"
 	
-	return self.beam_info_dict	
+        return self.beam_info_dict
 
     def emit_beam_info_change(self): 
-	if self.beam_info_dict["size_x"] <> 9999 and \
-	   self.beam_info_dict["size_y"] <> 9999:		
-	    self.emit("beamSizeChanged", ((self.beam_info_dict["size_x"],\
+        if self.beam_info_dict["size_x"] <> 9999 and \
+            self.beam_info_dict["size_y"] <> 9999:
+            self.emit("beamSizeChanged", ((self.beam_info_dict["size_x"],\
 					   self.beam_info_dict["size_y"]), ))
             self.emit("beamInfoChanged", (self.beam_info_dict, ))
-	    if self.chan_beam_size_microns is not None:
-		self.chan_beam_size_microns.setValue((self.beam_info_dict["size_x"] * 1000, \
-					 	     self.beam_info_dict["size_y"] * 1000))	
+            if self.chan_beam_size_microns is not None:
+                self.chan_beam_size_microns.setValue((self.beam_info_dict["size_x"] * 1000, \
+                                                      self.beam_info_dict["size_y"] * 1000))
             if self.chan_beam_shape_ellipse is not None:
                 self.chan_beam_shape_ellipse.setValue(self.beam_info_dict["shape"] == "ellipse") 

--- a/HardwareObjects/ESRF/ID231BeamInfo.py
+++ b/HardwareObjects/ESRF/ID231BeamInfo.py
@@ -30,7 +30,7 @@ class BeamInfo(Equipment):
         self.beam_size_slits = [9999, 9999]
         self.beam_size_aperture = [9999, 9999]
         self.beam_size_definer = [9999, 9999]
-	self.beam_position = [0, 0]
+        self.beam_position = [0, 0]
 
         self.aperture_HO = None
         self.slits_HO = None
@@ -38,11 +38,11 @@ class BeamInfo(Equipment):
         self.beam_info_dict = {}
 
     def init(self):
-	try:
+        try:
            self.aperture_HO = HardwareRepository.HardwareRepository().getHardwareObject(self.getProperty("aperture"))
-	   self.connect(self.aperture_HO, "apertureChanged", self.aperture_pos_changed)
-	except:
-	   logging.getLogger("HWR").debug('BeamInfo: aperture not defined correctly')
+           self.connect(self.aperture_HO, "apertureChanged", self.aperture_pos_changed)
+        except:
+           logging.getLogger("HWR").debug('BeamInfo: aperture not defined correctly')
         try:
            self.slits_HO = HardwareRepository.HardwareRepository().getHardwareObject(self.getProperty("slits"))
            self.connect(self.slits_HO, "gapSizeChanged", self.slits_gap_changed)
@@ -118,12 +118,12 @@ class BeamInfo(Equipment):
         Returns: dictionary, {size_x: 0.1, size_y: 0.1, shape: "rectangular"}
         """
         size_x = min(self.beam_size_aperture[0],
-	   	     self.beam_size_slits[0],
-		     self.beam_size_definer[0]) 
+                     self.beam_size_slits[0],
+                     self.beam_size_definer[0])
         size_y = min(self.beam_size_aperture[1],
-  		     self.beam_size_slits[1], 
-		     self.beam_size_definer[1]) 
-	
+                     self.beam_size_slits[1],
+                     self.beam_size_definer[1])
+
         self.beam_info_dict["size_x"] = size_x
         self.beam_info_dict["size_y"] = size_y
 
@@ -131,14 +131,14 @@ class BeamInfo(Equipment):
             self.beam_info_dict["shape"] = "ellipse"
         else:
             self.beam_info_dict["shape"] = "rectangular"
-	
+
         return self.beam_info_dict
 
     def emit_beam_info_change(self): 
         if self.beam_info_dict["size_x"] <> 9999 and \
             self.beam_info_dict["size_y"] <> 9999:
             self.emit("beamSizeChanged", ((self.beam_info_dict["size_x"],\
-					   self.beam_info_dict["size_y"]), ))
+                                           self.beam_info_dict["size_y"]), ))
             self.emit("beamInfoChanged", (self.beam_info_dict, ))
             if self.chan_beam_size_microns is not None:
                 self.chan_beam_size_microns.setValue((self.beam_info_dict["size_x"] * 1000, \

--- a/HardwareObjects/ESRF/ID29BeamCmds.py
+++ b/HardwareObjects/ESRF/ID29BeamCmds.py
@@ -7,7 +7,7 @@ class ControllerCommand(CommandObject):
     def __init__(self, name, cmd):
         CommandObject.__init__(self, name)
         self._cmd = cmd
-	self._cmd_execution = None
+        self._cmd_execution = None
 
     def isConnected(self):
         return True

--- a/HardwareObjects/ESRF/ID29HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID29HutchTrigger.py
@@ -98,5 +98,5 @@ class ID29HutchTrigger(BaseHardwareObjects.HardwareObject):
             self.emit('hutchTrigger', (0, ))
 
         self.hutch_opened = 1-value
-	self.initialized = True
+        self.initialized = True
 

--- a/HardwareObjects/ESRF/ID29MultiCollect.py
+++ b/HardwareObjects/ESRF/ID29MultiCollect.py
@@ -121,7 +121,7 @@ class ID29MultiCollect(ESRFMultiCollect):
         self.helical_pos = helical_oscil_pos
 
     def set_transmission(self, transmission):
-    	self.getObjectByRole("transmission").set_value(transmission)
+        self.getObjectByRole("transmission").set_value(transmission)
 
     def get_transmission(self):
         return self.getObjectByRole("transmission").get_value()

--- a/HardwareObjects/ESRF/ID30A1MultiCollect.py
+++ b/HardwareObjects/ESRF/ID30A1MultiCollect.py
@@ -102,7 +102,7 @@ class ID30A1MultiCollect(ESRFMultiCollect):
         self.helical_pos = helical_oscil_pos
 
     def set_transmission(self, transmission):
-    	self.getObjectByRole("transmission").set_value(transmission)
+        self.getObjectByRole("transmission").set_value(transmission)
 
     def get_transmission(self):
         return self.getObjectByRole("transmission").get_value()

--- a/HardwareObjects/ESRF/ID30BBeamCmds.py
+++ b/HardwareObjects/ESRF/ID30BBeamCmds.py
@@ -7,7 +7,7 @@ class ControllerCommand(CommandObject):
     def __init__(self, name, cmd):
         CommandObject.__init__(self, name)
         self._cmd = cmd
-	self._cmd_execution = None
+        self._cmd_execution = None
 
     def isConnected(self):
         return True

--- a/HardwareObjects/ESRF/ID30BMultiCollect.py
+++ b/HardwareObjects/ESRF/ID30BMultiCollect.py
@@ -124,7 +124,7 @@ class ID30BMultiCollect(ESRFMultiCollect):
         self.helical_pos = helical_oscil_pos
 
     def set_transmission(self, transmission):
-    	self.getObjectByRole("transmission").set_value(transmission)
+        self.getObjectByRole("transmission").set_value(transmission)
 
     def get_transmission(self):
         return self.getObjectByRole("transmission").get_value()

--- a/HardwareObjects/ESRF/ID30BeamCmds.py
+++ b/HardwareObjects/ESRF/ID30BeamCmds.py
@@ -8,7 +8,7 @@ class ControllerCommand(CommandObject):
     def __init__(self, name, cmd):
         CommandObject.__init__(self, name)
         self._cmd = cmd
-	self._cmd_execution = None
+        self._cmd_execution = None
 
     def isConnected(self):
         return True

--- a/HardwareObjects/ESRF/ID30Cryo.py
+++ b/HardwareObjects/ESRF/ID30Cryo.py
@@ -16,7 +16,7 @@ class ID30Cryo(Device):
     def init(self):
         controller = self.getObjectByRole("controller")
 
-	self._state = None
+        self._state = None
         self.username = self.name()
         self.wago_controller = getattr(controller, self.wago)
         self.command_key = self.getProperty("cmd")

--- a/HardwareObjects/ESRF/ID30HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID30HutchTrigger.py
@@ -110,5 +110,5 @@ class ID30HutchTrigger(BaseHardwareObjects.HardwareObject):
         elif value == 1 and self.initialized:
             self.emit('hutchTrigger', (0, ))
         self.hutch_opened = 1-value
-	self.initialized = True
+        self.initialized = True
 

--- a/HardwareObjects/EnergyScanMockup.py
+++ b/HardwareObjects/EnergyScanMockup.py
@@ -296,7 +296,7 @@ class EnergyScanMockup(AbstractEnergyScan, HardwareObject):
         """
         Descript. :
         """
-        return self.scan_data
+        return list(self.scan_data)
 
     def store_energy_scan(self):
         """

--- a/HardwareObjects/Frontend.py
+++ b/HardwareObjects/Frontend.py
@@ -39,7 +39,7 @@ class Frontend(BaseHardwareObjects.Device):
 
         self.shutterStateValue = 13
         self.automaticModeTimeLeft = None
-        self.undulatorGaps = {}       
+        self._undulatorGaps = {}
  
     def init(self):
         try:
@@ -74,7 +74,7 @@ class Frontend(BaseHardwareObjects.Device):
         self.getCommandObject("Close")()
 
     def getUndulatorGaps(self):
-        if len(self.undulatorGaps) == 0:
+        if len(self._undulatorGaps) == 0:
           tangoname = self.getChannelObject('State').\
               deviceName.replace("fe", "id")
 
@@ -86,17 +86,17 @@ class Frontend(BaseHardwareObjects.Device):
           for name in movable_names:
               if "GAP" in name:
                   key = name + '_Position'
-                  self.undulatorGaps[key] = -1
+                  self._undulatorGaps[key] = -1
                   self.addChannel({ 'type': 'tango', 'name': key,
                                     'tangoname': tangoname}, key)
 
-        for key in list(self.undulatorGaps.keys()):
+        for key in list(self._undulatorGaps.keys()):
             gap = self.getChannelObject(key).getValue()
             if gap is None or math.isnan(gap):
               gap = -1
-            self.undulatorGaps[key] = gap
+            self._undulatorGaps[key] = gap
 
-        return self.undulatorGaps
+        return self._undulatorGaps.copy()
 
     def getUndulatorGap(self, name):
         undulator_gaps = self.getUndulatorGaps()

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -320,18 +320,18 @@ class GenericDiffractometer(HardwareObject):
             if self.transfer_mode is None or self.transfer_mode == "SAMPLE_CHANGER":
                 self.use_sc = True
 
-	try:
+        try:
            self.use_sample_centring = self.getProperty("sample_centring")
-	   if self.use_sample_centring:
-		self.centring_phi=sample_centring.CentringMotor(\
+           if self.use_sample_centring:
+                self.centring_phi=sample_centring.CentringMotor(\
                      self.motor_hwobj_dict['phi'], direction=-1)
-	        self.centring_phiz=sample_centring.CentringMotor(\
+                self.centring_phiz=sample_centring.CentringMotor(\
                      self.motor_hwobj_dict['phiz'])
-        	self.centring_phiy=sample_centring.CentringMotor(
+                self.centring_phiy=sample_centring.CentringMotor(
                      self.motor_hwobj_dict['phiy'],direction=-1)
-        	self.centring_sampx=sample_centring.CentringMotor(
+                self.centring_sampx=sample_centring.CentringMotor(
                      self.motor_hwobj_dict['sampx'])
-        	self.centring_sampy=sample_centring.CentringMotor(\
+                self.centring_sampy=sample_centring.CentringMotor(\
                       self.motor_hwobj_dict['sampy'])
         except:
            pass # used the default value
@@ -634,7 +634,7 @@ class GenericDiffractometer(HardwareObject):
         """
         """
         self.emit_progress_message("Manual 3 click centring...")
-	if self.use_sample_centring:
+        if self.use_sample_centring:
             self.current_centring_procedure = \
                  sample_centring.start({"phi": self.centring_phi,
                                         "phiy": self.centring_phiy,
@@ -645,7 +645,7 @@ class GenericDiffractometer(HardwareObject):
                                         self.pixels_per_mm_y,
                                         self.beam_position[0],
                                         self.beam_position[1])
-	else:
+        else:
             self.current_centring_procedure = gevent.spawn(self.manual_centring)
         self.current_centring_procedure.link(self.centring_done)
 
@@ -862,9 +862,9 @@ class GenericDiffractometer(HardwareObject):
         """
         Descript. :
         """
-	if self.use_sample_centring:
-   	    sample_centring.user_click(x,y)
-	else:
+        if self.use_sample_centring:
+               sample_centring.user_click(x,y)
+        else:
             self.user_clicked_event.set((x, y))
 
     def accept_centring(self):

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -165,8 +165,8 @@ class GenericDiffractometer(HardwareObject):
         self.command_dict = {}
         self.used_commands_list = GenericDiffractometer.COMMANDS_NAME
 
-	# flag for using sample_centring hwobj or not
-	self.use_sample_centring = None 
+        # flag for using sample_centring hwobj or not
+        self.use_sample_centring = None
 
         # Internal values -----------------------------------------------------
         self.ready_event = None

--- a/HardwareObjects/HutchTrigger.py
+++ b/HardwareObjects/HutchTrigger.py
@@ -113,7 +113,7 @@ class TacoHutchTrigger(TacoDevice.TacoDevice):
         elif value == 1 and self.initialized:
             self.emit('hutchTrigger', (0, ))
 
-	self.initialized = True
+        self.initialized = True
 
 
 class TangoHutchTrigger(BaseHardwareObjects.Device):
@@ -127,7 +127,7 @@ class TangoHutchTrigger(BaseHardwareObjects.Device):
         except PyTango.DevFailed as traceback:
             last_error = traceback[-1]
             logging.getLogger('HWR').error("%s: %s", str(self.name()), last_error['desc'])
-	    self.device = None
+            self.device = None
             self.device.imported = False
         else:
             self.device.imported = True
@@ -237,7 +237,7 @@ class TangoHutchTrigger(BaseHardwareObjects.Device):
         elif value == 1 and self.initialized:
             self.emit('hutchTrigger', (0, ))
 
-	self.initialized = True
+        self.initialized = True
 
 
 class HutchTrigger(BaseHardwareObjects.Device):

--- a/HardwareObjects/ISPyBClient2Mockup.py
+++ b/HardwareObjects/ISPyBClient2Mockup.py
@@ -75,16 +75,16 @@ class ISPyBClient2Mockup(HardwareObject):
             return {'status':{ "code": "error", "msg": "loginID 'wrong' does not exist!" }, 'Proposal': None, 'Session': None} 
         # to simulate wrong psd
         if psd == "wrong":
-	    return {'status':{ "code": "error", "msg": "Wrong password!" }, 'Proposal': None, 'Session': None}
+            return {'status':{ "code": "error", "msg": "Wrong password!" }, 'Proposal': None, 'Session': None}
         # to simulate ispybDown, but login succeed
         if psd == "ispybDown":
-	    return {'status':{ "code": "ispybDown", "msg": "ispyb is down" }, 'Proposal': None, 'Session': None}
+            return {'status':{ "code": "ispybDown", "msg": "ispyb is down" }, 'Proposal': None, 'Session': None}
  
         new_session = False
         if psd == "nosession":
-	    new_session=True
+            new_session=True
         prop=self.get_proposal(loginID,"")
-	return {'status':{ "code": "ok", "msg": "Successful login" }, 'Proposal': prop['Proposal'],
+        return {'status':{ "code": "ok", "msg": "Successful login" }, 'Proposal': prop['Proposal'],
                  'session': {"session": prop['Session'],"new_session_flag":new_session, "is_inhouse": False},
                  'local_contact': "BL Scientist",
                  'person': prop['Person'],

--- a/HardwareObjects/InOut.py
+++ b/HardwareObjects/InOut.py
@@ -18,7 +18,7 @@ class InOut(Device):
         self.set_in.connectSignal("disconnected", self._setReady)
         self.set_out = self.getCommandObject("set_out")
         self._setReady()
-	self.offset = self.getProperty("offset")
+        self.offset = self.getProperty("offset")
         if self.offset > 0:
            self.states = {self.offset:"out", self.offset-1:"in",}
         else:

--- a/HardwareObjects/LdapLogin.py
+++ b/HardwareObjects/LdapLogin.py
@@ -33,7 +33,7 @@ class LdapLogin(Procedure):
         ldaphost = self.getProperty('ldaphost')
         ldapport = self.getProperty('ldapport')
         domain   = self.getProperty('ldapdomain')
-	ldapou   = self.getProperty('ldapou')
+        ldapou   = self.getProperty('ldapou')
 
         if ldaphost is None:
             logging.getLogger("HWR").error("LdapLogin: you must specify the LDAP hostname")
@@ -108,7 +108,7 @@ class LdapLogin(Procedure):
             return self.cleanup(msg="invalid password for %s" % username)
 
         logging.getLogger("HWR").debug("LdapLogin: validating %s" % username)
-	try:
+        try:
             bind_str = "uid=%s, ou=%s, %s" % (username,self.ldapou, self.domstr)
         except AttributeError as attr:
             bind_str = "uid=%s,%s" % (username, self.domstr)

--- a/HardwareObjects/LimaVideo.py
+++ b/HardwareObjects/LimaVideo.py
@@ -68,7 +68,7 @@ class LimaVideo(Device):
         if self.cam_type == 'prosilica':
             from Lima import Prosilica
             self.camera = Prosilica.Camera(self.cam_address)
-            self.interface = Prosilica.Interface(self.camera)	
+            self.interface = Prosilica.Interface(self.camera)
         if self.cam_type == 'ueye':
             from Lima import Ueye
             self.camera = Ueye.Camera(self.cam_address)
@@ -101,7 +101,7 @@ class LimaVideo(Device):
             self.image_format = BayerType(image_format.split(":")[1])
             if image_format.lower() == "bayer:8":
                 self.scaling_type = pixmaptools.LUT.Scaling.BAYER_RG8
-            elif image_format.lower() == "bayer:16":  	
+            elif image_format.lower() == "bayer:16":
                 self.scaling_type = pixmaptools.LUT.Scaling.BAYER_RG16
         elif image_format.lower().startswith("y:"):
             self.image_format = BayerType(image_format.split(":")[1])
@@ -183,7 +183,7 @@ class LimaVideo(Device):
         Descript. :
         """
         return
-	#self.video.setGain(gain)
+        #self.video.setGain(gain)
 
     def getGain(self):
         """
@@ -250,7 +250,7 @@ class LimaVideo(Device):
         Descript. :
         """
         return self.image_dimensions[0]
-	
+
     def getHeight(self):
         """
         Descript. :
@@ -265,7 +265,7 @@ class LimaVideo(Device):
         while self.video.getLive():
             self.get_new_image()
             time.sleep(sleep_time)
-	     	
+
     def connectNotify(self, signal):
         """
         Descript. :
@@ -287,7 +287,7 @@ class LimaVideo(Device):
         """
         image = self.video.getLastImage()
         if image.frameNumber() > -1:
-            raw_buffer = image.buffer()	
+            raw_buffer = image.buffer()
             if self.do_scaling:
                 self.scaling.autoscale_min_max(raw_buffer,
                      image.width(), image.height(), self.scaling_type)

--- a/HardwareObjects/MAXIV/BIOMAXBeamInfo.py
+++ b/HardwareObjects/MAXIV/BIOMAXBeamInfo.py
@@ -78,8 +78,8 @@ class BIOMAXBeamInfo(BeamInfo.BeamInfo):
         print "beam position changed", self.beam_position
 
     def beam_info_changed(self,value):
-	self.evaluate_beam_info()
-	self.emit("beamInfoChanged", (self.beam_info_dict, ))
+        self.evaluate_beam_info()
+        self.emit("beamInfoChanged", (self.beam_info_dict, ))
 
         print "beam x %s and y %s " % (self.chan_beam_pos_x.getValue(),self.chan_beam_pos_y.getValue())
         """
@@ -113,7 +113,7 @@ class BIOMAXBeamInfo(BeamInfo.BeamInfo):
         self.beam_position[0] = 687 * self.chan_ImageZoom.getValue()
         self.beam_position[1] = 519 * self.chan_ImageZoom.getValue()
         return self.beam_position
-	if self.chan_ImageZoom.getValue() is not None:
+        if self.chan_ImageZoom.getValue() is not None:
             zoom = self.chan_ImageZoom.getValue()
             self.beam_position[0] = self.chan_beam_pos_x.getValue() * zoom
             self.beam_position[1] = self.chan_beam_pos_y.getValue() * zoom
@@ -137,11 +137,11 @@ class BIOMAXBeamInfo(BeamInfo.BeamInfo):
                 self.beam_info_dict["shape"] = "ellipse"
         curpos=self.aperture_hwobj.getCurrentPositionName()
         size_x = size_y = eval(str(curpos)) / 1000.0
-	#if self.chan_beam_size_x.getValue() /1000.0 < size_x and self.chan_beam_size_y.getValue() / 1000.0 < size_y:
+        #if self.chan_beam_size_x.getValue() /1000.0 < size_x and self.chan_beam_size_y.getValue() / 1000.0 < size_y:
         #    self.beam_info_dict["size_x"] = self.chan_beam_size_x.getValue() / 1000.0
         #    self.beam_info_dict["size_y"] = self.chan_beam_size_y.getValue() / 1000.0
        # else:
-	self.beam_info_dict["size_x"] = size_x
+        self.beam_info_dict["size_x"] = size_x
         self.beam_info_dict["size_y"] = size_y
-	self.beam_info_dict['pos'] = self.beam_position
+        self.beam_info_dict['pos'] = self.beam_position
         return self.beam_info_dict

--- a/HardwareObjects/MAXIV/BIOMAXCollect.py
+++ b/HardwareObjects/MAXIV/BIOMAXCollect.py
@@ -112,60 +112,60 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         log = logging.getLogger("user_level_log")
         log.info("Collection: Preparing to collect")
         # todo, add more exceptions and abort
-	try:
-		self.emit("collectReady", (False, ))
+        try:
+                self.emit("collectReady", (False, ))
                 self.emit("collectStarted", (owner, 1))
 
-		# ----------------------------------------------------------------
-		""" should all go data collection hook
+                # ----------------------------------------------------------------
+                """ should all go data collection hook
 		self.open_detector_cover()
 		self.open_safety_shutter()
 		self.open_fast_shutter()
 		"""
 
-		# ----------------------------------------------------------------
-		
-		self.current_dc_parameters["status"] = "Running"
-		self.current_dc_parameters["collection_start_time"] = \
-		     time.strftime("%Y-%m-%d %H:%M:%S")
-		self.current_dc_parameters["synchrotronMode"] = \
-		     self.get_machine_fill_mode()
+                # ----------------------------------------------------------------
 
-		log.info("Collection: Storing data collection in LIMS")
-		self.store_data_collection_in_lims()
+                self.current_dc_parameters["status"] = "Running"
+                self.current_dc_parameters["collection_start_time"] = \
+                     time.strftime("%Y-%m-%d %H:%M:%S")
+                self.current_dc_parameters["synchrotronMode"] = \
+                     self.get_machine_fill_mode()
 
-		log.info("Collection: Creating directories for raw images and processing files")
-		self.create_file_directories()
+                log.info("Collection: Storing data collection in LIMS")
+                self.store_data_collection_in_lims()
 
-		log.info("Collection: Getting sample info from parameters")
-		self.get_sample_info()
+                log.info("Collection: Creating directories for raw images and processing files")
+                self.create_file_directories()
 
-		#log.info("Collect: Storing sample info in LIMS")
-		#self.store_sample_info_in_lims()
+                log.info("Collection: Getting sample info from parameters")
+                self.get_sample_info()
 
-		if all(item == None for item in self.current_dc_parameters['motors'].values()):
-		    # No centring point defined
-		    # create point based on the current position
-		    current_diffractometer_position = self.diffractometer_hwobj.getPositions()
-		    for motor in self.current_dc_parameters['motors'].keys():
-		        self.current_dc_parameters['motors'][motor] = \
-		             current_diffractometer_position[motor]
+                #log.info("Collect: Storing sample info in LIMS")
+                #self.store_sample_info_in_lims()
 
-		log.info("Collection: Moving to centred position")
-		#todo, self.move_to_centered_position() should go inside take_crystal_snapshots, 
-		#which makes sure it move motors to the correct positions and move back 
-		#if there is a phase change
-		self.take_crystal_snapshots()
+                if all(item == None for item in self.current_dc_parameters['motors'].values()):
+                    # No centring point defined
+                    # create point based on the current position
+                    current_diffractometer_position = self.diffractometer_hwobj.getPositions()
+                    for motor in self.current_dc_parameters['motors'].keys():
+                        self.current_dc_parameters['motors'][motor] = \
+                             current_diffractometer_position[motor]
 
-		# prepare beamline for data acquisiion
-		self.prepare_acquisition()
+                log.info("Collection: Moving to centred position")
+                #todo, self.move_to_centered_position() should go inside take_crystal_snapshots,
+                #which makes sure it move motors to the correct positions and move back
+                #if there is a phase change
+                self.take_crystal_snapshots()
+
+                # prepare beamline for data acquisiion
+                self.prepare_acquisition()
                 self.emit("collectOscillationStarted", (owner, None, \
                     None, None, self.current_dc_parameters, None))
 
-		self.data_collection_hook()
-		self.emit_collection_finished()
-	except:
-	        self.emit_collection_failed()
+                self.data_collection_hook()
+                self.emit_collection_finished()
+        except:
+                self.emit_collection_failed()
         # ----------------------------------------------------------------
 
         """ should all go data collection hook
@@ -229,7 +229,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         Descript. : main collection command
         """
 
-	try:
+        try:
             oscillation_parameters = self.current_dc_parameters["oscillation_sequence"][0]
             osc_start = oscillation_parameters['start']
             osc_end = osc_start + oscillation_parameters["range"] * \
@@ -249,8 +249,8 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
             self.close_safety_shutter()
             self.close_detector_cover()
             self.emit("collectImageTaken", oscillation_parameters['number_of_images'])
-	except:
-	    self.data_collection_cleanup()
+        except:
+            self.data_collection_cleanup()
             raise Exception("data collection hook failed")
 
     def oscil(self, start, end, exptime, npass, wait = True):

--- a/HardwareObjects/MAXIV/BIOMAXEiger.py
+++ b/HardwareObjects/MAXIV/BIOMAXEiger.py
@@ -75,8 +75,8 @@ class BIOMAXEiger(Equipment):
                     'BeamCenterX','BeamCenterY','DetectorDistance','OmegaIncrement','OmegaStart',
                     'Compression','RoiMode', 'State',"Status",'XPixelsDetector','YPixelsDetector')
 
-	fw_list = ('FilenamePattern','ImagesPerFile','BufferFree',# 'CompressionEnabled'
-		  'FileWriterState', 'ImageNbStart', 'Mode')
+        fw_list = ('FilenamePattern','ImagesPerFile','BufferFree',# 'CompressionEnabled'
+                  'FileWriterState', 'ImageNbStart', 'Mode')
 
         # config needed to be set up for data collection
         # if values are None, use the one from the system
@@ -367,9 +367,9 @@ class BIOMAXEiger(Equipment):
                 if self.set_photon_energy( new_egy ) is False:
                     raise Exception("Could not program energy in detector")
 
-	if "CountTime" in self._config_vals.keys():
-	    self.set_value("CountTime",  self._config_vals["CountTime"])
-	    self.set_value("FrameTime",  self._config_vals["CountTime"]+self.get_readout_time())
+        if "CountTime" in self._config_vals.keys():
+            self.set_value("CountTime",  self._config_vals["CountTime"])
+            self.set_value("FrameTime",  self._config_vals["CountTime"]+self.get_readout_time())
 
         for cfg_name, cfg_value in self._config_vals.items():
             t0 = time.time()   

--- a/HardwareObjects/MAXIV/BIOMAXEigerMockup.py
+++ b/HardwareObjects/MAXIV/BIOMAXEigerMockup.py
@@ -106,7 +106,7 @@ class BIOMAXEigerMockup(Equipment):
         return self.roi_mode
 
     def set_roi_mode(self, value):
-	self.roi_mode = value
+        self.roi_mode = value
 
     def get_pixel_size_x(self):
         """

--- a/HardwareObjects/MAXIV/BIOMAXMD2.py
+++ b/HardwareObjects/MAXIV/BIOMAXMD2.py
@@ -114,6 +114,6 @@ class BIOMAXMD2(GenericDiffractometer):
             beam_yc = self.beam_position[1]
             self.centring_phiz.moveRelative((y-beam_yc)/float(self.pixelsPerMmZ))
             self.centring_phiy.moveRelative(-1*(x-beam_xc)/float(self.pixelsPerMmY))
-	except:
+        except:
             logging.getLogger("HWR").exception("MiniDiff: could not center to beam, aborting")
 

--- a/HardwareObjects/MAXIV/BIOMAXMD3.py
+++ b/HardwareObjects/MAXIV/BIOMAXMD3.py
@@ -70,10 +70,10 @@ class BIOMAXMD3(GenericDiffractometer):
         except:
             logging.getLogger("HWR").warning('Cannot initialize CentringTableVerticalPosition')
 
-	try:
-	    use_sc = self.getProperty("use_sc")
-	    self.set_use_sc(use_sc)
-	except:
+        try:
+            use_sc = self.getProperty("use_sc")
+            self.set_use_sc(use_sc)
+        except:
             logging.getLogger("HWR").debug('Cannot set sc mode, use_sc: ', str(use_sc))
 
         try:
@@ -156,7 +156,7 @@ class BIOMAXMD3(GenericDiffractometer):
             surface_score_list.append(score)
             self.phi_motor_hwobj.moveRelative(\
                  360.0 / BIOMAXMD3.AUTOMATIC_CENTRING_IMAGES)
-	    #gevent.sleep(2)
+            #gevent.sleep(2)
             self.wait_device_ready(5)
         self.omega_reference_add_constraint()
         return self.centring_hwobj.centeredPosition(return_by_name=False)
@@ -373,9 +373,9 @@ class BIOMAXMD3(GenericDiffractometer):
             return
         self.wait_device_ready(2000)
         self.command_dict["startSimultaneousMoveMotors"](argin)
-	#task_info = self.command_dict["getTaskInfo"](task_id)
+        #task_info = self.command_dict["getTaskInfo"](task_id)
         if wait:
-	    self.wait_device_ready(timeout)
+            self.wait_device_ready(timeout)
 
 
     def moveToBeam(self, x, y):

--- a/HardwareObjects/MAXIV/BIOMAXMD3Camera.py
+++ b/HardwareObjects/MAXIV/BIOMAXMD3Camera.py
@@ -34,13 +34,13 @@ class BIOMAXMD3Camera(Device):
 
         self.image_attr = self.addChannel({"type":"exporter", "name":"image"  }, 'ImageJPG')
 
-	# new attrs for the MD3 with extra camera options
+        # new attrs for the MD3 with extra camera options
         self.width = 680
-	self.height = 512
-	self.chan_zoom = self.addChannel({"type":"exporter", "name":"ImageZoom"  }, 'ImageZoom')
-	self.roi_x = self.addChannel({"type":"exporter", "name":"RoiX"  }, 'RoiX')
-	self.roi_y = self.addChannel({"type":"exporter", "name":"RoiY"  }, 'RoiY')
-	self.roi_width = self.addChannel({"type":"exporter", "name":"RoiWidth"  }, 'RoiWidth')
+        self.height = 512
+        self.chan_zoom = self.addChannel({"type":"exporter", "name":"ImageZoom"  }, 'ImageZoom')
+        self.roi_x = self.addChannel({"type":"exporter", "name":"RoiX"  }, 'RoiX')
+        self.roi_y = self.addChannel({"type":"exporter", "name":"RoiY"  }, 'RoiY')
+        self.roi_width = self.addChannel({"type":"exporter", "name":"RoiWidth"  }, 'RoiWidth')
         self.roi_height = self.addChannel({"type":"exporter", "name":"RoiHeight"  }, 'RoiHeight')
         self.set_camera_roi = self.addCommand({"type":"exporter", "name":"setCameraROI"  }, 'setCameraROI')
   
@@ -56,9 +56,9 @@ class BIOMAXMD3Camera(Device):
             self.chan_zoom.setValue(self.zoom)
             self.width=self.roi_width.getValue()*self.zoom
             self.height = self.roi_height.getValue()*self.zoom
-	except:
+        except:
             logging.getLogger("HWR").info( "cannot set image zoom level")
-	thread = Thread(target=self.poll)
+        thread = Thread(target=self.poll)
         thread.daemon = True
         thread.start()
 
@@ -88,55 +88,55 @@ class BIOMAXMD3Camera(Device):
                 self.image_attr = self.addChannel({"type":"exporter", "name":"image"  }, 'ImageJPG')
 
     def stopPolling(self):
-	self.stopper = True
+        self.stopper = True
     def startPolling(self):
-	# assuming that it is already stop, more advances features with threading.Event, Event.is_set...
-	self.stopper = False
-	thread.stop()
+        # assuming that it is already stop, more advances features with threading.Event, Event.is_set...
+        self.stopper = False
+        thread.stop()
         thread = Thread(target=self.poll)
-	thread.daemon = True
-	thread.start()
+        thread.daemon = True
+        thread.start()
 
     def setCameraRoi(self, x1, y1, x2, y2):
- 	"""
-	Configure the camera Region Of Interest.
-	X1 (int): abscissa of top left corner
-	Y1 (int): ordinate of top left corner
+        """
+	    Configure the camera Region Of Interest.
+	    X1 (int): abscissa of top left corner
+	    Y1 (int): ordinate of top left corner
         X2 (int): abscissa of bottom right corner
-	Y2 (int): ordinate of bottom right corner
-	"""
-	try:
-	    self.set_camera_roi(x1, y1, x1, y2)
-	    self.width = x2 - x1
-	    self.height = y1 - y2
-	    return True
+	    Y2 (int): ordinate of bottom right corner
+	    """
+        try:
+            self.set_camera_roi(x1, y1, x1, y2)
+            self.width = x2 - x1
+            self.height = y1 - y2
+            return True
         except:
-	    logging.getLogger("HWR").exception("Could not set image roi")
-	    return False
+            logging.getLogger("HWR").exception("Could not set image roi")
+            return False
 
     def getCameraRoi(self):
-	"""
-	Retrieve camera roi settings
-	"""
-	try:
-	    return [self.roi_x.getValue(), self.roi_y.getValue(), self.roi_width.getValue(), self.roi_height.getValue()]
-	except:
-	    logging.getLogger("HWR").exception("Could not retrieve image roi settings")
-	    return False
+        """
+	    Retrieve camera roi settings
+	    """
+        try:
+            return [self.roi_x.getValue(), self.roi_y.getValue(), self.roi_width.getValue(), self.roi_height.getValue()]
+        except:
+            logging.getLogger("HWR").exception("Could not retrieve image roi settings")
+            return False
 
     def getImageZoom(self):
         try:
-	    return self.zoom.getValue()
-	except Exception, e:
-	    logging.getLogger("HWR").exception("Could not retrieve image zoom settings")
-	    return False
+            return self.zoom.getValue()
+        except Exception, e:
+            logging.getLogger("HWR").exception("Could not retrieve image zoom settings")
+            return False
 
     def setImageZoom(self, new_zoom):
-	try:
-	    return self.zoom.setValue(new_zoom)
-	except Exception, e:
-	    logging.getLogger("HWR").exception("Could not retrieve image zoom settings")
-	    return False
+        try:
+            return self.zoom.setValue(new_zoom)
+        except Exception, e:
+            logging.getLogger("HWR").exception("Could not retrieve image zoom settings")
+            return False
 
     def imageUpdated(self, value):
        print "<HW> got new image"
@@ -155,7 +155,7 @@ class BIOMAXMD3Camera(Device):
         return self.width
     def getHeight(self):
         #return self.roi_height.getValue()
-	return self.height
+        return self.height
     def setLive(self, state):
         self.liveState = state
         return True

--- a/HardwareObjects/MAXIV/old/ElementAnalysis.py
+++ b/HardwareObjects/MAXIV/old/ElementAnalysis.py
@@ -287,4 +287,4 @@ class ElementAnalysis(Procedure):
         self.safeEmit("processEnergiesUpdated",(data,))
     def energyChanged(self,value):
         self.energy_value=self.energy.getValue() 
-	self.emit("energyUpdated")
+        self.emit("energyUpdated")

--- a/HardwareObjects/MAXIV/old/MAXLABBeamInfo.py
+++ b/HardwareObjects/MAXIV/old/MAXLABBeamInfo.py
@@ -16,7 +16,7 @@ class MAXLABBeamInfo(BeamInfo.BeamInfo):
         self.get_beam_size()
 #        self.beam_size_aperture=self.aperture_hwobj.getApertureSize()
         self.aperture_pos_changed(self.aperture_hwobj.getApertureSize())
-	self.emit("beamInfoChanged", (self.beam_info_dict, ))
+        self.emit("beamInfoChanged", (self.beam_info_dict, ))
         self.emit("beamPosChanged", (self.beam_position, ))
 
     def get_beam_position(self):

--- a/HardwareObjects/MAXIV/old/MAXLABCats90.py
+++ b/HardwareObjects/MAXIV/old/MAXLABCats90.py
@@ -237,7 +237,7 @@ class MAXLABCats90(SampleChanger):
         while self._chnCurrentPhase.getValue() != 'Centring':
             if timeout > 60:
                 logging.info("waited for too long, change to centring mode manually")
-		return
+                return
             time.sleep(1)
             timeout+=1
             logging.info("current phase is " + self._chnCurrentPhase.getValue())

--- a/HardwareObjects/MAXIV/old/MAXLABMarCCD.py
+++ b/HardwareObjects/MAXIV/old/MAXLABMarCCD.py
@@ -65,7 +65,7 @@ class MAXLABMarCCD(Equipment):
         Descript. :
         """
         if self.detector_modes_dict is not None:
-            return self.detector_modes_dict.keys()	
+            return self.detector_modes_dict.keys()
         else:
             return [] 
 

--- a/HardwareObjects/MAXIV/old/MAXLABMultiCollect.py
+++ b/HardwareObjects/MAXIV/old/MAXLABMultiCollect.py
@@ -314,7 +314,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
                                       beam_divergence_vertical = self.bl_control.beam_info.getProperty('beam_divergence_vertical'),
                                       beam_divergence_horizontal = self.bl_control.beam_info.getProperty('beam_divergence_horizontal'),     
                                       polarisation = self.getProperty('polarisation'),
-			              input_files_server = self.getProperty("input_files_server"))
+                                      input_files_server = self.getProperty("input_files_server"))
   
         self._detector.addCommand = self.addCommand
         self._detector.addChannel = self.addChannel
@@ -409,7 +409,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
 
     @task
     def open_safety_shutter(self):
-	return
+        return
         #self.bl_control.safety_shutter.openShutter()
         #while self.bl_control.safety_shutter.getShutterState() == 'closed':
         #  time.sleep(0.1)
@@ -578,7 +578,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
         mosflm_file_template = "%(prefix)s_%(run_number)s_###.%(suffix)s" % finfo
 
         for input_file_dir, file_prefix in ((self.raw_data_input_file_dir, "../.."), (self.xds_directory, "../links")): 
-	  xds_input_file = os.path.join(input_file_dir, "XDS.INP")
+          xds_input_file = os.path.join(input_file_dir, "XDS.INP")
 
           xds_file = open(xds_input_file, "w")
 
@@ -645,7 +645,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
           os.chmod(xds_input_file, 0666)
 
         for input_file_dir, file_prefix in ((self.mosflm_raw_data_input_file_dir, "../.."), (self.mosflm_directory, "../links")): 
-	  mosflm_input_file = os.path.join(input_file_dir, "mosflm.inp")
+          mosflm_input_file = os.path.join(input_file_dir, "mosflm.inp")
 
           mosflm_file = open(mosflm_input_file, "w")
 
@@ -710,7 +710,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
 
           valdict = {
                   "omfilename":       om_filename,
-                  "omtype":	      om_type,
+                  "omtype":           om_type,
                   "omega":            omega,
                   "kappa":            kappa,
                   "sampx":            sampx,
@@ -786,7 +786,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
 
 
     def get_machine_message(self):
-	return ""
+        return ""
         if  self.bl_control.machine_current:
             return self.bl_control.machine_current.getMessage()
         else:
@@ -794,7 +794,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
 
 
     def get_machine_fill_mode(self):
-	return ""
+        return ""
 
         if self.bl_control.machine_current:
             return self.bl_control.machine_current.getFillMode()
@@ -862,7 +862,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
                 return True
 
     def get_flux(self):
-	return 0
+        return 0
 #        return self.bl_control.flux.getCurrentFlux()
 
     @task
@@ -1152,7 +1152,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
         if nframes == 0:
             return
 
-	# data collection
+        # data collection
         self.data_collection_hook(data_collect_parameters)
 
         if 'transmission' in data_collect_parameters:
@@ -1314,7 +1314,7 @@ class MAXLABMultiCollect(AbstractMultiCollect, HardwareObject):
 
                           if data_collect_parameters.get("shutterless"):
                               with gevent.Timeout(10, RuntimeError("Timeout waiting for detector trigger, no image taken")):
-   			          while self.last_image_saved() == 0:
+                                  while self.last_image_saved() == 0:
                                       time.sleep(exptime)
                           
                               last_image_saved = self.last_image_saved()

--- a/HardwareObjects/MAXIV/old/MAXLABResolution.py
+++ b/HardwareObjects/MAXIV/old/MAXLABResolution.py
@@ -20,8 +20,8 @@ class MAXLABResolution(BaseHardwareObjects.Equipment):
         self.dtox = self.getDeviceByRole("dtox")
         self.wavelength = self.getDeviceByRole("wavelength")
         self.energy = self.getDeviceByRole("energy")
-	self.getradius = self.getCommandObject("detector_radius")
-   	self.detector_diameter_chan = self.addChannel({"type":"spec", "version": self.getradius.specVersion, "name":"detector_radius"}, "MXBCM_PARS/detector_radius")
+        self.getradius = self.getCommandObject("detector_radius")
+        self.detector_diameter_chan = self.addChannel({"type":"spec", "version": self.getradius.specVersion, "name":"detector_radius"}, "MXBCM_PARS/detector_radius")
         # some value has to be read, otherwise subsequent calls will fail due to some variables inside the buffer?????
          
         self.detector_diameter = 0
@@ -160,7 +160,7 @@ class MAXLABResolution(BaseHardwareObjects.Equipment):
             return (self.dist2res(low), self.dist2res(high))
 
     def move(self, pos, wait=True):
-	logging.getLogger().info("move Resolution to %s", pos)
+        logging.getLogger().info("move Resolution to %s", pos)
         if wait:
             self.newDistance(self.res2dist(pos)) 
         else:

--- a/HardwareObjects/MAXIV/old/MaxLabMDCamera.py
+++ b/HardwareObjects/MAXIV/old/MaxLabMDCamera.py
@@ -99,11 +99,11 @@ class MaxLabMDCamera(BaseHardwareObjects.Device):
        #print "reading the image"
 
        try:
-	  img=None
+          img=None
           img=self.device.getImageJPG()
           # JN, 20140807,adapt the MD2 screen (768x576) to mxCuBE2 
 #          logging.getLogger('HWR').info("Img_chr dimension %s",img.shape)
-	  if img is not None:
+          if img is not None:
                 f = open("/tmp/mxcube_tmp.jpg","w")
                 f.write("".join(map(chr, img)))
                 f.close()

--- a/HardwareObjects/MDBeamInfo.py
+++ b/HardwareObjects/MDBeamInfo.py
@@ -47,8 +47,8 @@ class MDBeamInfo(BeamInfo.BeamInfo):
         """
         if self.chan_beam_position_hor and self.chan_beam_position_ver:
             self.beam_position = [self.chan_beam_position_hor.getValue(), \
-	                          self.chan_beam_position_ver.getValue()]
-        return self.beam_position	
+                                  self.chan_beam_position_ver.getValue()]
+        return self.beam_position
 
     def set_beam_position(self, beam_x, beam_y):
         """

--- a/HardwareObjects/MachineInfoMockup.py
+++ b/HardwareObjects/MachineInfoMockup.py
@@ -34,12 +34,12 @@ class MachineInfoMockup(HardwareObject):
     """
 
     def __init__(self, name):
-	HardwareObject.__init__(self, name)
+        HardwareObject.__init__(self, name)
         """
         Descript. : 
         """
         #Parameters
-	#Intensity current ranges
+        #Intensity current ranges
         self.values_list = []
         temp_dict = {}
         temp_dict['value'] = 90.1
@@ -104,7 +104,7 @@ class MachineInfoMockup(HardwareObject):
         """     
         return self.values_list[0]['value']
 
-    def	get_message(self):
+    def get_message(self):
         """
         Descript :
         """  

--- a/HardwareObjects/MicrodiffHutchTrigger.py
+++ b/HardwareObjects/MicrodiffHutchTrigger.py
@@ -108,5 +108,5 @@ class MicrodiffHutchTrigger(BaseHardwareObjects.HardwareObject):
             self.emit('hutchTrigger', (0, ))
 
         self.hutch_opened = 1-value
-	self.initialized = True
+        self.initialized = True
 

--- a/HardwareObjects/MicrodiffZoomMockup.py
+++ b/HardwareObjects/MicrodiffZoomMockup.py
@@ -46,7 +46,7 @@ class MicrodiffZoomMockup(Device):
         else:
             return True#.connectNotify.im_func(self, signal)
     def getState(self):
-    	return 2
+            return 2
     def getLimits(self):
         return (1,10)
 

--- a/HardwareObjects/MiniDiff.py
+++ b/HardwareObjects/MiniDiff.py
@@ -323,11 +323,11 @@ class MiniDiff(Equipment):
         return (None, None)
 
     def get_pixels_per_mm(self):
-	return (self.pixelsPerMmY, self.pixelsPerMmZ)
+        return (self.pixelsPerMmY, self.pixelsPerMmZ)
 
     def getBeamInfo(self, callback=None):
-	beam_info = self.beam_info.get_beam_info() 
-	if callable(callback):
+        beam_info = self.beam_info.get_beam_info()
+        if callable(callback):
           callback(beam_info)
         return beam_info
 
@@ -607,7 +607,7 @@ class MiniDiff(Equipment):
        
         self.currentCentringProcedure.link(self.autoCentringDone)
 
-	self.emitProgressMessage("Starting automatic centring procedure...")
+        self.emitProgressMessage("Starting automatic centring procedure...")
        
     @task 
     def moveToCentredPosition(self, centred_position):
@@ -653,7 +653,7 @@ class MiniDiff(Equipment):
               try:
                 self.centringStatus["motors"][role] = centred_pos[motor]
               except KeyError:
-		continue
+                continue
 
             self.centringStatus["method"]=self.currentCentringMethod
             self.centringStatus["valid"]=True

--- a/HardwareObjects/MiniKappaCorrection.py
+++ b/HardwareObjects/MiniKappaCorrection.py
@@ -23,7 +23,7 @@ class MiniKappaCorrection(Device):
         Rk1=self.rotation_matrix(self.kappa, -kappa1)
         Rp =self.rotation_matrix(self.phi, phi2-phi1)
         
-	a=tk-np.dot(Rk1,(tk-x))
+        a=tk-np.dot(Rk1,(tk-x))
         b=tp-np.dot(Rp ,(tp-a))
         return tk-np.dot(Rk2,(tk-b))
  

--- a/HardwareObjects/MultiCollectMockup.py
+++ b/HardwareObjects/MultiCollectMockup.py
@@ -53,7 +53,7 @@ class MultiCollectMockup(AbstractMultiCollect, HardwareObject):
         for data_collect_parameters in data_collect_parameters_list:
             logging.debug("collect parameters = %r", data_collect_parameters)
             failed = False
-       	    data_collect_parameters["status"]='Data collection successful'
+            data_collect_parameters["status"]='Data collection successful'
             osc_id, sample_id, sample_code, sample_location = self.update_oscillations_history(data_collect_parameters)
             self.emit('collectOscillationStarted', (owner, sample_id, sample_code, sample_location, data_collect_parameters, osc_id))
 

--- a/HardwareObjects/MultiplePositions.py
+++ b/HardwareObjects/MultiplePositions.py
@@ -191,11 +191,11 @@ class MultiplePositions(Equipment):
             self.connect(mot, "positionChanged", self.checkPosition)
             self.connect(mot, "stateChanged", self.stateChanged)
 
-	
+
     def getState(self):
         if not self.isReady():
             return ""
-			
+
         state = "READY"
         for mot in self.motors.values():
             if mot.getState() == mot.MOVING:
@@ -273,7 +273,7 @@ class MultiplePositions(Equipment):
         if position is None:
             self.checkPosition()
             return
-                	
+
         for role, pos in list(newPositions.items()):
             self.positions[name][role] = pos
             position.setProperty(role, pos)

--- a/HardwareObjects/RobodiffLight.py
+++ b/HardwareObjects/RobodiffLight.py
@@ -17,7 +17,7 @@ class RobodiffLight(Device):
     def init(self):
         controller = self.getObjectByRole("controller")
 
-	self._state = None
+        self._state = None
         self.username = self.name()
         self.wago_controller = getattr(controller, self.wago)
         self.command_key = self.getProperty("cmd")

--- a/HardwareObjects/RobodiffMotorWPositions.py
+++ b/HardwareObjects/RobodiffMotorWPositions.py
@@ -51,7 +51,7 @@ class RobodiffMotorWPositions(RobodiffMotor):
             
     def sortPredefinedPositionsList(self):
         self.predefinedPositionsNamesList = self.predefinedPositions.keys()
-	self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y]))) 
+        self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y])))
         
     def updateState(self, state=None, emit=False):
        RobodiffMotor.updateState(self, state)
@@ -73,11 +73,11 @@ class RobodiffMotorWPositions(RobodiffMotor):
         try:
             self.move(self.predefinedPositions[positionName])
         except:
-	    logging.getLogger("HWR").exception('Cannot move motor %s: invalid position name.', str(self.userName())) 
+            logging.getLogger("HWR").exception('Cannot move motor %s: invalid position name.', str(self.userName()))
 
     def getCurrentPositionName(self):
         if not self.motorIsMoving(): #self.isReady() and self.getState() == self.READY:
-	    for positionName in self.predefinedPositions:
+            for positionName in self.predefinedPositions:
                 if self.predefinedPositions[positionName] >= self.getPosition()-self.delta and self.predefinedPositions[positionName] <= self.getPosition()+self.delta:
                    return positionName 
         return ''

--- a/HardwareObjects/SOLEIL/BeamInfoPX1.py
+++ b/HardwareObjects/SOLEIL/BeamInfoPX1.py
@@ -153,7 +153,7 @@ class BeamInfoPX1(Equipment):
         self.emit("beamInfoChanged", (self.beam_info_dict, ))
 
     def positionUpdated(self):
-	self.emit("beamPosChanged", (self.beam_position, ))
+        self.emit("beamPosChanged", (self.beam_position, ))
         self.sizeUpdated()
 
     def get_beam_info(self):
@@ -162,5 +162,5 @@ class BeamInfoPX1(Equipment):
         
     def get_beam_position(self):
         logging.getLogger().warning('returning beam positions. It is %s ' % str(self.beam_position))
-	return self.beam_position	
+        return self.beam_position
 

--- a/HardwareObjects/SOLEIL/BeamInfoPX1.py
+++ b/HardwareObjects/SOLEIL/BeamInfoPX1.py
@@ -38,8 +38,8 @@ class BeamInfoPX1(Equipment):
     def __init__(self, *args):
         Equipment.__init__(self, *args)
 
-	self.beam_position = [None, None]
-	self.beam_size     = [None, None]
+        self.beam_position = [None, None]
+        self.beam_size     = [None, None]
         self.shape         = 'rectangular'
 
         self.beam_info_dict  = {'size_x': None, 'size_y': None, 'shape': self.shape}

--- a/HardwareObjects/SOLEIL/BeamInfoPX2.py
+++ b/HardwareObjects/SOLEIL/BeamInfoPX2.py
@@ -143,7 +143,7 @@ class BeamInfoPX2(Equipment):
         
     def get_beam_position(self):
         #logging.getLogger().warning('returning beam positions. It is %s ' % str(self.beam_position))
-        return self.beam_position	
+        return self.beam_position
 
     def get_beam_size(self):
         """

--- a/HardwareObjects/SOLEIL/CatsPX1.py
+++ b/HardwareObjects/SOLEIL/CatsPX1.py
@@ -47,7 +47,7 @@ class Basket(Container):
         return str(basket_number)
 
     def clearInfo(self):
-	self.getContainer()._reset_basket_info(self.getIndex()+1)
+        self.getContainer()._reset_basket_info(self.getIndex()+1)
         self.getContainer()._triggerInfoChangedEvent()
 
 

--- a/HardwareObjects/SOLEIL/EnergyScanPX1.py
+++ b/HardwareObjects/SOLEIL/EnergyScanPX1.py
@@ -211,7 +211,7 @@ class EnergyScanPX1(Equipment):
 
  
 #        return self.doEnergyScan is not None
-	
+
     def startEnergyScan(self, 
                         element, 
                         edge, 
@@ -493,7 +493,7 @@ class EnergyScanPX1(Equipment):
         return filenameIn
     
     def doEnergyScan(self, element, edge, directory, filename):
-        logging.getLogger("HWR").info('EnergyScan: Element:%s Edge:%s' %(element,edge))    	
+        logging.getLogger("HWR").info('EnergyScan: Element:%s Edge:%s' %(element,edge))
 
         e_edge, roi_center = self.getEdgefromXabs(element, edge)
         self.thEdge = e_edge
@@ -850,7 +850,7 @@ class EnergyScanThread(QThread):
             intensity = 0
             eventsInRun = 0
             eventsInRun_upToROI = 0
-	    eventsInRun_diffusion = 0
+            eventsInRun_diffusion = 0
             for mS in range(self.miniSteps):
                 measurement += 1
                 self.parent.fluodetdevice.Start()
@@ -872,7 +872,7 @@ class EnergyScanThread(QThread):
                 #print 5*'\n'
 #                eventsInRun_upToROI += sum(self.parent.fluodetdevice.channel00[ :channel_end + 1])
                 eventsInRun_upToROI += sum(self.parent.fluodetdevice.channel02[ :channel_end + 1])
-		eventsInRun_diffusion += sum(self.parent.fluodetdevice.channel02[ channel_end + 50 :])
+                eventsInRun_diffusion += sum(self.parent.fluodetdevice.channel02[ channel_end + 50 :])
                 #collectRecord['DataPoints'][measurement] = {}
                 #collectRecord['DataPoints'][measurement]['MonoEnergy'] = pos_i
                 #collectRecord['DataPoints'][measurement]['ROICounts']  = self.parent.fluodetdevice.roi00_01

--- a/HardwareObjects/SOLEIL/EnergyScanPX2.py
+++ b/HardwareObjects/SOLEIL/EnergyScanPX2.py
@@ -194,7 +194,7 @@ class EnergyScanPX2(Equipment):
 
  
 #        return self.doEnergyScan is not None
-	
+
     def startEnergyScan(self, 
                         element, 
                         edge, 
@@ -670,7 +670,7 @@ class EnergyScanPX2(Equipment):
         return filenameIn
     
     def doEnergyScan(self, element, edge, directory, filename):
-        logging.getLogger("HWR").info('EnergyScan: Element:%s Edge:%s' %(element,edge))    	
+        logging.getLogger("HWR").info('EnergyScan: Element:%s Edge:%s' %(element,edge))
 
         e_edge, roi_center = self.getEdgefromXabs(element, edge)
         self.thEdge = e_edge

--- a/HardwareObjects/SOLEIL/MiniDiffPX2.py
+++ b/HardwareObjects/SOLEIL/MiniDiffPX2.py
@@ -945,7 +945,7 @@ class MiniDiffPX2(Equipment):
               try:
                 self.centringStatus["motors"][role] = centred_pos[motor]
               except KeyError:
-		continue
+                continue
             self.centringStatus["method"]=self.currentCentringMethod
             self.centringStatus["valid"]=True
             

--- a/HardwareObjects/SOLEIL/PX1MultiCollect.py
+++ b/HardwareObjects/SOLEIL/PX1MultiCollect.py
@@ -482,6 +482,7 @@ class PX1MultiCollect(AbstractMultiCollect, HardwareObject):
                 nkey = key[:-9]
                 all_gaps[nkey] = _gaps[key]
             else:
+                # TODO FIXME ERROR this cannot possibly be right:
                 all_gaps = _gaps
         return all_gaps
 

--- a/HardwareObjects/SOLEIL/PX2Cats.py
+++ b/HardwareObjects/SOLEIL/PX2Cats.py
@@ -60,7 +60,7 @@ class Basket(Container):
         return str(basket_number)
 
     def clearInfo(self):
-	self.getContainer()._reset_basket_info(self.getIndex()+1)
+        self.getContainer()._reset_basket_info(self.getIndex()+1)
         self.getContainer()._triggerInfoChangedEvent()
 
 #identique a Cats90

--- a/HardwareObjects/SOLEIL/PX2Collect.py
+++ b/HardwareObjects/SOLEIL/PX2Collect.py
@@ -28,6 +28,7 @@ from AbstractCollect import AbstractCollect
 
 from eiger import detector, goniometer
 import eiger
+import time
 
 __author__ = "laurent gadea"
 __credits__ = ["MXCuBE colaboration"]
@@ -154,6 +155,8 @@ class PX2Collect(AbstractCollect, HardwareObject):
 #              polarisation = self.getProperty('polarisation'),
 #              input_files_server = self.getProperty("input_files_server"))
 #==============================================================================
+
+        # TODO FIXME ERROR
                                       detector_type = bcm_pars["detector"].getProperty("type"),
                                       detector_mode = spec_pars["detector"].getProperty("binning"),####### >>> ISPYBCLIENT queue_model_object
                                       detector_manufacturer = bcm_pars["detector"].getProperty("manufacturer"),
@@ -567,6 +570,7 @@ class PX2Collect(AbstractCollect, HardwareObject):
         """
         Descript. : 
         """
+        # TODO FIXME ERROR
         if self.energy_hwobj is not None:
             self.energy_obj.startMoveEnergy(energy)
             logging.info("energy_obj.getState() %s " % energy_obj.getState())
@@ -676,7 +680,7 @@ class PX2Collect(AbstractCollect, HardwareObject):
 #==============================================================================
 #         #a tester 
 #==============================================================================
-        if self.detectordistance_hwobj is not None:	
+        if self.detectordistance_hwobj is not None:
             return self.detectordistance_hwobj.getPosition()
     #OK !!!!!!!!!!!!!!!!!!
     def get_detector_distance_limits(self):

--- a/HardwareObjects/SOLEIL/PX2DataAnalysis.py
+++ b/HardwareObjects/SOLEIL/PX2DataAnalysis.py
@@ -25,4 +25,4 @@ def test():
 if __name__ == '__main__':
     test()
 
-  	      
+

--- a/HardwareObjects/SOLEIL/Ps_attenuatorPX1.py
+++ b/HardwareObjects/SOLEIL/Ps_attenuatorPX1.py
@@ -29,10 +29,10 @@ class Ps_attenuatorPX1(Device):
                        
         if self.deviceOk:
             self.connected()
-	    
+
             self.chanAttState = self.getChannelObject('State')
             self.chanAttState.connectSignal('update', self.attStateChanged)
-	    
+
             self.chanAttFactor = self.getChannelObject('TrueTrans_FP')
             self.chanAttFactor.connectSignal('update', self.attFactorChanged)
                          
@@ -93,7 +93,7 @@ class Ps_attenuatorPX1(Device):
 #        print "Dans attToggleChanged  channelValue = %s" %channelValue
 #        logging.getLogger().debug("HOS Attenuator: passe dans attToggleChanged")
         try:
-  	        value = int(channelValue)
+            value = int(channelValue)
         except:
             logging.getLogger("HWR").error('%s attToggleChanged : received value on channel is not a float value', str(self.name()))
         else:
@@ -118,4 +118,4 @@ class Ps_attenuatorPX1(Device):
         logging.getLogger().error("Check Instance of Device server %s" % db.DbGetDeviceInfo(device)[1][3])
         self.sDisconnected()
 
-  	      
+

--- a/HardwareObjects/SOLEIL/Ps_attenuatorPX2.py
+++ b/HardwareObjects/SOLEIL/Ps_attenuatorPX2.py
@@ -171,4 +171,4 @@ class Ps_attenuatorPX2(Device):
         logging.getLogger().error("Check Instance of Device server %s" % db.DbGetDeviceInfo(device)[1][3])
         self.sDisconnected()
 
-  	      
+

--- a/HardwareObjects/SOLEIL/SOLEILISPyBClient.py
+++ b/HardwareObjects/SOLEIL/SOLEILISPyBClient.py
@@ -131,10 +131,10 @@ class SOLEILISPyBClient(ISPyBClient2.ISPyBClient2):
         for i in range(4):
             try: 
                 prop = 'xtalSnapshotFullPath%d' % (i+1)
-	        path = mx_collect_dict[prop] 
+                path = mx_collect_dict[prop]
                 ispyb_path = self.session_hwobj.path_to_ispyb( path )
                 logging.debug("SOLEIL ISPyBClient - %s is %s " % (prop, ispyb_path))
-	        mx_collect_dict[prop] = ispyb_path
+                mx_collect_dict[prop] = ispyb_path
             except:
                 pass
 

--- a/HardwareObjects/SOLEIL/SOLEILMiniDiff.py
+++ b/HardwareObjects/SOLEIL/SOLEILMiniDiff.py
@@ -123,7 +123,7 @@ class SOLEILMiniDiff(MiniDiff.MiniDiff):
         return self.cmd_get_motor_state(motor_name).name
         
     def get_phase_list(self):
-        return self.phase_list
+        return list(self.phase_list)
 
     def start_set_phase(self, name):
         """

--- a/HardwareObjects/SOLEIL/SOLEILSession.py
+++ b/HardwareObjects/SOLEIL/SOLEILSession.py
@@ -66,7 +66,7 @@ class SOLEILSession(Session.Session):
             #directory = os.path.join(self.base_directory, self.endstation_name,
             #                         self.get_user_category(), self.get_proposal(),
             #                         start_time)
-            directory = os.path.join(self.base_directory, start_time, self.proposal_number, self.get_proposal_number())	    
+            directory = os.path.join(self.base_directory, start_time, self.proposal_number, self.get_proposal_number())
         else:
             #directory = os.path.join(self.base_directory, self.get_user_category(),
             #                         self.get_proposal(), self.endstation_name,

--- a/HardwareObjects/SOLEIL/TangoGonioPositions.py
+++ b/HardwareObjects/SOLEIL/TangoGonioPositions.py
@@ -17,9 +17,9 @@ class TangoInOut(Device):
         self._setReady()
 
         try:
-	   self.inversed = self.getProperty("inversed")
+           self.inversed = self.getProperty("inversed")
         except:
-	   self.inversed = False
+           self.inversed = False
 
         if self.inversed:
            self.states = ["in", "out"]

--- a/HardwareObjects/SOLEIL/TangoInOut.py
+++ b/HardwareObjects/SOLEIL/TangoInOut.py
@@ -17,9 +17,9 @@ class TangoInOut(Device):
         self._setReady()
 
         try:
-	   self.inversed = self.getProperty("inversed")
+           self.inversed = self.getProperty("inversed")
         except:
-	   self.inversed = False
+           self.inversed = False
 
         if self.inversed:
            self.states = ["in", "out"]

--- a/HardwareObjects/SOLEIL/TangoLightPX1.py
+++ b/HardwareObjects/SOLEIL/TangoLightPX1.py
@@ -32,9 +32,9 @@ class TangoLightPX1(Device):
 
         self._setReady()
         try:
-	   self.inversed = self.getProperty("inversed")
+           self.inversed = self.getProperty("inversed")
         except:
-	   self.inversed = False
+           self.inversed = False
 
         if self.inversed:
            self.states = ["in", "out"]

--- a/HardwareObjects/SOLEIL/Zoom.py
+++ b/HardwareObjects/SOLEIL/Zoom.py
@@ -54,7 +54,7 @@ class Zoom(TangoDCMotor.TangoDCMotor):
 
     def sortPredefinedPositionsList(self):
         self.predefinedPositionsNamesList = self.predefinedPositions.keys()
-	self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y]))) 
+        self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y])))
                 
     def motorMoveDone(self, channelValue):
 
@@ -85,12 +85,12 @@ class Zoom(TangoDCMotor.TangoDCMotor):
             self.move(self.predefinedPositions[positionName])
             self.light_dev.intensity = self.predefinedLightLevel[positionName]
         except:
-	    logging.getLogger().exception('Cannot move motor %s: invalid position name.', str(self.userName())) 
+            logging.getLogger().exception('Cannot move motor %s: invalid position name.', str(self.userName()))
 
 
     def getCurrentPositionName(self):
         if self.isReady() and self.getState() == self.READY:
-	    for positionName in self.predefinedPositions:
+            for positionName in self.predefinedPositions:
                 if self.predefinedPositions[positionName] >= self.getPosition()-self.delta and self.predefinedPositions[positionName] <= self.getPosition()+self.delta:
                    return positionName 
         return ''

--- a/HardwareObjects/ShapeHistory.py
+++ b/HardwareObjects/ShapeHistory.py
@@ -319,7 +319,7 @@ class DrawingEvent(QubDrawingEvent):
         self.selection_cb = None
         self.deletion_cb = None
         self.move_to_centred_position_cb = None
-	self.move_to_screen_position_cb = None
+        self.move_to_screen_position_cb = None
 
     def rawKeyPressed(self, keyevent):
         """

--- a/HardwareObjects/ShapeHistoryMockup.py
+++ b/HardwareObjects/ShapeHistoryMockup.py
@@ -76,9 +76,9 @@ class ShapeHistoryMockup(HardwareObject):
         :returns: The snapshot
         :rtype: QImage
         """
-	cwd = os.getcwd()
+        cwd = os.getcwd()
         path = os.path.join(cwd, "./test/HardwareObjectsMockup.xml/")
-	qimg_path = os.path.join(path, "mxcube_sample_snapshot.jpeg")
+        qimg_path = os.path.join(path, "mxcube_sample_snapshot.jpeg")
         qimg = open (qimg_path,'rb').read()
 
         return qimg
@@ -201,13 +201,13 @@ class ShapeHistoryMockup(HardwareObject):
         """
         Clear the shape history, remove all contents.
         """
-	return
+        return
 
     def de_select_all(self):
         return
 
     def select_shape_with_cpos(self, cpos):
-	return
+        return
 
 
 
@@ -316,10 +316,10 @@ class Line(Shape):
         self.qub_line.moveSecondPoint(new_positions[1][0], new_positions[1][1])
 
     def highlight(self):
-	return
+        return
 
     def unhighlight(self):
-	return
+        return
 
     def get_hit(self, x, y):
         return None
@@ -373,14 +373,14 @@ class Point(Shape):
         return
 
     def hide(self):
-	return
+        return
 
     def move(self, new_positions):
-	return
+        return
 
     def highlight(self):
-	return
+        return
 
     def unhighlight(self):
-	return
+        return
 

--- a/HardwareObjects/SlitsMockup.py
+++ b/HardwareObjects/SlitsMockup.py
@@ -35,7 +35,7 @@ class SlitsMockup(HardwareObject):
         HardwareObject.__init__(self, *args)
         self.hor_gap = False
         self.ver_gap = False
-	
+
     def init(self):
         self.gaps_dict = {}
         self.gaps_dict['Hor'] = self['gapH'].getProperties()
@@ -63,7 +63,7 @@ class SlitsMockup(HardwareObject):
         Return    : min gap values (list of two values)
         """
         return [self.gaps_dict['Hor']['minGap'], 
-                self.gaps_dict['Ver']['minGap']]		
+                self.gaps_dict['Ver']['minGap']]
 
     def get_max_gaps(self):
         """
@@ -72,7 +72,7 @@ class SlitsMockup(HardwareObject):
         Return    : max gap values (list of two values)
 	"""
         return [self.gaps_dict['Hor']['maxGap'], 
-                self.gaps_dict['Ver']['maxGap']] 	
+                self.gaps_dict['Ver']['maxGap']]
 
     def get_gap_limits(self, gap_name):
         """
@@ -104,7 +104,7 @@ class SlitsMockup(HardwareObject):
         Descript.
         """
         return self.get_gap_hor(), self.get_gap_ver()
-	
+
     def set_gap(self, gap_name, new_gap):
         """Sets new gap value
         Arguments : gap name(string), gap value(float)                                        
@@ -131,7 +131,7 @@ class SlitsMockup(HardwareObject):
         """
         if new_gaps_limits is not None:
             self.gaps_dict['Hor']['maxGap'] = min(self.init_max_gaps[0], new_gaps_limits[0])
-            self.gaps_dict['Ver']['maxGap'] = min(self.init_max_gaps[1], new_gaps_limits[1])	
+            self.gaps_dict['Ver']['maxGap'] = min(self.init_max_gaps[1], new_gaps_limits[1])
             self.emit('gapLimitsChanged', [self.gaps_dict['Hor']['maxGap'], 
                                            self.gaps_dict['Ver']['maxGap']])
 

--- a/HardwareObjects/SpecMotorWPositions.py
+++ b/HardwareObjects/SpecMotorWPositions.py
@@ -45,7 +45,7 @@ class SpecMotorWPositions(SpecMotor.SpecMotor):
 
     def sortPredefinedPositionsList(self):
         self.predefinedPositionsNamesList = list(self.predefinedPositions.keys())
-	self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y]))) 
+        self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y])))
                 
     def motorMoveDone(self, channelValue):
        SpecMotor.SpecMotor.motorMoveDone.__func__(self, channelValue)
@@ -68,12 +68,12 @@ class SpecMotorWPositions(SpecMotor.SpecMotor):
         try:
             self.move(self.predefinedPositions[positionName])
         except:
-	    logging.getLogger("HWR").exception('Cannot move motor %s: invalid position name.', str(self.userName())) 
+            logging.getLogger("HWR").exception('Cannot move motor %s: invalid position name.', str(self.userName()))
 
 
     def getCurrentPositionName(self):
         if not self.motorIsMoving(): #self.isReady() and self.getState() == self.READY:
-	    for positionName in self.predefinedPositions:
+            for positionName in self.predefinedPositions:
                 if self.predefinedPositions[positionName] >= self.getPosition()-self.delta and self.predefinedPositions[positionName] <= self.getPosition()+self.delta:
                    return positionName 
         return ''

--- a/HardwareObjects/SpecMotorWSpecPositions.py
+++ b/HardwareObjects/SpecMotorWSpecPositions.py
@@ -30,24 +30,24 @@ class SpecMotorWSpecPositions(SpecMotor.SpecMotor):
                
 
     def disconnected(self):
-	self.predefinedPositions = {}
+        self.predefinedPositions = {}
         self.predefinedPositionsNamesList = []
-	self.emit('newPredefinedPositions', (self.predefinedPositionsNamesList, ))
+        self.emit('newPredefinedPositions', (self.predefinedPositionsNamesList, ))
 
     
     def positionsArrayChanged(self, positionsArray):
         self.predefinedPositions = positionsArray
         
-	for pos in self.predefinedPositions:
-   	    self.predefinedPositions[pos] = float(self.predefinedPositions[pos])
+        for pos in self.predefinedPositions:
+               self.predefinedPositions[pos] = float(self.predefinedPositions[pos])
 
-	self.sortPredefinedPositionsList()
+        self.sortPredefinedPositionsList()
         self.emit('newPredefinedPositions', (self.predefinedPositionsNamesList, ))
        
         
     def sortPredefinedPositionsList(self):
         self.predefinedPositionsNamesList = list(self.predefinedPositions.keys())
-	self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y])))
+        self.predefinedPositionsNamesList.sort(lambda x, y: int(round(self.predefinedPositions[x] - self.predefinedPositions[y])))
 
 
     def motorPositionChanged(self, channelValue):

--- a/HardwareObjects/TangoLimaVideo.py
+++ b/HardwareObjects/TangoLimaVideo.py
@@ -64,7 +64,7 @@ class TangoLimaVideo(BaseHardwareObjects.Device):
     def _do_polling(self, sleep_time):
         while True:
             qimage = self._get_last_image()
-   	    self.emit("imageReceived", qimage, qimage.width(), qimage.height(), False)
+            self.emit("imageReceived", qimage, qimage.width(), qimage.height(), False)
 
             time.sleep(sleep_time)
 

--- a/HardwareObjects/VaporyVideo.py
+++ b/HardwareObjects/VaporyVideo.py
@@ -54,7 +54,7 @@ class VaporyVideo(BaseHardwareObjects.Device):
         self.simulated_loop.set_position(0, 0, 0)
 
         self.force_update = False
-        self.image_dimensions = [600, 400]	
+        self.image_dimensions = [600, 400]
         self.image_type = JpegType()
         self.setIsReady(True)
         self.generate_image()
@@ -193,7 +193,7 @@ class VaporyVideo(BaseHardwareObjects.Device):
         Descript. :
         """
         return self.image_dimensions[0]
-	
+
     def getHeight(self):
         """
         Descript. :

--- a/HardwareObjects/WagoCounter.py
+++ b/HardwareObjects/WagoCounter.py
@@ -33,9 +33,9 @@ class WagoCounter(TacoDevice.TacoDevice):
     def getGain(self):
         try:
            gain = self.device.DevReadDigi( self.gainid ) 
-	   
-	   try:
-	     gn = gain.index(1)+1
+
+           try:
+             gn = gain.index(1)+1
            except ValueError:
              gn = -1 
         except: 
@@ -51,15 +51,15 @@ class WagoCounter(TacoDevice.TacoDevice):
         gn = self.getGain()
 
         if gn < 0:
-	  # invalid gain
-	  value = None
-	else:
+          # invalid gain
+          value = None
+        else:
           gain = math.pow(self.gainfactor, gn)
           value = gain * value
 
         #print self.device.devname," --> ", gain, "x", value, " = " ,gain*value
-	
-	self.emit('valueChanged', (value,) )
+
+        self.emit('valueChanged', (value,) )
         return value
 
     def getValue(self):
@@ -75,7 +75,7 @@ class WagoCounter(TacoDevice.TacoDevice):
         if gn < 0:
             # invalid gain
             value = -9999
-	else:
+        else:
             gain = math.pow(self.gainfactor, gn)
             value = gain * value
         return value

--- a/HardwareObjects/XSDataCommon.py
+++ b/HardwareObjects/XSDataCommon.py
@@ -18,24 +18,24 @@ from xml.dom import Node
 
 # Compabiltity between Python 2 and 3:
 if sys.version.startswith('3'):
-	unicode = str
-	from io import StringIO
+        unicode = str
+        from io import StringIO
 else:
-	from StringIO import StringIO
+        from StringIO import StringIO
 
 
 def showIndent(outfile, level):
-	for idx in range(level):
-		outfile.write(unicode('    '))
+        for idx in range(level):
+                outfile.write(unicode('    '))
 
 
 def checkType(_strClassName, _strMethodName, _value, _strExpectedType):
-	if not _strExpectedType in ["float", "double", "string", "boolean", "integer"]:
-		if _value != None:
-			if _value.__class__.__name__ != _strExpectedType:
-				strMessage = "ERROR! %s.%s argument is not %s but %s" % (_strClassName, _strMethodName, _strExpectedType, _value.__class__.__name__)
-				print(strMessage)
-				#raise BaseException(strMessage)
+        if not _strExpectedType in ["float", "double", "string", "boolean", "integer"]:
+                if _value != None:
+                        if _value.__class__.__name__ != _strExpectedType:
+                                strMessage = "ERROR! %s.%s argument is not %s but %s" % (_strClassName, _strMethodName, _strExpectedType, _value.__class__.__name__)
+                                print(strMessage)
+                                #raise BaseException(strMessage)
 #	elif _value is None:
 #		strMessage = "ERROR! %s.%s argument which should be %s is None" % (_strClassName, _strMethodName, _strExpectedType)
 #		print(strMessage)
@@ -43,56 +43,56 @@ def checkType(_strClassName, _strMethodName, _value, _strExpectedType):
 
 
 def warnEmptyAttribute(_strName, _strTypeName):
-	pass
-	#if not _strTypeName in ["float", "double", "string", "boolean", "integer"]:
-	#		print("Warning! Non-optional attribute %s of type %s is None!" % (_strName, _strTypeName))
+        pass
+        #if not _strTypeName in ["float", "double", "string", "boolean", "integer"]:
+        #		print("Warning! Non-optional attribute %s of type %s is None!" % (_strName, _strTypeName))
 
 class MixedContainer(object):
-	# Constants for category:
-	CategoryNone = 0
-	CategoryText = 1
-	CategorySimple = 2
-	CategoryComplex = 3
-	# Constants for content_type:
-	TypeNone = 0
-	TypeText = 1
-	TypeString = 2
-	TypeInteger = 3
-	TypeFloat = 4
-	TypeDecimal = 5
-	TypeDouble = 6
-	TypeBoolean = 7
-	def __init__(self, category, content_type, name, value):
-		self.category = category
-		self.content_type = content_type
-		self.name = name
-		self.value = value
-	def getCategory(self):
-		return self.category
-	def getContenttype(self, content_type):
-		return self.content_type
-	def getValue(self):
-		return self.value
-	def getName(self):
-		return self.name
-	def export(self, outfile, level, name):
-		if self.category == MixedContainer.CategoryText:
-			outfile.write(self.value)
-		elif self.category == MixedContainer.CategorySimple:
-			self.exportSimple(outfile, level, name)
-		else:	 # category == MixedContainer.CategoryComplex
-			self.value.export(outfile, level, name)
-	def exportSimple(self, outfile, level, name):
-		if self.content_type == MixedContainer.TypeString:
-			outfile.write(unicode('<%s>%s</%s>' % (self.name, self.value, self.name)))
-		elif self.content_type == MixedContainer.TypeInteger or \
-				self.content_type == MixedContainer.TypeBoolean:
-			outfile.write(unicode('<%s>%d</%s>' % (self.name, self.value, self.name)))
-		elif self.content_type == MixedContainer.TypeFloat or \
-				self.content_type == MixedContainer.TypeDecimal:
-			outfile.write(unicode('<%s>%f</%s>' % (self.name, self.value, self.name)))
-		elif self.content_type == MixedContainer.TypeDouble:
-			outfile.write(unicode('<%s>%g</%s>' % (self.name, self.value, self.name)))
+        # Constants for category:
+        CategoryNone = 0
+        CategoryText = 1
+        CategorySimple = 2
+        CategoryComplex = 3
+        # Constants for content_type:
+        TypeNone = 0
+        TypeText = 1
+        TypeString = 2
+        TypeInteger = 3
+        TypeFloat = 4
+        TypeDecimal = 5
+        TypeDouble = 6
+        TypeBoolean = 7
+        def __init__(self, category, content_type, name, value):
+                self.category = category
+                self.content_type = content_type
+                self.name = name
+                self.value = value
+        def getCategory(self):
+                return self.category
+        def getContenttype(self, content_type):
+                return self.content_type
+        def getValue(self):
+                return self.value
+        def getName(self):
+                return self.name
+        def export(self, outfile, level, name):
+                if self.category == MixedContainer.CategoryText:
+                        outfile.write(self.value)
+                elif self.category == MixedContainer.CategorySimple:
+                        self.exportSimple(outfile, level, name)
+                else:         # category == MixedContainer.CategoryComplex
+                        self.value.export(outfile, level, name)
+        def exportSimple(self, outfile, level, name):
+                if self.content_type == MixedContainer.TypeString:
+                        outfile.write(unicode('<%s>%s</%s>' % (self.name, self.value, self.name)))
+                elif self.content_type == MixedContainer.TypeInteger or \
+                                self.content_type == MixedContainer.TypeBoolean:
+                        outfile.write(unicode('<%s>%d</%s>' % (self.name, self.value, self.name)))
+                elif self.content_type == MixedContainer.TypeFloat or \
+                                self.content_type == MixedContainer.TypeDecimal:
+                        outfile.write(unicode('<%s>%f</%s>' % (self.name, self.value, self.name)))
+                elif self.content_type == MixedContainer.TypeDouble:
+                        outfile.write(unicode('<%s>%g</%s>' % (self.name, self.value, self.name)))
 
 #
 # Data representation classes.
@@ -100,4471 +100,4471 @@ class MixedContainer(object):
 
 
 class XSConfiguration(object):
-	def __init__(self, XSPluginList=None):
-		checkType("XSConfiguration", "Constructor of XSConfiguration", XSPluginList, "XSPluginList")
-		self.__XSPluginList = XSPluginList
-	def getXSPluginList(self): return self.__XSPluginList
-	def setXSPluginList(self, XSPluginList):
-		checkType("XSConfiguration", "setXSPluginList", XSPluginList, "XSPluginList")
-		self.__XSPluginList = XSPluginList
-	def delXSPluginList(self): self.__XSPluginList = None
-	# Properties
-	XSPluginList = property(getXSPluginList, setXSPluginList, delXSPluginList, "Property for XSPluginList")
-	def export(self, outfile, level, name_='XSConfiguration'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSConfiguration'):
-		pass
-		if self.__XSPluginList is not None:
-			self.XSPluginList.export(outfile, level, name_='XSPluginList')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'XSPluginList':
-			obj_ = XSPluginList()
-			obj_.build(child_)
-			self.setXSPluginList(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSConfiguration" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSConfiguration' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSConfiguration is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSConfiguration.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSConfiguration()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSConfiguration" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSConfiguration()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, XSPluginList=None):
+                checkType("XSConfiguration", "Constructor of XSConfiguration", XSPluginList, "XSPluginList")
+                self.__XSPluginList = XSPluginList
+        def getXSPluginList(self): return self.__XSPluginList
+        def setXSPluginList(self, XSPluginList):
+                checkType("XSConfiguration", "setXSPluginList", XSPluginList, "XSPluginList")
+                self.__XSPluginList = XSPluginList
+        def delXSPluginList(self): self.__XSPluginList = None
+        # Properties
+        XSPluginList = property(getXSPluginList, setXSPluginList, delXSPluginList, "Property for XSPluginList")
+        def export(self, outfile, level, name_='XSConfiguration'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSConfiguration'):
+                pass
+                if self.__XSPluginList is not None:
+                        self.XSPluginList.export(outfile, level, name_='XSPluginList')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'XSPluginList':
+                        obj_ = XSPluginList()
+                        obj_.build(child_)
+                        self.setXSPluginList(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSConfiguration" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSConfiguration' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSConfiguration is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSConfiguration.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSConfiguration()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSConfiguration" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSConfiguration()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSConfiguration
 
 class XSData(object):
-	def __init__(self):
-		pass
-	def export(self, outfile, level, name_='XSData'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSData'):
-		pass
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSData" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSData' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSData is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSData.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSData()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSData" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSData()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self):
+                pass
+        def export(self, outfile, level, name_='XSData'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSData'):
+                pass
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSData" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSData' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSData is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSData.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSData()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSData" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSData()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSData
 
 class XSDataDisplacement(object):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		checkType("XSDataDisplacement", "Constructor of XSDataDisplacement", error, "XSDataDouble")
-		self.__error = error
-		checkType("XSDataDisplacement", "Constructor of XSDataDisplacement", unit, "XSDataString")
-		self.__unit = unit
-		checkType("XSDataDisplacement", "Constructor of XSDataDisplacement", value, "double")
-		self.__value = value
-	def getError(self): return self.__error
-	def setError(self, error):
-		checkType("XSDataDisplacement", "setError", error, "XSDataDouble")
-		self.__error = error
-	def delError(self): self.__error = None
-	# Properties
-	error = property(getError, setError, delError, "Property for error")
-	def getUnit(self): return self.__unit
-	def setUnit(self, unit):
-		checkType("XSDataDisplacement", "setUnit", unit, "XSDataString")
-		self.__unit = unit
-	def delUnit(self): self.__unit = None
-	# Properties
-	unit = property(getUnit, setUnit, delUnit, "Property for unit")
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataDisplacement", "setValue", value, "double")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataDisplacement'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataDisplacement'):
-		pass
-		if self.__error is not None:
-			self.error.export(outfile, level, name_='error')
-		if self.__unit is not None:
-			self.unit.export(outfile, level, name_='unit')
-		if self.__value is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<value>%e</value>\n' % self.__value))
-		else:
-			warnEmptyAttribute("value", "double")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'error':
-			obj_ = XSDataDouble()
-			obj_.build(child_)
-			self.setError(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'unit':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setUnit(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__value = fval_
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataDisplacement" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataDisplacement' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataDisplacement is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataDisplacement.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataDisplacement()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataDisplacement" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataDisplacement()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                checkType("XSDataDisplacement", "Constructor of XSDataDisplacement", error, "XSDataDouble")
+                self.__error = error
+                checkType("XSDataDisplacement", "Constructor of XSDataDisplacement", unit, "XSDataString")
+                self.__unit = unit
+                checkType("XSDataDisplacement", "Constructor of XSDataDisplacement", value, "double")
+                self.__value = value
+        def getError(self): return self.__error
+        def setError(self, error):
+                checkType("XSDataDisplacement", "setError", error, "XSDataDouble")
+                self.__error = error
+        def delError(self): self.__error = None
+        # Properties
+        error = property(getError, setError, delError, "Property for error")
+        def getUnit(self): return self.__unit
+        def setUnit(self, unit):
+                checkType("XSDataDisplacement", "setUnit", unit, "XSDataString")
+                self.__unit = unit
+        def delUnit(self): self.__unit = None
+        # Properties
+        unit = property(getUnit, setUnit, delUnit, "Property for unit")
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataDisplacement", "setValue", value, "double")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataDisplacement'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataDisplacement'):
+                pass
+                if self.__error is not None:
+                        self.error.export(outfile, level, name_='error')
+                if self.__unit is not None:
+                        self.unit.export(outfile, level, name_='unit')
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<value>%e</value>\n' % self.__value))
+                else:
+                        warnEmptyAttribute("value", "double")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'error':
+                        obj_ = XSDataDouble()
+                        obj_.build(child_)
+                        self.setError(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'unit':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setUnit(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__value = fval_
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataDisplacement" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataDisplacement' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataDisplacement is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataDisplacement.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataDisplacement()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataDisplacement" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataDisplacement()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataDisplacement
 
 class XSDataExecutionInfo(object):
-	"""This class contains details of the execution of a particular plugin."""
-	def __init__(self, workingDirectory=None, systeminfo=None, startOfExecution=None, pluginName=None, executionTime=None, configuration=None, baseDirectory=None):
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", baseDirectory, "XSDataFile")
-		self.__baseDirectory = baseDirectory
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", configuration, "XSConfiguration")
-		self.__configuration = configuration
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", executionTime, "XSDataTime")
-		self.__executionTime = executionTime
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", pluginName, "XSDataString")
-		self.__pluginName = pluginName
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", startOfExecution, "XSDataDate")
-		self.__startOfExecution = startOfExecution
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", systeminfo, "XSDataSysteminfo")
-		self.__systeminfo = systeminfo
-		checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", workingDirectory, "XSDataFile")
-		self.__workingDirectory = workingDirectory
-	def getBaseDirectory(self): return self.__baseDirectory
-	def setBaseDirectory(self, baseDirectory):
-		checkType("XSDataExecutionInfo", "setBaseDirectory", baseDirectory, "XSDataFile")
-		self.__baseDirectory = baseDirectory
-	def delBaseDirectory(self): self.__baseDirectory = None
-	# Properties
-	baseDirectory = property(getBaseDirectory, setBaseDirectory, delBaseDirectory, "Property for baseDirectory")
-	def getConfiguration(self): return self.__configuration
-	def setConfiguration(self, configuration):
-		checkType("XSDataExecutionInfo", "setConfiguration", configuration, "XSConfiguration")
-		self.__configuration = configuration
-	def delConfiguration(self): self.__configuration = None
-	# Properties
-	configuration = property(getConfiguration, setConfiguration, delConfiguration, "Property for configuration")
-	def getExecutionTime(self): return self.__executionTime
-	def setExecutionTime(self, executionTime):
-		checkType("XSDataExecutionInfo", "setExecutionTime", executionTime, "XSDataTime")
-		self.__executionTime = executionTime
-	def delExecutionTime(self): self.__executionTime = None
-	# Properties
-	executionTime = property(getExecutionTime, setExecutionTime, delExecutionTime, "Property for executionTime")
-	def getPluginName(self): return self.__pluginName
-	def setPluginName(self, pluginName):
-		checkType("XSDataExecutionInfo", "setPluginName", pluginName, "XSDataString")
-		self.__pluginName = pluginName
-	def delPluginName(self): self.__pluginName = None
-	# Properties
-	pluginName = property(getPluginName, setPluginName, delPluginName, "Property for pluginName")
-	def getStartOfExecution(self): return self.__startOfExecution
-	def setStartOfExecution(self, startOfExecution):
-		checkType("XSDataExecutionInfo", "setStartOfExecution", startOfExecution, "XSDataDate")
-		self.__startOfExecution = startOfExecution
-	def delStartOfExecution(self): self.__startOfExecution = None
-	# Properties
-	startOfExecution = property(getStartOfExecution, setStartOfExecution, delStartOfExecution, "Property for startOfExecution")
-	def getSysteminfo(self): return self.__systeminfo
-	def setSysteminfo(self, systeminfo):
-		checkType("XSDataExecutionInfo", "setSysteminfo", systeminfo, "XSDataSysteminfo")
-		self.__systeminfo = systeminfo
-	def delSysteminfo(self): self.__systeminfo = None
-	# Properties
-	systeminfo = property(getSysteminfo, setSysteminfo, delSysteminfo, "Property for systeminfo")
-	def getWorkingDirectory(self): return self.__workingDirectory
-	def setWorkingDirectory(self, workingDirectory):
-		checkType("XSDataExecutionInfo", "setWorkingDirectory", workingDirectory, "XSDataFile")
-		self.__workingDirectory = workingDirectory
-	def delWorkingDirectory(self): self.__workingDirectory = None
-	# Properties
-	workingDirectory = property(getWorkingDirectory, setWorkingDirectory, delWorkingDirectory, "Property for workingDirectory")
-	def export(self, outfile, level, name_='XSDataExecutionInfo'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataExecutionInfo'):
-		pass
-		if self.__baseDirectory is not None:
-			self.baseDirectory.export(outfile, level, name_='baseDirectory')
-		else:
-			warnEmptyAttribute("baseDirectory", "XSDataFile")
-		if self.__configuration is not None:
-			self.configuration.export(outfile, level, name_='configuration')
-		else:
-			warnEmptyAttribute("configuration", "XSConfiguration")
-		if self.__executionTime is not None:
-			self.executionTime.export(outfile, level, name_='executionTime')
-		else:
-			warnEmptyAttribute("executionTime", "XSDataTime")
-		if self.__pluginName is not None:
-			self.pluginName.export(outfile, level, name_='pluginName')
-		else:
-			warnEmptyAttribute("pluginName", "XSDataString")
-		if self.__startOfExecution is not None:
-			self.startOfExecution.export(outfile, level, name_='startOfExecution')
-		else:
-			warnEmptyAttribute("startOfExecution", "XSDataDate")
-		if self.__systeminfo is not None:
-			self.systeminfo.export(outfile, level, name_='systeminfo')
-		else:
-			warnEmptyAttribute("systeminfo", "XSDataSysteminfo")
-		if self.__workingDirectory is not None:
-			self.workingDirectory.export(outfile, level, name_='workingDirectory')
-		else:
-			warnEmptyAttribute("workingDirectory", "XSDataFile")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'baseDirectory':
-			obj_ = XSDataFile()
-			obj_.build(child_)
-			self.setBaseDirectory(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'configuration':
-			obj_ = XSConfiguration()
-			obj_.build(child_)
-			self.setConfiguration(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'executionTime':
-			obj_ = XSDataTime()
-			obj_.build(child_)
-			self.setExecutionTime(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'pluginName':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setPluginName(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'startOfExecution':
-			obj_ = XSDataDate()
-			obj_.build(child_)
-			self.setStartOfExecution(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'systeminfo':
-			obj_ = XSDataSysteminfo()
-			obj_.build(child_)
-			self.setSysteminfo(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'workingDirectory':
-			obj_ = XSDataFile()
-			obj_.build(child_)
-			self.setWorkingDirectory(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataExecutionInfo" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataExecutionInfo' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataExecutionInfo is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataExecutionInfo.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataExecutionInfo()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataExecutionInfo" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataExecutionInfo()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """This class contains details of the execution of a particular plugin."""
+        def __init__(self, workingDirectory=None, systeminfo=None, startOfExecution=None, pluginName=None, executionTime=None, configuration=None, baseDirectory=None):
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", baseDirectory, "XSDataFile")
+                self.__baseDirectory = baseDirectory
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", configuration, "XSConfiguration")
+                self.__configuration = configuration
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", executionTime, "XSDataTime")
+                self.__executionTime = executionTime
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", pluginName, "XSDataString")
+                self.__pluginName = pluginName
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", startOfExecution, "XSDataDate")
+                self.__startOfExecution = startOfExecution
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", systeminfo, "XSDataSysteminfo")
+                self.__systeminfo = systeminfo
+                checkType("XSDataExecutionInfo", "Constructor of XSDataExecutionInfo", workingDirectory, "XSDataFile")
+                self.__workingDirectory = workingDirectory
+        def getBaseDirectory(self): return self.__baseDirectory
+        def setBaseDirectory(self, baseDirectory):
+                checkType("XSDataExecutionInfo", "setBaseDirectory", baseDirectory, "XSDataFile")
+                self.__baseDirectory = baseDirectory
+        def delBaseDirectory(self): self.__baseDirectory = None
+        # Properties
+        baseDirectory = property(getBaseDirectory, setBaseDirectory, delBaseDirectory, "Property for baseDirectory")
+        def getConfiguration(self): return self.__configuration
+        def setConfiguration(self, configuration):
+                checkType("XSDataExecutionInfo", "setConfiguration", configuration, "XSConfiguration")
+                self.__configuration = configuration
+        def delConfiguration(self): self.__configuration = None
+        # Properties
+        configuration = property(getConfiguration, setConfiguration, delConfiguration, "Property for configuration")
+        def getExecutionTime(self): return self.__executionTime
+        def setExecutionTime(self, executionTime):
+                checkType("XSDataExecutionInfo", "setExecutionTime", executionTime, "XSDataTime")
+                self.__executionTime = executionTime
+        def delExecutionTime(self): self.__executionTime = None
+        # Properties
+        executionTime = property(getExecutionTime, setExecutionTime, delExecutionTime, "Property for executionTime")
+        def getPluginName(self): return self.__pluginName
+        def setPluginName(self, pluginName):
+                checkType("XSDataExecutionInfo", "setPluginName", pluginName, "XSDataString")
+                self.__pluginName = pluginName
+        def delPluginName(self): self.__pluginName = None
+        # Properties
+        pluginName = property(getPluginName, setPluginName, delPluginName, "Property for pluginName")
+        def getStartOfExecution(self): return self.__startOfExecution
+        def setStartOfExecution(self, startOfExecution):
+                checkType("XSDataExecutionInfo", "setStartOfExecution", startOfExecution, "XSDataDate")
+                self.__startOfExecution = startOfExecution
+        def delStartOfExecution(self): self.__startOfExecution = None
+        # Properties
+        startOfExecution = property(getStartOfExecution, setStartOfExecution, delStartOfExecution, "Property for startOfExecution")
+        def getSysteminfo(self): return self.__systeminfo
+        def setSysteminfo(self, systeminfo):
+                checkType("XSDataExecutionInfo", "setSysteminfo", systeminfo, "XSDataSysteminfo")
+                self.__systeminfo = systeminfo
+        def delSysteminfo(self): self.__systeminfo = None
+        # Properties
+        systeminfo = property(getSysteminfo, setSysteminfo, delSysteminfo, "Property for systeminfo")
+        def getWorkingDirectory(self): return self.__workingDirectory
+        def setWorkingDirectory(self, workingDirectory):
+                checkType("XSDataExecutionInfo", "setWorkingDirectory", workingDirectory, "XSDataFile")
+                self.__workingDirectory = workingDirectory
+        def delWorkingDirectory(self): self.__workingDirectory = None
+        # Properties
+        workingDirectory = property(getWorkingDirectory, setWorkingDirectory, delWorkingDirectory, "Property for workingDirectory")
+        def export(self, outfile, level, name_='XSDataExecutionInfo'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataExecutionInfo'):
+                pass
+                if self.__baseDirectory is not None:
+                        self.baseDirectory.export(outfile, level, name_='baseDirectory')
+                else:
+                        warnEmptyAttribute("baseDirectory", "XSDataFile")
+                if self.__configuration is not None:
+                        self.configuration.export(outfile, level, name_='configuration')
+                else:
+                        warnEmptyAttribute("configuration", "XSConfiguration")
+                if self.__executionTime is not None:
+                        self.executionTime.export(outfile, level, name_='executionTime')
+                else:
+                        warnEmptyAttribute("executionTime", "XSDataTime")
+                if self.__pluginName is not None:
+                        self.pluginName.export(outfile, level, name_='pluginName')
+                else:
+                        warnEmptyAttribute("pluginName", "XSDataString")
+                if self.__startOfExecution is not None:
+                        self.startOfExecution.export(outfile, level, name_='startOfExecution')
+                else:
+                        warnEmptyAttribute("startOfExecution", "XSDataDate")
+                if self.__systeminfo is not None:
+                        self.systeminfo.export(outfile, level, name_='systeminfo')
+                else:
+                        warnEmptyAttribute("systeminfo", "XSDataSysteminfo")
+                if self.__workingDirectory is not None:
+                        self.workingDirectory.export(outfile, level, name_='workingDirectory')
+                else:
+                        warnEmptyAttribute("workingDirectory", "XSDataFile")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'baseDirectory':
+                        obj_ = XSDataFile()
+                        obj_.build(child_)
+                        self.setBaseDirectory(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'configuration':
+                        obj_ = XSConfiguration()
+                        obj_.build(child_)
+                        self.setConfiguration(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'executionTime':
+                        obj_ = XSDataTime()
+                        obj_.build(child_)
+                        self.setExecutionTime(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'pluginName':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setPluginName(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'startOfExecution':
+                        obj_ = XSDataDate()
+                        obj_.build(child_)
+                        self.setStartOfExecution(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'systeminfo':
+                        obj_ = XSDataSysteminfo()
+                        obj_.build(child_)
+                        self.setSysteminfo(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'workingDirectory':
+                        obj_ = XSDataFile()
+                        obj_.build(child_)
+                        self.setWorkingDirectory(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataExecutionInfo" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataExecutionInfo' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataExecutionInfo is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataExecutionInfo.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataExecutionInfo()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataExecutionInfo" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataExecutionInfo()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataExecutionInfo
 
 class XSDataKeyValuePair(object):
-	def __init__(self, value=None, key=None):
-		checkType("XSDataKeyValuePair", "Constructor of XSDataKeyValuePair", key, "XSDataString")
-		self.__key = key
-		checkType("XSDataKeyValuePair", "Constructor of XSDataKeyValuePair", value, "XSDataString")
-		self.__value = value
-	def getKey(self): return self.__key
-	def setKey(self, key):
-		checkType("XSDataKeyValuePair", "setKey", key, "XSDataString")
-		self.__key = key
-	def delKey(self): self.__key = None
-	# Properties
-	key = property(getKey, setKey, delKey, "Property for key")
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataKeyValuePair", "setValue", value, "XSDataString")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataKeyValuePair'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataKeyValuePair'):
-		pass
-		if self.__key is not None:
-			self.key.export(outfile, level, name_='key')
-		else:
-			warnEmptyAttribute("key", "XSDataString")
-		if self.__value is not None:
-			self.value.export(outfile, level, name_='value')
-		else:
-			warnEmptyAttribute("value", "XSDataString")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'key':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setKey(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setValue(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataKeyValuePair" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataKeyValuePair' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataKeyValuePair is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataKeyValuePair.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataKeyValuePair()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataKeyValuePair" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataKeyValuePair()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, value=None, key=None):
+                checkType("XSDataKeyValuePair", "Constructor of XSDataKeyValuePair", key, "XSDataString")
+                self.__key = key
+                checkType("XSDataKeyValuePair", "Constructor of XSDataKeyValuePair", value, "XSDataString")
+                self.__value = value
+        def getKey(self): return self.__key
+        def setKey(self, key):
+                checkType("XSDataKeyValuePair", "setKey", key, "XSDataString")
+                self.__key = key
+        def delKey(self): self.__key = None
+        # Properties
+        key = property(getKey, setKey, delKey, "Property for key")
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataKeyValuePair", "setValue", value, "XSDataString")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataKeyValuePair'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataKeyValuePair'):
+                pass
+                if self.__key is not None:
+                        self.key.export(outfile, level, name_='key')
+                else:
+                        warnEmptyAttribute("key", "XSDataString")
+                if self.__value is not None:
+                        self.value.export(outfile, level, name_='value')
+                else:
+                        warnEmptyAttribute("value", "XSDataString")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'key':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setKey(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setValue(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataKeyValuePair" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataKeyValuePair' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataKeyValuePair is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataKeyValuePair.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataKeyValuePair()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataKeyValuePair" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataKeyValuePair()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataKeyValuePair
 
 class XSDataDictionary(object):
-	def __init__(self, keyValuePair=None):
-		if keyValuePair is None:
-			self.__keyValuePair = []
-		else:
-			checkType("XSDataDictionary", "Constructor of XSDataDictionary", keyValuePair, "list")
-			self.__keyValuePair = keyValuePair
-	def getKeyValuePair(self): return self.__keyValuePair
-	def setKeyValuePair(self, keyValuePair):
-		checkType("XSDataDictionary", "setKeyValuePair", keyValuePair, "list")
-		self.__keyValuePair = keyValuePair
-	def delKeyValuePair(self): self.__keyValuePair = None
-	# Properties
-	keyValuePair = property(getKeyValuePair, setKeyValuePair, delKeyValuePair, "Property for keyValuePair")
-	def addKeyValuePair(self, value):
-		checkType("XSDataDictionary", "setKeyValuePair", value, "XSDataKeyValuePair")
-		self.__keyValuePair.append(value)
-	def insertKeyValuePair(self, index, value):
-		checkType("XSDataDictionary", "setKeyValuePair", value, "XSDataKeyValuePair")
-		self.__keyValuePair[index] = value
-	def export(self, outfile, level, name_='XSDataDictionary'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataDictionary'):
-		pass
-		for keyValuePair_ in self.getKeyValuePair():
-			keyValuePair_.export(outfile, level, name_='keyValuePair')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'keyValuePair':
-			obj_ = XSDataKeyValuePair()
-			obj_.build(child_)
-			self.keyValuePair.append(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataDictionary" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataDictionary' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataDictionary is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataDictionary.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataDictionary()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataDictionary" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataDictionary()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, keyValuePair=None):
+                if keyValuePair is None:
+                        self.__keyValuePair = []
+                else:
+                        checkType("XSDataDictionary", "Constructor of XSDataDictionary", keyValuePair, "list")
+                        self.__keyValuePair = keyValuePair
+        def getKeyValuePair(self): return self.__keyValuePair
+        def setKeyValuePair(self, keyValuePair):
+                checkType("XSDataDictionary", "setKeyValuePair", keyValuePair, "list")
+                self.__keyValuePair = keyValuePair
+        def delKeyValuePair(self): self.__keyValuePair = None
+        # Properties
+        keyValuePair = property(getKeyValuePair, setKeyValuePair, delKeyValuePair, "Property for keyValuePair")
+        def addKeyValuePair(self, value):
+                checkType("XSDataDictionary", "setKeyValuePair", value, "XSDataKeyValuePair")
+                self.__keyValuePair.append(value)
+        def insertKeyValuePair(self, index, value):
+                checkType("XSDataDictionary", "setKeyValuePair", value, "XSDataKeyValuePair")
+                self.__keyValuePair[index] = value
+        def export(self, outfile, level, name_='XSDataDictionary'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataDictionary'):
+                pass
+                for keyValuePair_ in self.getKeyValuePair():
+                        keyValuePair_.export(outfile, level, name_='keyValuePair')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'keyValuePair':
+                        obj_ = XSDataKeyValuePair()
+                        obj_.build(child_)
+                        self.keyValuePair.append(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataDictionary" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataDictionary' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataDictionary is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataDictionary.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataDictionary()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataDictionary" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataDictionary()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataDictionary
 
 class XSOptionItem(object):
-	def __init__(self, name=None, enabled=None):
-		checkType("XSOptionItem", "Constructor of XSOptionItem", enabled, "boolean")
-		self.__enabled = enabled
-		checkType("XSOptionItem", "Constructor of XSOptionItem", name, "string")
-		self.__name = name
-	def getEnabled(self): return self.__enabled
-	def setEnabled(self, enabled):
-		checkType("XSOptionItem", "setEnabled", enabled, "boolean")
-		self.__enabled = enabled
-	def delEnabled(self): self.__enabled = None
-	# Properties
-	enabled = property(getEnabled, setEnabled, delEnabled, "Property for enabled")
-	def getName(self): return self.__name
-	def setName(self, name):
-		checkType("XSOptionItem", "setName", name, "string")
-		self.__name = name
-	def delName(self): self.__name = None
-	# Properties
-	name = property(getName, setName, delName, "Property for name")
-	def export(self, outfile, level, name_='XSOptionItem'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSOptionItem'):
-		pass
-		if self.__enabled is not None:
-			showIndent(outfile, level)
-			if self.__enabled:
-				outfile.write(unicode('<enabled>true</enabled>\n'))
-			else:
-				outfile.write(unicode('<enabled>false</enabled>\n'))
-		else:
-			warnEmptyAttribute("enabled", "boolean")
-		if self.__name is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<name>%s</name>\n' % self.__name))
-		else:
-			warnEmptyAttribute("name", "string")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'enabled':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				if sval_ in ('True', 'true', '1'):
-					ival_ = True
-				elif sval_ in ('False', 'false', '0'):
-					ival_ = False
-				else:
-					raise ValueError('requires boolean -- %s' % child_.toxml())
-				self.__enabled = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'name':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__name = value_
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSOptionItem" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSOptionItem' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSOptionItem is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSOptionItem.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSOptionItem()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSOptionItem" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSOptionItem()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, name=None, enabled=None):
+                checkType("XSOptionItem", "Constructor of XSOptionItem", enabled, "boolean")
+                self.__enabled = enabled
+                checkType("XSOptionItem", "Constructor of XSOptionItem", name, "string")
+                self.__name = name
+        def getEnabled(self): return self.__enabled
+        def setEnabled(self, enabled):
+                checkType("XSOptionItem", "setEnabled", enabled, "boolean")
+                self.__enabled = enabled
+        def delEnabled(self): self.__enabled = None
+        # Properties
+        enabled = property(getEnabled, setEnabled, delEnabled, "Property for enabled")
+        def getName(self): return self.__name
+        def setName(self, name):
+                checkType("XSOptionItem", "setName", name, "string")
+                self.__name = name
+        def delName(self): self.__name = None
+        # Properties
+        name = property(getName, setName, delName, "Property for name")
+        def export(self, outfile, level, name_='XSOptionItem'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSOptionItem'):
+                pass
+                if self.__enabled is not None:
+                        showIndent(outfile, level)
+                        if self.__enabled:
+                                outfile.write(unicode('<enabled>true</enabled>\n'))
+                        else:
+                                outfile.write(unicode('<enabled>false</enabled>\n'))
+                else:
+                        warnEmptyAttribute("enabled", "boolean")
+                if self.__name is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<name>%s</name>\n' % self.__name))
+                else:
+                        warnEmptyAttribute("name", "string")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'enabled':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                if sval_ in ('True', 'true', '1'):
+                                        ival_ = True
+                                elif sval_ in ('False', 'false', '0'):
+                                        ival_ = False
+                                else:
+                                        raise ValueError('requires boolean -- %s' % child_.toxml())
+                                self.__enabled = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'name':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__name = value_
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSOptionItem" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSOptionItem' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSOptionItem is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSOptionItem.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSOptionItem()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSOptionItem" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSOptionItem()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSOptionItem
 
 class XSOptionList(object):
-	def __init__(self, XSOptionItem=None):
-		if XSOptionItem is None:
-			self.__XSOptionItem = []
-		else:
-			checkType("XSOptionList", "Constructor of XSOptionList", XSOptionItem, "list")
-			self.__XSOptionItem = XSOptionItem
-	def getXSOptionItem(self): return self.__XSOptionItem
-	def setXSOptionItem(self, XSOptionItem):
-		checkType("XSOptionList", "setXSOptionItem", XSOptionItem, "list")
-		self.__XSOptionItem = XSOptionItem
-	def delXSOptionItem(self): self.__XSOptionItem = None
-	# Properties
-	XSOptionItem = property(getXSOptionItem, setXSOptionItem, delXSOptionItem, "Property for XSOptionItem")
-	def addXSOptionItem(self, value):
-		checkType("XSOptionList", "setXSOptionItem", value, "XSOptionItem")
-		self.__XSOptionItem.append(value)
-	def insertXSOptionItem(self, index, value):
-		checkType("XSOptionList", "setXSOptionItem", value, "XSOptionItem")
-		self.__XSOptionItem[index] = value
-	def export(self, outfile, level, name_='XSOptionList'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSOptionList'):
-		pass
-		for XSOptionItem_ in self.getXSOptionItem():
-			XSOptionItem_.export(outfile, level, name_='XSOptionItem')
-		if self.getXSOptionItem() == []:
-			warnEmptyAttribute("XSOptionItem", "XSOptionItem")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'XSOptionItem':
-			obj_ = XSOptionItem()
-			obj_.build(child_)
-			self.XSOptionItem.append(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSOptionList" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSOptionList' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSOptionList is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSOptionList.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSOptionList()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSOptionList" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSOptionList()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, XSOptionItem=None):
+                if XSOptionItem is None:
+                        self.__XSOptionItem = []
+                else:
+                        checkType("XSOptionList", "Constructor of XSOptionList", XSOptionItem, "list")
+                        self.__XSOptionItem = XSOptionItem
+        def getXSOptionItem(self): return self.__XSOptionItem
+        def setXSOptionItem(self, XSOptionItem):
+                checkType("XSOptionList", "setXSOptionItem", XSOptionItem, "list")
+                self.__XSOptionItem = XSOptionItem
+        def delXSOptionItem(self): self.__XSOptionItem = None
+        # Properties
+        XSOptionItem = property(getXSOptionItem, setXSOptionItem, delXSOptionItem, "Property for XSOptionItem")
+        def addXSOptionItem(self, value):
+                checkType("XSOptionList", "setXSOptionItem", value, "XSOptionItem")
+                self.__XSOptionItem.append(value)
+        def insertXSOptionItem(self, index, value):
+                checkType("XSOptionList", "setXSOptionItem", value, "XSOptionItem")
+                self.__XSOptionItem[index] = value
+        def export(self, outfile, level, name_='XSOptionList'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSOptionList'):
+                pass
+                for XSOptionItem_ in self.getXSOptionItem():
+                        XSOptionItem_.export(outfile, level, name_='XSOptionItem')
+                if self.getXSOptionItem() == []:
+                        warnEmptyAttribute("XSOptionItem", "XSOptionItem")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'XSOptionItem':
+                        obj_ = XSOptionItem()
+                        obj_.build(child_)
+                        self.XSOptionItem.append(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSOptionList" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSOptionList' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSOptionList is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSOptionList.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSOptionList()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSOptionList" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSOptionList()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSOptionList
 
 class XSParamItem(object):
-	def __init__(self, value=None, name=None):
-		checkType("XSParamItem", "Constructor of XSParamItem", name, "string")
-		self.__name = name
-		checkType("XSParamItem", "Constructor of XSParamItem", value, "string")
-		self.__value = value
-	def getName(self): return self.__name
-	def setName(self, name):
-		checkType("XSParamItem", "setName", name, "string")
-		self.__name = name
-	def delName(self): self.__name = None
-	# Properties
-	name = property(getName, setName, delName, "Property for name")
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSParamItem", "setValue", value, "string")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSParamItem'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSParamItem'):
-		pass
-		if self.__name is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<name>%s</name>\n' % self.__name))
-		else:
-			warnEmptyAttribute("name", "string")
-		if self.__value is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<value>%s</value>\n' % self.__value))
-		else:
-			warnEmptyAttribute("value", "string")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'name':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__name = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__value = value_
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSParamItem" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSParamItem' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSParamItem is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSParamItem.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSParamItem()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSParamItem" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSParamItem()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, value=None, name=None):
+                checkType("XSParamItem", "Constructor of XSParamItem", name, "string")
+                self.__name = name
+                checkType("XSParamItem", "Constructor of XSParamItem", value, "string")
+                self.__value = value
+        def getName(self): return self.__name
+        def setName(self, name):
+                checkType("XSParamItem", "setName", name, "string")
+                self.__name = name
+        def delName(self): self.__name = None
+        # Properties
+        name = property(getName, setName, delName, "Property for name")
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSParamItem", "setValue", value, "string")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSParamItem'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSParamItem'):
+                pass
+                if self.__name is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<name>%s</name>\n' % self.__name))
+                else:
+                        warnEmptyAttribute("name", "string")
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<value>%s</value>\n' % self.__value))
+                else:
+                        warnEmptyAttribute("value", "string")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'name':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__name = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__value = value_
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSParamItem" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSParamItem' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSParamItem is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSParamItem.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSParamItem()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSParamItem" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSParamItem()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSParamItem
 
 class XSParamList(object):
-	def __init__(self, XSParamItem=None):
-		if XSParamItem is None:
-			self.__XSParamItem = []
-		else:
-			checkType("XSParamList", "Constructor of XSParamList", XSParamItem, "list")
-			self.__XSParamItem = XSParamItem
-	def getXSParamItem(self): return self.__XSParamItem
-	def setXSParamItem(self, XSParamItem):
-		checkType("XSParamList", "setXSParamItem", XSParamItem, "list")
-		self.__XSParamItem = XSParamItem
-	def delXSParamItem(self): self.__XSParamItem = None
-	# Properties
-	XSParamItem = property(getXSParamItem, setXSParamItem, delXSParamItem, "Property for XSParamItem")
-	def addXSParamItem(self, value):
-		checkType("XSParamList", "setXSParamItem", value, "XSParamItem")
-		self.__XSParamItem.append(value)
-	def insertXSParamItem(self, index, value):
-		checkType("XSParamList", "setXSParamItem", value, "XSParamItem")
-		self.__XSParamItem[index] = value
-	def export(self, outfile, level, name_='XSParamList'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSParamList'):
-		pass
-		for XSParamItem_ in self.getXSParamItem():
-			XSParamItem_.export(outfile, level, name_='XSParamItem')
-		if self.getXSParamItem() == []:
-			warnEmptyAttribute("XSParamItem", "XSParamItem")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'XSParamItem':
-			obj_ = XSParamItem()
-			obj_.build(child_)
-			self.XSParamItem.append(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSParamList" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSParamList' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSParamList is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSParamList.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSParamList()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSParamList" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSParamList()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, XSParamItem=None):
+                if XSParamItem is None:
+                        self.__XSParamItem = []
+                else:
+                        checkType("XSParamList", "Constructor of XSParamList", XSParamItem, "list")
+                        self.__XSParamItem = XSParamItem
+        def getXSParamItem(self): return self.__XSParamItem
+        def setXSParamItem(self, XSParamItem):
+                checkType("XSParamList", "setXSParamItem", XSParamItem, "list")
+                self.__XSParamItem = XSParamItem
+        def delXSParamItem(self): self.__XSParamItem = None
+        # Properties
+        XSParamItem = property(getXSParamItem, setXSParamItem, delXSParamItem, "Property for XSParamItem")
+        def addXSParamItem(self, value):
+                checkType("XSParamList", "setXSParamItem", value, "XSParamItem")
+                self.__XSParamItem.append(value)
+        def insertXSParamItem(self, index, value):
+                checkType("XSParamList", "setXSParamItem", value, "XSParamItem")
+                self.__XSParamItem[index] = value
+        def export(self, outfile, level, name_='XSParamList'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSParamList'):
+                pass
+                for XSParamItem_ in self.getXSParamItem():
+                        XSParamItem_.export(outfile, level, name_='XSParamItem')
+                if self.getXSParamItem() == []:
+                        warnEmptyAttribute("XSParamItem", "XSParamItem")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'XSParamItem':
+                        obj_ = XSParamItem()
+                        obj_.build(child_)
+                        self.XSParamItem.append(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSParamList" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSParamList' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSParamList is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSParamList.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSParamList()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSParamList" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSParamList()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSParamList
 
 class XSPluginItem(object):
-	def __init__(self, name=None, XSParamList=None, XSOptionList=None):
-		checkType("XSPluginItem", "Constructor of XSPluginItem", XSOptionList, "XSOptionList")
-		self.__XSOptionList = XSOptionList
-		checkType("XSPluginItem", "Constructor of XSPluginItem", XSParamList, "XSParamList")
-		self.__XSParamList = XSParamList
-		checkType("XSPluginItem", "Constructor of XSPluginItem", name, "string")
-		self.__name = name
-	def getXSOptionList(self): return self.__XSOptionList
-	def setXSOptionList(self, XSOptionList):
-		checkType("XSPluginItem", "setXSOptionList", XSOptionList, "XSOptionList")
-		self.__XSOptionList = XSOptionList
-	def delXSOptionList(self): self.__XSOptionList = None
-	# Properties
-	XSOptionList = property(getXSOptionList, setXSOptionList, delXSOptionList, "Property for XSOptionList")
-	def getXSParamList(self): return self.__XSParamList
-	def setXSParamList(self, XSParamList):
-		checkType("XSPluginItem", "setXSParamList", XSParamList, "XSParamList")
-		self.__XSParamList = XSParamList
-	def delXSParamList(self): self.__XSParamList = None
-	# Properties
-	XSParamList = property(getXSParamList, setXSParamList, delXSParamList, "Property for XSParamList")
-	def getName(self): return self.__name
-	def setName(self, name):
-		checkType("XSPluginItem", "setName", name, "string")
-		self.__name = name
-	def delName(self): self.__name = None
-	# Properties
-	name = property(getName, setName, delName, "Property for name")
-	def export(self, outfile, level, name_='XSPluginItem'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSPluginItem'):
-		pass
-		if self.__XSOptionList is not None:
-			self.XSOptionList.export(outfile, level, name_='XSOptionList')
-		if self.__XSParamList is not None:
-			self.XSParamList.export(outfile, level, name_='XSParamList')
-		if self.__name is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<name>%s</name>\n' % self.__name))
-		else:
-			warnEmptyAttribute("name", "string")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'XSOptionList':
-			obj_ = XSOptionList()
-			obj_.build(child_)
-			self.setXSOptionList(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'XSParamList':
-			obj_ = XSParamList()
-			obj_.build(child_)
-			self.setXSParamList(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'name':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__name = value_
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSPluginItem" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSPluginItem' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSPluginItem is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSPluginItem.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSPluginItem()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSPluginItem" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSPluginItem()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, name=None, XSParamList=None, XSOptionList=None):
+                checkType("XSPluginItem", "Constructor of XSPluginItem", XSOptionList, "XSOptionList")
+                self.__XSOptionList = XSOptionList
+                checkType("XSPluginItem", "Constructor of XSPluginItem", XSParamList, "XSParamList")
+                self.__XSParamList = XSParamList
+                checkType("XSPluginItem", "Constructor of XSPluginItem", name, "string")
+                self.__name = name
+        def getXSOptionList(self): return self.__XSOptionList
+        def setXSOptionList(self, XSOptionList):
+                checkType("XSPluginItem", "setXSOptionList", XSOptionList, "XSOptionList")
+                self.__XSOptionList = XSOptionList
+        def delXSOptionList(self): self.__XSOptionList = None
+        # Properties
+        XSOptionList = property(getXSOptionList, setXSOptionList, delXSOptionList, "Property for XSOptionList")
+        def getXSParamList(self): return self.__XSParamList
+        def setXSParamList(self, XSParamList):
+                checkType("XSPluginItem", "setXSParamList", XSParamList, "XSParamList")
+                self.__XSParamList = XSParamList
+        def delXSParamList(self): self.__XSParamList = None
+        # Properties
+        XSParamList = property(getXSParamList, setXSParamList, delXSParamList, "Property for XSParamList")
+        def getName(self): return self.__name
+        def setName(self, name):
+                checkType("XSPluginItem", "setName", name, "string")
+                self.__name = name
+        def delName(self): self.__name = None
+        # Properties
+        name = property(getName, setName, delName, "Property for name")
+        def export(self, outfile, level, name_='XSPluginItem'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSPluginItem'):
+                pass
+                if self.__XSOptionList is not None:
+                        self.XSOptionList.export(outfile, level, name_='XSOptionList')
+                if self.__XSParamList is not None:
+                        self.XSParamList.export(outfile, level, name_='XSParamList')
+                if self.__name is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<name>%s</name>\n' % self.__name))
+                else:
+                        warnEmptyAttribute("name", "string")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'XSOptionList':
+                        obj_ = XSOptionList()
+                        obj_.build(child_)
+                        self.setXSOptionList(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'XSParamList':
+                        obj_ = XSParamList()
+                        obj_.build(child_)
+                        self.setXSParamList(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'name':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__name = value_
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSPluginItem" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSPluginItem' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSPluginItem is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSPluginItem.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSPluginItem()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSPluginItem" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSPluginItem()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSPluginItem
 
 class XSPluginList(object):
-	def __init__(self, XSPluginItem=None):
-		if XSPluginItem is None:
-			self.__XSPluginItem = []
-		else:
-			checkType("XSPluginList", "Constructor of XSPluginList", XSPluginItem, "list")
-			self.__XSPluginItem = XSPluginItem
-	def getXSPluginItem(self): return self.__XSPluginItem
-	def setXSPluginItem(self, XSPluginItem):
-		checkType("XSPluginList", "setXSPluginItem", XSPluginItem, "list")
-		self.__XSPluginItem = XSPluginItem
-	def delXSPluginItem(self): self.__XSPluginItem = None
-	# Properties
-	XSPluginItem = property(getXSPluginItem, setXSPluginItem, delXSPluginItem, "Property for XSPluginItem")
-	def addXSPluginItem(self, value):
-		checkType("XSPluginList", "setXSPluginItem", value, "XSPluginItem")
-		self.__XSPluginItem.append(value)
-	def insertXSPluginItem(self, index, value):
-		checkType("XSPluginList", "setXSPluginItem", value, "XSPluginItem")
-		self.__XSPluginItem[index] = value
-	def export(self, outfile, level, name_='XSPluginList'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSPluginList'):
-		pass
-		for XSPluginItem_ in self.getXSPluginItem():
-			XSPluginItem_.export(outfile, level, name_='XSPluginItem')
-		if self.getXSPluginItem() == []:
-			warnEmptyAttribute("XSPluginItem", "XSPluginItem")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'XSPluginItem':
-			obj_ = XSPluginItem()
-			obj_.build(child_)
-			self.XSPluginItem.append(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSPluginList" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSPluginList' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSPluginList is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSPluginList.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSPluginList()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSPluginList" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSPluginList()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, XSPluginItem=None):
+                if XSPluginItem is None:
+                        self.__XSPluginItem = []
+                else:
+                        checkType("XSPluginList", "Constructor of XSPluginList", XSPluginItem, "list")
+                        self.__XSPluginItem = XSPluginItem
+        def getXSPluginItem(self): return self.__XSPluginItem
+        def setXSPluginItem(self, XSPluginItem):
+                checkType("XSPluginList", "setXSPluginItem", XSPluginItem, "list")
+                self.__XSPluginItem = XSPluginItem
+        def delXSPluginItem(self): self.__XSPluginItem = None
+        # Properties
+        XSPluginItem = property(getXSPluginItem, setXSPluginItem, delXSPluginItem, "Property for XSPluginItem")
+        def addXSPluginItem(self, value):
+                checkType("XSPluginList", "setXSPluginItem", value, "XSPluginItem")
+                self.__XSPluginItem.append(value)
+        def insertXSPluginItem(self, index, value):
+                checkType("XSPluginList", "setXSPluginItem", value, "XSPluginItem")
+                self.__XSPluginItem[index] = value
+        def export(self, outfile, level, name_='XSPluginList'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSPluginList'):
+                pass
+                for XSPluginItem_ in self.getXSPluginItem():
+                        XSPluginItem_.export(outfile, level, name_='XSPluginItem')
+                if self.getXSPluginItem() == []:
+                        warnEmptyAttribute("XSPluginItem", "XSPluginItem")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'XSPluginItem':
+                        obj_ = XSPluginItem()
+                        obj_.build(child_)
+                        self.XSPluginItem.append(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSPluginList" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSPluginList' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSPluginList is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSPluginList.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSPluginList()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSPluginList" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSPluginList()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSPluginList
 
 class XSDataAngle(XSDataDisplacement):
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDisplacement.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataAngle'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataAngle'):
-		XSDataDisplacement.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDisplacement.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataAngle" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataAngle' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataAngle is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataAngle.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataAngle()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataAngle" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataAngle()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDisplacement.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataAngle'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataAngle'):
+                XSDataDisplacement.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDisplacement.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataAngle" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataAngle' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataAngle is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataAngle.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataAngle()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataAngle" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataAngle()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataAngle
 
 class XSDataArray(XSData):
-	"""md5 checksum has to be calculated on the decoded data, not the encoded one. Default encoding is "base64" default byte order is "little-endian" (intel) not "big-endian" (java)"""
-	def __init__(self, size=None, shape=None, md5sum=None, dtype=None, data=None, coding=None):
-		XSData.__init__(self, )
-		checkType("XSDataArray", "Constructor of XSDataArray", coding, "XSDataString")
-		self.__coding = coding
-		checkType("XSDataArray", "Constructor of XSDataArray", data, "string")
-		self.__data = data
-		checkType("XSDataArray", "Constructor of XSDataArray", dtype, "string")
-		self.__dtype = dtype
-		checkType("XSDataArray", "Constructor of XSDataArray", md5sum, "XSDataString")
-		self.__md5sum = md5sum
-		if shape is None:
-			self.__shape = []
-		else:
-			checkType("XSDataArray", "Constructor of XSDataArray", shape, "list")
-			self.__shape = shape
-		checkType("XSDataArray", "Constructor of XSDataArray", size, "integer")
-		self.__size = size
-	def getCoding(self): return self.__coding
-	def setCoding(self, coding):
-		checkType("XSDataArray", "setCoding", coding, "XSDataString")
-		self.__coding = coding
-	def delCoding(self): self.__coding = None
-	# Properties
-	coding = property(getCoding, setCoding, delCoding, "Property for coding")
-	def getData(self): return self.__data
-	def setData(self, data):
-		checkType("XSDataArray", "setData", data, "string")
-		self.__data = data
-	def delData(self): self.__data = None
-	# Properties
-	data = property(getData, setData, delData, "Property for data")
-	def getDtype(self): return self.__dtype
-	def setDtype(self, dtype):
-		checkType("XSDataArray", "setDtype", dtype, "string")
-		self.__dtype = dtype
-	def delDtype(self): self.__dtype = None
-	# Properties
-	dtype = property(getDtype, setDtype, delDtype, "Property for dtype")
-	def getMd5sum(self): return self.__md5sum
-	def setMd5sum(self, md5sum):
-		checkType("XSDataArray", "setMd5sum", md5sum, "XSDataString")
-		self.__md5sum = md5sum
-	def delMd5sum(self): self.__md5sum = None
-	# Properties
-	md5sum = property(getMd5sum, setMd5sum, delMd5sum, "Property for md5sum")
-	def getShape(self): return self.__shape
-	def setShape(self, shape):
-		checkType("XSDataArray", "setShape", shape, "list")
-		self.__shape = shape
-	def delShape(self): self.__shape = None
-	# Properties
-	shape = property(getShape, setShape, delShape, "Property for shape")
-	def addShape(self, value):
-		checkType("XSDataArray", "setShape", value, "integer")
-		self.__shape.append(value)
-	def insertShape(self, index, value):
-		checkType("XSDataArray", "setShape", value, "integer")
-		self.__shape[index] = value
-	def getSize(self): return self.__size
-	def setSize(self, size):
-		checkType("XSDataArray", "setSize", size, "integer")
-		self.__size = size
-	def delSize(self): self.__size = None
-	# Properties
-	size = property(getSize, setSize, delSize, "Property for size")
-	def export(self, outfile, level, name_='XSDataArray'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataArray'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__coding is not None:
-			self.coding.export(outfile, level, name_='coding')
-		if self.__data is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<data>%s</data>\n' % self.__data))
-		else:
-			warnEmptyAttribute("data", "string")
-		if self.__dtype is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<dtype>%s</dtype>\n' % self.__dtype))
-		else:
-			warnEmptyAttribute("dtype", "string")
-		if self.__md5sum is not None:
-			self.md5sum.export(outfile, level, name_='md5sum')
-		for shape_ in self.getShape():
-			showIndent(outfile, level)
-			outfile.write(unicode('<shape>%d</shape>\n' % shape_))
-		if self.getShape() == []:
-			warnEmptyAttribute("shape", "integer")
-		if self.__size is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<size>%d</size>\n' % self.__size))
-		else:
-			warnEmptyAttribute("size", "integer")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'coding':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setCoding(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'data':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__data = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'dtype':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__dtype = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'md5sum':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setMd5sum(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'shape':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__shape.append(ival_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'size':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__size = ival_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataArray" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataArray' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataArray is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataArray.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataArray()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataArray" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataArray()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """md5 checksum has to be calculated on the decoded data, not the encoded one. Default encoding is "base64" default byte order is "little-endian" (intel) not "big-endian" (java)"""
+        def __init__(self, size=None, shape=None, md5sum=None, dtype=None, data=None, coding=None):
+                XSData.__init__(self, )
+                checkType("XSDataArray", "Constructor of XSDataArray", coding, "XSDataString")
+                self.__coding = coding
+                checkType("XSDataArray", "Constructor of XSDataArray", data, "string")
+                self.__data = data
+                checkType("XSDataArray", "Constructor of XSDataArray", dtype, "string")
+                self.__dtype = dtype
+                checkType("XSDataArray", "Constructor of XSDataArray", md5sum, "XSDataString")
+                self.__md5sum = md5sum
+                if shape is None:
+                        self.__shape = []
+                else:
+                        checkType("XSDataArray", "Constructor of XSDataArray", shape, "list")
+                        self.__shape = shape
+                checkType("XSDataArray", "Constructor of XSDataArray", size, "integer")
+                self.__size = size
+        def getCoding(self): return self.__coding
+        def setCoding(self, coding):
+                checkType("XSDataArray", "setCoding", coding, "XSDataString")
+                self.__coding = coding
+        def delCoding(self): self.__coding = None
+        # Properties
+        coding = property(getCoding, setCoding, delCoding, "Property for coding")
+        def getData(self): return self.__data
+        def setData(self, data):
+                checkType("XSDataArray", "setData", data, "string")
+                self.__data = data
+        def delData(self): self.__data = None
+        # Properties
+        data = property(getData, setData, delData, "Property for data")
+        def getDtype(self): return self.__dtype
+        def setDtype(self, dtype):
+                checkType("XSDataArray", "setDtype", dtype, "string")
+                self.__dtype = dtype
+        def delDtype(self): self.__dtype = None
+        # Properties
+        dtype = property(getDtype, setDtype, delDtype, "Property for dtype")
+        def getMd5sum(self): return self.__md5sum
+        def setMd5sum(self, md5sum):
+                checkType("XSDataArray", "setMd5sum", md5sum, "XSDataString")
+                self.__md5sum = md5sum
+        def delMd5sum(self): self.__md5sum = None
+        # Properties
+        md5sum = property(getMd5sum, setMd5sum, delMd5sum, "Property for md5sum")
+        def getShape(self): return self.__shape
+        def setShape(self, shape):
+                checkType("XSDataArray", "setShape", shape, "list")
+                self.__shape = shape
+        def delShape(self): self.__shape = None
+        # Properties
+        shape = property(getShape, setShape, delShape, "Property for shape")
+        def addShape(self, value):
+                checkType("XSDataArray", "setShape", value, "integer")
+                self.__shape.append(value)
+        def insertShape(self, index, value):
+                checkType("XSDataArray", "setShape", value, "integer")
+                self.__shape[index] = value
+        def getSize(self): return self.__size
+        def setSize(self, size):
+                checkType("XSDataArray", "setSize", size, "integer")
+                self.__size = size
+        def delSize(self): self.__size = None
+        # Properties
+        size = property(getSize, setSize, delSize, "Property for size")
+        def export(self, outfile, level, name_='XSDataArray'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataArray'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__coding is not None:
+                        self.coding.export(outfile, level, name_='coding')
+                if self.__data is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<data>%s</data>\n' % self.__data))
+                else:
+                        warnEmptyAttribute("data", "string")
+                if self.__dtype is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<dtype>%s</dtype>\n' % self.__dtype))
+                else:
+                        warnEmptyAttribute("dtype", "string")
+                if self.__md5sum is not None:
+                        self.md5sum.export(outfile, level, name_='md5sum')
+                for shape_ in self.getShape():
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<shape>%d</shape>\n' % shape_))
+                if self.getShape() == []:
+                        warnEmptyAttribute("shape", "integer")
+                if self.__size is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<size>%d</size>\n' % self.__size))
+                else:
+                        warnEmptyAttribute("size", "integer")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'coding':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setCoding(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'data':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__data = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'dtype':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__dtype = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'md5sum':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setMd5sum(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'shape':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__shape.append(ival_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'size':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__size = ival_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataArray" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataArray' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataArray is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataArray.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataArray()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataArray" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataArray()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataArray
 
 class XSDataBoolean(XSData):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None):
-		XSData.__init__(self, )
-		checkType("XSDataBoolean", "Constructor of XSDataBoolean", value, "boolean")
-		self.__value = value
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataBoolean", "setValue", value, "boolean")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataBoolean'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataBoolean'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__value is not None:
-			showIndent(outfile, level)
-			if self.__value:
-				outfile.write(unicode('<value>true</value>\n'))
-			else:
-				outfile.write(unicode('<value>false</value>\n'))
-		else:
-			warnEmptyAttribute("value", "boolean")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				if sval_ in ('True', 'true', '1'):
-					ival_ = True
-				elif sval_ in ('False', 'false', '0'):
-					ival_ = False
-				else:
-					raise ValueError('requires boolean -- %s' % child_.toxml())
-				self.__value = ival_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataBoolean" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataBoolean' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataBoolean is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataBoolean.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataBoolean()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataBoolean" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataBoolean()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None):
+                XSData.__init__(self, )
+                checkType("XSDataBoolean", "Constructor of XSDataBoolean", value, "boolean")
+                self.__value = value
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataBoolean", "setValue", value, "boolean")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataBoolean'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataBoolean'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        if self.__value:
+                                outfile.write(unicode('<value>true</value>\n'))
+                        else:
+                                outfile.write(unicode('<value>false</value>\n'))
+                else:
+                        warnEmptyAttribute("value", "boolean")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                if sval_ in ('True', 'true', '1'):
+                                        ival_ = True
+                                elif sval_ in ('False', 'false', '0'):
+                                        ival_ = False
+                                else:
+                                        raise ValueError('requires boolean -- %s' % child_.toxml())
+                                self.__value = ival_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataBoolean" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataBoolean' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataBoolean is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataBoolean.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataBoolean()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataBoolean" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataBoolean()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataBoolean
 
 class XSDataDouble(XSData):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None):
-		XSData.__init__(self, )
-		checkType("XSDataDouble", "Constructor of XSDataDouble", value, "double")
-		self.__value = value
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataDouble", "setValue", value, "double")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataDouble'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataDouble'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__value is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<value>%e</value>\n' % self.__value))
-		else:
-			warnEmptyAttribute("value", "double")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__value = fval_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataDouble" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataDouble' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataDouble is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataDouble.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataDouble()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataDouble" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataDouble()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None):
+                XSData.__init__(self, )
+                checkType("XSDataDouble", "Constructor of XSDataDouble", value, "double")
+                self.__value = value
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataDouble", "setValue", value, "double")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataDouble'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataDouble'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<value>%e</value>\n' % self.__value))
+                else:
+                        warnEmptyAttribute("value", "double")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__value = fval_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataDouble" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataDouble' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataDouble is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataDouble.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataDouble()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataDouble" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataDouble()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataDouble
 
 class XSDataFile(XSData):
-	"""These objects use the simple objects described above to create useful structures for the rest for the data model."""
-	def __init__(self, path=None):
-		XSData.__init__(self, )
-		checkType("XSDataFile", "Constructor of XSDataFile", path, "XSDataString")
-		self.__path = path
-	def getPath(self): return self.__path
-	def setPath(self, path):
-		checkType("XSDataFile", "setPath", path, "XSDataString")
-		self.__path = path
-	def delPath(self): self.__path = None
-	# Properties
-	path = property(getPath, setPath, delPath, "Property for path")
-	def export(self, outfile, level, name_='XSDataFile'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataFile'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__path is not None:
-			self.path.export(outfile, level, name_='path')
-		else:
-			warnEmptyAttribute("path", "XSDataString")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'path':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setPath(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataFile" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataFile' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataFile is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataFile.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataFile()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataFile" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataFile()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These objects use the simple objects described above to create useful structures for the rest for the data model."""
+        def __init__(self, path=None):
+                XSData.__init__(self, )
+                checkType("XSDataFile", "Constructor of XSDataFile", path, "XSDataString")
+                self.__path = path
+        def getPath(self): return self.__path
+        def setPath(self, path):
+                checkType("XSDataFile", "setPath", path, "XSDataString")
+                self.__path = path
+        def delPath(self): self.__path = None
+        # Properties
+        path = property(getPath, setPath, delPath, "Property for path")
+        def export(self, outfile, level, name_='XSDataFile'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataFile'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__path is not None:
+                        self.path.export(outfile, level, name_='path')
+                else:
+                        warnEmptyAttribute("path", "XSDataString")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'path':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setPath(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataFile" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataFile' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataFile is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataFile.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataFile()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataFile" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataFile()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataFile
 
 class XSDataFloat(XSData):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None):
-		XSData.__init__(self, )
-		checkType("XSDataFloat", "Constructor of XSDataFloat", value, "double")
-		self.__value = value
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataFloat", "setValue", value, "double")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataFloat'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataFloat'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__value is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<value>%e</value>\n' % self.__value))
-		else:
-			warnEmptyAttribute("value", "double")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__value = fval_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataFloat" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataFloat' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataFloat is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataFloat.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataFloat()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataFloat" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataFloat()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None):
+                XSData.__init__(self, )
+                checkType("XSDataFloat", "Constructor of XSDataFloat", value, "double")
+                self.__value = value
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataFloat", "setValue", value, "double")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataFloat'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataFloat'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<value>%e</value>\n' % self.__value))
+                else:
+                        warnEmptyAttribute("value", "double")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__value = fval_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataFloat" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataFloat' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataFloat is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataFloat.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataFloat()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataFloat" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataFloat()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataFloat
 
 class XSDataInput(XSData):
-	"""All plugin input and result classes should be derived from these two classes."""
-	def __init__(self, configuration=None):
-		XSData.__init__(self, )
-		checkType("XSDataInput", "Constructor of XSDataInput", configuration, "XSConfiguration")
-		self.__configuration = configuration
-	def getConfiguration(self): return self.__configuration
-	def setConfiguration(self, configuration):
-		checkType("XSDataInput", "setConfiguration", configuration, "XSConfiguration")
-		self.__configuration = configuration
-	def delConfiguration(self): self.__configuration = None
-	# Properties
-	configuration = property(getConfiguration, setConfiguration, delConfiguration, "Property for configuration")
-	def export(self, outfile, level, name_='XSDataInput'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataInput'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__configuration is not None:
-			self.configuration.export(outfile, level, name_='configuration')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'configuration':
-			obj_ = XSConfiguration()
-			obj_.build(child_)
-			self.setConfiguration(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataInput" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataInput' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataInput is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataInput.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataInput()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataInput" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataInput()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """All plugin input and result classes should be derived from these two classes."""
+        def __init__(self, configuration=None):
+                XSData.__init__(self, )
+                checkType("XSDataInput", "Constructor of XSDataInput", configuration, "XSConfiguration")
+                self.__configuration = configuration
+        def getConfiguration(self): return self.__configuration
+        def setConfiguration(self, configuration):
+                checkType("XSDataInput", "setConfiguration", configuration, "XSConfiguration")
+                self.__configuration = configuration
+        def delConfiguration(self): self.__configuration = None
+        # Properties
+        configuration = property(getConfiguration, setConfiguration, delConfiguration, "Property for configuration")
+        def export(self, outfile, level, name_='XSDataInput'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataInput'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__configuration is not None:
+                        self.configuration.export(outfile, level, name_='configuration')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'configuration':
+                        obj_ = XSConfiguration()
+                        obj_.build(child_)
+                        self.setConfiguration(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataInput" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataInput' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataInput is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataInput.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataInput()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataInput" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataInput()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataInput
 
 class XSDataInteger(XSData):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None):
-		XSData.__init__(self, )
-		checkType("XSDataInteger", "Constructor of XSDataInteger", value, "integer")
-		self.__value = value
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataInteger", "setValue", value, "integer")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataInteger'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataInteger'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__value is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<value>%d</value>\n' % self.__value))
-		else:
-			warnEmptyAttribute("value", "integer")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__value = ival_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataInteger" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataInteger' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataInteger is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataInteger.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataInteger()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataInteger" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataInteger()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None):
+                XSData.__init__(self, )
+                checkType("XSDataInteger", "Constructor of XSDataInteger", value, "integer")
+                self.__value = value
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataInteger", "setValue", value, "integer")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataInteger'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataInteger'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<value>%d</value>\n' % self.__value))
+                else:
+                        warnEmptyAttribute("value", "integer")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__value = ival_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataInteger" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataInteger' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataInteger is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataInteger.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataInteger()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataInteger" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataInteger()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataInteger
 
 class XSDataLinearDisplacement(XSDataDisplacement):
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDisplacement.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataLinearDisplacement'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataLinearDisplacement'):
-		XSDataDisplacement.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDisplacement.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataLinearDisplacement" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataLinearDisplacement' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataLinearDisplacement is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataLinearDisplacement.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataLinearDisplacement()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataLinearDisplacement" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataLinearDisplacement()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDisplacement.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataLinearDisplacement'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataLinearDisplacement'):
+                XSDataDisplacement.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDisplacement.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataLinearDisplacement" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataLinearDisplacement' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataLinearDisplacement is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataLinearDisplacement.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataLinearDisplacement()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataLinearDisplacement" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataLinearDisplacement()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataLinearDisplacement
 
 class XSDataMatrixDouble(XSData):
-	"""These are compound object used for linear algebra operations."""
-	def __init__(self, m33=None, m32=None, m31=None, m23=None, m22=None, m21=None, m13=None, m12=None, m11=None):
-		XSData.__init__(self, )
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m11, "double")
-		self.__m11 = m11
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m12, "double")
-		self.__m12 = m12
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m13, "double")
-		self.__m13 = m13
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m21, "double")
-		self.__m21 = m21
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m22, "double")
-		self.__m22 = m22
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m23, "double")
-		self.__m23 = m23
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m31, "double")
-		self.__m31 = m31
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m32, "double")
-		self.__m32 = m32
-		checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m33, "double")
-		self.__m33 = m33
-	def getM11(self): return self.__m11
-	def setM11(self, m11):
-		checkType("XSDataMatrixDouble", "setM11", m11, "double")
-		self.__m11 = m11
-	def delM11(self): self.__m11 = None
-	# Properties
-	m11 = property(getM11, setM11, delM11, "Property for m11")
-	def getM12(self): return self.__m12
-	def setM12(self, m12):
-		checkType("XSDataMatrixDouble", "setM12", m12, "double")
-		self.__m12 = m12
-	def delM12(self): self.__m12 = None
-	# Properties
-	m12 = property(getM12, setM12, delM12, "Property for m12")
-	def getM13(self): return self.__m13
-	def setM13(self, m13):
-		checkType("XSDataMatrixDouble", "setM13", m13, "double")
-		self.__m13 = m13
-	def delM13(self): self.__m13 = None
-	# Properties
-	m13 = property(getM13, setM13, delM13, "Property for m13")
-	def getM21(self): return self.__m21
-	def setM21(self, m21):
-		checkType("XSDataMatrixDouble", "setM21", m21, "double")
-		self.__m21 = m21
-	def delM21(self): self.__m21 = None
-	# Properties
-	m21 = property(getM21, setM21, delM21, "Property for m21")
-	def getM22(self): return self.__m22
-	def setM22(self, m22):
-		checkType("XSDataMatrixDouble", "setM22", m22, "double")
-		self.__m22 = m22
-	def delM22(self): self.__m22 = None
-	# Properties
-	m22 = property(getM22, setM22, delM22, "Property for m22")
-	def getM23(self): return self.__m23
-	def setM23(self, m23):
-		checkType("XSDataMatrixDouble", "setM23", m23, "double")
-		self.__m23 = m23
-	def delM23(self): self.__m23 = None
-	# Properties
-	m23 = property(getM23, setM23, delM23, "Property for m23")
-	def getM31(self): return self.__m31
-	def setM31(self, m31):
-		checkType("XSDataMatrixDouble", "setM31", m31, "double")
-		self.__m31 = m31
-	def delM31(self): self.__m31 = None
-	# Properties
-	m31 = property(getM31, setM31, delM31, "Property for m31")
-	def getM32(self): return self.__m32
-	def setM32(self, m32):
-		checkType("XSDataMatrixDouble", "setM32", m32, "double")
-		self.__m32 = m32
-	def delM32(self): self.__m32 = None
-	# Properties
-	m32 = property(getM32, setM32, delM32, "Property for m32")
-	def getM33(self): return self.__m33
-	def setM33(self, m33):
-		checkType("XSDataMatrixDouble", "setM33", m33, "double")
-		self.__m33 = m33
-	def delM33(self): self.__m33 = None
-	# Properties
-	m33 = property(getM33, setM33, delM33, "Property for m33")
-	def export(self, outfile, level, name_='XSDataMatrixDouble'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataMatrixDouble'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__m11 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m11>%e</m11>\n' % self.__m11))
-		else:
-			warnEmptyAttribute("m11", "double")
-		if self.__m12 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m12>%e</m12>\n' % self.__m12))
-		else:
-			warnEmptyAttribute("m12", "double")
-		if self.__m13 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m13>%e</m13>\n' % self.__m13))
-		else:
-			warnEmptyAttribute("m13", "double")
-		if self.__m21 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m21>%e</m21>\n' % self.__m21))
-		else:
-			warnEmptyAttribute("m21", "double")
-		if self.__m22 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m22>%e</m22>\n' % self.__m22))
-		else:
-			warnEmptyAttribute("m22", "double")
-		if self.__m23 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m23>%e</m23>\n' % self.__m23))
-		else:
-			warnEmptyAttribute("m23", "double")
-		if self.__m31 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m31>%e</m31>\n' % self.__m31))
-		else:
-			warnEmptyAttribute("m31", "double")
-		if self.__m32 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m32>%e</m32>\n' % self.__m32))
-		else:
-			warnEmptyAttribute("m32", "double")
-		if self.__m33 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m33>%e</m33>\n' % self.__m33))
-		else:
-			warnEmptyAttribute("m33", "double")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm11':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m11 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm12':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m12 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm13':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m13 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm21':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m21 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm22':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m22 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm23':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m23 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm31':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m31 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm32':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m32 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm33':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__m33 = fval_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataMatrixDouble" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataMatrixDouble' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataMatrixDouble is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataMatrixDouble.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataMatrixDouble()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataMatrixDouble" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataMatrixDouble()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These are compound object used for linear algebra operations."""
+        def __init__(self, m33=None, m32=None, m31=None, m23=None, m22=None, m21=None, m13=None, m12=None, m11=None):
+                XSData.__init__(self, )
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m11, "double")
+                self.__m11 = m11
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m12, "double")
+                self.__m12 = m12
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m13, "double")
+                self.__m13 = m13
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m21, "double")
+                self.__m21 = m21
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m22, "double")
+                self.__m22 = m22
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m23, "double")
+                self.__m23 = m23
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m31, "double")
+                self.__m31 = m31
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m32, "double")
+                self.__m32 = m32
+                checkType("XSDataMatrixDouble", "Constructor of XSDataMatrixDouble", m33, "double")
+                self.__m33 = m33
+        def getM11(self): return self.__m11
+        def setM11(self, m11):
+                checkType("XSDataMatrixDouble", "setM11", m11, "double")
+                self.__m11 = m11
+        def delM11(self): self.__m11 = None
+        # Properties
+        m11 = property(getM11, setM11, delM11, "Property for m11")
+        def getM12(self): return self.__m12
+        def setM12(self, m12):
+                checkType("XSDataMatrixDouble", "setM12", m12, "double")
+                self.__m12 = m12
+        def delM12(self): self.__m12 = None
+        # Properties
+        m12 = property(getM12, setM12, delM12, "Property for m12")
+        def getM13(self): return self.__m13
+        def setM13(self, m13):
+                checkType("XSDataMatrixDouble", "setM13", m13, "double")
+                self.__m13 = m13
+        def delM13(self): self.__m13 = None
+        # Properties
+        m13 = property(getM13, setM13, delM13, "Property for m13")
+        def getM21(self): return self.__m21
+        def setM21(self, m21):
+                checkType("XSDataMatrixDouble", "setM21", m21, "double")
+                self.__m21 = m21
+        def delM21(self): self.__m21 = None
+        # Properties
+        m21 = property(getM21, setM21, delM21, "Property for m21")
+        def getM22(self): return self.__m22
+        def setM22(self, m22):
+                checkType("XSDataMatrixDouble", "setM22", m22, "double")
+                self.__m22 = m22
+        def delM22(self): self.__m22 = None
+        # Properties
+        m22 = property(getM22, setM22, delM22, "Property for m22")
+        def getM23(self): return self.__m23
+        def setM23(self, m23):
+                checkType("XSDataMatrixDouble", "setM23", m23, "double")
+                self.__m23 = m23
+        def delM23(self): self.__m23 = None
+        # Properties
+        m23 = property(getM23, setM23, delM23, "Property for m23")
+        def getM31(self): return self.__m31
+        def setM31(self, m31):
+                checkType("XSDataMatrixDouble", "setM31", m31, "double")
+                self.__m31 = m31
+        def delM31(self): self.__m31 = None
+        # Properties
+        m31 = property(getM31, setM31, delM31, "Property for m31")
+        def getM32(self): return self.__m32
+        def setM32(self, m32):
+                checkType("XSDataMatrixDouble", "setM32", m32, "double")
+                self.__m32 = m32
+        def delM32(self): self.__m32 = None
+        # Properties
+        m32 = property(getM32, setM32, delM32, "Property for m32")
+        def getM33(self): return self.__m33
+        def setM33(self, m33):
+                checkType("XSDataMatrixDouble", "setM33", m33, "double")
+                self.__m33 = m33
+        def delM33(self): self.__m33 = None
+        # Properties
+        m33 = property(getM33, setM33, delM33, "Property for m33")
+        def export(self, outfile, level, name_='XSDataMatrixDouble'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataMatrixDouble'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__m11 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m11>%e</m11>\n' % self.__m11))
+                else:
+                        warnEmptyAttribute("m11", "double")
+                if self.__m12 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m12>%e</m12>\n' % self.__m12))
+                else:
+                        warnEmptyAttribute("m12", "double")
+                if self.__m13 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m13>%e</m13>\n' % self.__m13))
+                else:
+                        warnEmptyAttribute("m13", "double")
+                if self.__m21 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m21>%e</m21>\n' % self.__m21))
+                else:
+                        warnEmptyAttribute("m21", "double")
+                if self.__m22 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m22>%e</m22>\n' % self.__m22))
+                else:
+                        warnEmptyAttribute("m22", "double")
+                if self.__m23 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m23>%e</m23>\n' % self.__m23))
+                else:
+                        warnEmptyAttribute("m23", "double")
+                if self.__m31 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m31>%e</m31>\n' % self.__m31))
+                else:
+                        warnEmptyAttribute("m31", "double")
+                if self.__m32 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m32>%e</m32>\n' % self.__m32))
+                else:
+                        warnEmptyAttribute("m32", "double")
+                if self.__m33 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m33>%e</m33>\n' % self.__m33))
+                else:
+                        warnEmptyAttribute("m33", "double")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm11':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m11 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm12':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m12 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm13':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m13 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm21':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m21 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm22':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m22 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm23':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m23 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm31':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m31 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm32':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m32 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm33':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__m33 = fval_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataMatrixDouble" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataMatrixDouble' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataMatrixDouble is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataMatrixDouble.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataMatrixDouble()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataMatrixDouble" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataMatrixDouble()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataMatrixDouble
 
 class XSDataMatrixInteger(XSData):
-	"""These are compound object used for linear algebra operations."""
-	def __init__(self, m33=None, m32=None, m31=None, m23=None, m22=None, m21=None, m13=None, m12=None, m11=None):
-		XSData.__init__(self, )
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m11, "integer")
-		self.__m11 = m11
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m12, "integer")
-		self.__m12 = m12
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m13, "integer")
-		self.__m13 = m13
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m21, "integer")
-		self.__m21 = m21
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m22, "integer")
-		self.__m22 = m22
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m23, "integer")
-		self.__m23 = m23
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m31, "integer")
-		self.__m31 = m31
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m32, "integer")
-		self.__m32 = m32
-		checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m33, "integer")
-		self.__m33 = m33
-	def getM11(self): return self.__m11
-	def setM11(self, m11):
-		checkType("XSDataMatrixInteger", "setM11", m11, "integer")
-		self.__m11 = m11
-	def delM11(self): self.__m11 = None
-	# Properties
-	m11 = property(getM11, setM11, delM11, "Property for m11")
-	def getM12(self): return self.__m12
-	def setM12(self, m12):
-		checkType("XSDataMatrixInteger", "setM12", m12, "integer")
-		self.__m12 = m12
-	def delM12(self): self.__m12 = None
-	# Properties
-	m12 = property(getM12, setM12, delM12, "Property for m12")
-	def getM13(self): return self.__m13
-	def setM13(self, m13):
-		checkType("XSDataMatrixInteger", "setM13", m13, "integer")
-		self.__m13 = m13
-	def delM13(self): self.__m13 = None
-	# Properties
-	m13 = property(getM13, setM13, delM13, "Property for m13")
-	def getM21(self): return self.__m21
-	def setM21(self, m21):
-		checkType("XSDataMatrixInteger", "setM21", m21, "integer")
-		self.__m21 = m21
-	def delM21(self): self.__m21 = None
-	# Properties
-	m21 = property(getM21, setM21, delM21, "Property for m21")
-	def getM22(self): return self.__m22
-	def setM22(self, m22):
-		checkType("XSDataMatrixInteger", "setM22", m22, "integer")
-		self.__m22 = m22
-	def delM22(self): self.__m22 = None
-	# Properties
-	m22 = property(getM22, setM22, delM22, "Property for m22")
-	def getM23(self): return self.__m23
-	def setM23(self, m23):
-		checkType("XSDataMatrixInteger", "setM23", m23, "integer")
-		self.__m23 = m23
-	def delM23(self): self.__m23 = None
-	# Properties
-	m23 = property(getM23, setM23, delM23, "Property for m23")
-	def getM31(self): return self.__m31
-	def setM31(self, m31):
-		checkType("XSDataMatrixInteger", "setM31", m31, "integer")
-		self.__m31 = m31
-	def delM31(self): self.__m31 = None
-	# Properties
-	m31 = property(getM31, setM31, delM31, "Property for m31")
-	def getM32(self): return self.__m32
-	def setM32(self, m32):
-		checkType("XSDataMatrixInteger", "setM32", m32, "integer")
-		self.__m32 = m32
-	def delM32(self): self.__m32 = None
-	# Properties
-	m32 = property(getM32, setM32, delM32, "Property for m32")
-	def getM33(self): return self.__m33
-	def setM33(self, m33):
-		checkType("XSDataMatrixInteger", "setM33", m33, "integer")
-		self.__m33 = m33
-	def delM33(self): self.__m33 = None
-	# Properties
-	m33 = property(getM33, setM33, delM33, "Property for m33")
-	def export(self, outfile, level, name_='XSDataMatrixInteger'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataMatrixInteger'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__m11 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m11>%d</m11>\n' % self.__m11))
-		else:
-			warnEmptyAttribute("m11", "integer")
-		if self.__m12 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m12>%d</m12>\n' % self.__m12))
-		else:
-			warnEmptyAttribute("m12", "integer")
-		if self.__m13 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m13>%d</m13>\n' % self.__m13))
-		else:
-			warnEmptyAttribute("m13", "integer")
-		if self.__m21 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m21>%d</m21>\n' % self.__m21))
-		else:
-			warnEmptyAttribute("m21", "integer")
-		if self.__m22 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m22>%d</m22>\n' % self.__m22))
-		else:
-			warnEmptyAttribute("m22", "integer")
-		if self.__m23 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m23>%d</m23>\n' % self.__m23))
-		else:
-			warnEmptyAttribute("m23", "integer")
-		if self.__m31 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m31>%d</m31>\n' % self.__m31))
-		else:
-			warnEmptyAttribute("m31", "integer")
-		if self.__m32 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m32>%d</m32>\n' % self.__m32))
-		else:
-			warnEmptyAttribute("m32", "integer")
-		if self.__m33 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<m33>%d</m33>\n' % self.__m33))
-		else:
-			warnEmptyAttribute("m33", "integer")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm11':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m11 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm12':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m12 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm13':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m13 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm21':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m21 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm22':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m22 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm23':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m23 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm31':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m31 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm32':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m32 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'm33':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__m33 = ival_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataMatrixInteger" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataMatrixInteger' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataMatrixInteger is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataMatrixInteger.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataMatrixInteger()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataMatrixInteger" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataMatrixInteger()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These are compound object used for linear algebra operations."""
+        def __init__(self, m33=None, m32=None, m31=None, m23=None, m22=None, m21=None, m13=None, m12=None, m11=None):
+                XSData.__init__(self, )
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m11, "integer")
+                self.__m11 = m11
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m12, "integer")
+                self.__m12 = m12
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m13, "integer")
+                self.__m13 = m13
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m21, "integer")
+                self.__m21 = m21
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m22, "integer")
+                self.__m22 = m22
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m23, "integer")
+                self.__m23 = m23
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m31, "integer")
+                self.__m31 = m31
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m32, "integer")
+                self.__m32 = m32
+                checkType("XSDataMatrixInteger", "Constructor of XSDataMatrixInteger", m33, "integer")
+                self.__m33 = m33
+        def getM11(self): return self.__m11
+        def setM11(self, m11):
+                checkType("XSDataMatrixInteger", "setM11", m11, "integer")
+                self.__m11 = m11
+        def delM11(self): self.__m11 = None
+        # Properties
+        m11 = property(getM11, setM11, delM11, "Property for m11")
+        def getM12(self): return self.__m12
+        def setM12(self, m12):
+                checkType("XSDataMatrixInteger", "setM12", m12, "integer")
+                self.__m12 = m12
+        def delM12(self): self.__m12 = None
+        # Properties
+        m12 = property(getM12, setM12, delM12, "Property for m12")
+        def getM13(self): return self.__m13
+        def setM13(self, m13):
+                checkType("XSDataMatrixInteger", "setM13", m13, "integer")
+                self.__m13 = m13
+        def delM13(self): self.__m13 = None
+        # Properties
+        m13 = property(getM13, setM13, delM13, "Property for m13")
+        def getM21(self): return self.__m21
+        def setM21(self, m21):
+                checkType("XSDataMatrixInteger", "setM21", m21, "integer")
+                self.__m21 = m21
+        def delM21(self): self.__m21 = None
+        # Properties
+        m21 = property(getM21, setM21, delM21, "Property for m21")
+        def getM22(self): return self.__m22
+        def setM22(self, m22):
+                checkType("XSDataMatrixInteger", "setM22", m22, "integer")
+                self.__m22 = m22
+        def delM22(self): self.__m22 = None
+        # Properties
+        m22 = property(getM22, setM22, delM22, "Property for m22")
+        def getM23(self): return self.__m23
+        def setM23(self, m23):
+                checkType("XSDataMatrixInteger", "setM23", m23, "integer")
+                self.__m23 = m23
+        def delM23(self): self.__m23 = None
+        # Properties
+        m23 = property(getM23, setM23, delM23, "Property for m23")
+        def getM31(self): return self.__m31
+        def setM31(self, m31):
+                checkType("XSDataMatrixInteger", "setM31", m31, "integer")
+                self.__m31 = m31
+        def delM31(self): self.__m31 = None
+        # Properties
+        m31 = property(getM31, setM31, delM31, "Property for m31")
+        def getM32(self): return self.__m32
+        def setM32(self, m32):
+                checkType("XSDataMatrixInteger", "setM32", m32, "integer")
+                self.__m32 = m32
+        def delM32(self): self.__m32 = None
+        # Properties
+        m32 = property(getM32, setM32, delM32, "Property for m32")
+        def getM33(self): return self.__m33
+        def setM33(self, m33):
+                checkType("XSDataMatrixInteger", "setM33", m33, "integer")
+                self.__m33 = m33
+        def delM33(self): self.__m33 = None
+        # Properties
+        m33 = property(getM33, setM33, delM33, "Property for m33")
+        def export(self, outfile, level, name_='XSDataMatrixInteger'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataMatrixInteger'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__m11 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m11>%d</m11>\n' % self.__m11))
+                else:
+                        warnEmptyAttribute("m11", "integer")
+                if self.__m12 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m12>%d</m12>\n' % self.__m12))
+                else:
+                        warnEmptyAttribute("m12", "integer")
+                if self.__m13 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m13>%d</m13>\n' % self.__m13))
+                else:
+                        warnEmptyAttribute("m13", "integer")
+                if self.__m21 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m21>%d</m21>\n' % self.__m21))
+                else:
+                        warnEmptyAttribute("m21", "integer")
+                if self.__m22 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m22>%d</m22>\n' % self.__m22))
+                else:
+                        warnEmptyAttribute("m22", "integer")
+                if self.__m23 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m23>%d</m23>\n' % self.__m23))
+                else:
+                        warnEmptyAttribute("m23", "integer")
+                if self.__m31 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m31>%d</m31>\n' % self.__m31))
+                else:
+                        warnEmptyAttribute("m31", "integer")
+                if self.__m32 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m32>%d</m32>\n' % self.__m32))
+                else:
+                        warnEmptyAttribute("m32", "integer")
+                if self.__m33 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<m33>%d</m33>\n' % self.__m33))
+                else:
+                        warnEmptyAttribute("m33", "integer")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm11':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m11 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm12':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m12 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm13':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m13 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm21':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m21 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm22':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m22 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm23':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m23 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm31':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m31 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm32':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m32 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'm33':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__m33 = ival_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataMatrixInteger" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataMatrixInteger' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataMatrixInteger is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataMatrixInteger.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataMatrixInteger()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataMatrixInteger" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataMatrixInteger()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataMatrixInteger
 
 class XSDataString(XSData):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None):
-		XSData.__init__(self, )
-		checkType("XSDataString", "Constructor of XSDataString", value, "string")
-		self.__value = value
-	def getValue(self): return self.__value
-	def setValue(self, value):
-		checkType("XSDataString", "setValue", value, "string")
-		self.__value = value
-	def delValue(self): self.__value = None
-	# Properties
-	value = property(getValue, setValue, delValue, "Property for value")
-	def export(self, outfile, level, name_='XSDataString'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataString'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__value is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<value>%s</value>\n' % self.__value))
-		else:
-			warnEmptyAttribute("value", "string")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'value':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self.__value = value_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataString" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataString' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataString is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataString.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataString()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataString" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataString()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None):
+                XSData.__init__(self, )
+                checkType("XSDataString", "Constructor of XSDataString", value, "string")
+                self.__value = value
+        def getValue(self): return self.__value
+        def setValue(self, value):
+                checkType("XSDataString", "setValue", value, "string")
+                self.__value = value
+        def delValue(self): self.__value = None
+        # Properties
+        value = property(getValue, setValue, delValue, "Property for value")
+        def export(self, outfile, level, name_='XSDataString'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataString'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__value is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<value>%s</value>\n' % self.__value))
+                else:
+                        warnEmptyAttribute("value", "string")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'value':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self.__value = value_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataString" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataString' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataString is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataString.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataString()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataString" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataString()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataString
 
 class XSDataMessage(XSData):
-	"""This message class is used (amongst other messages) for warning and error messages."""
-	def __init__(self, type=None, text=None, level=None, debuginfo=None):
-		XSData.__init__(self, )
-		checkType("XSDataMessage", "Constructor of XSDataMessage", debuginfo, "XSDataString")
-		self.__debuginfo = debuginfo
-		checkType("XSDataMessage", "Constructor of XSDataMessage", level, "XSDataString")
-		self.__level = level
-		checkType("XSDataMessage", "Constructor of XSDataMessage", text, "XSDataString")
-		self.__text = text
-		checkType("XSDataMessage", "Constructor of XSDataMessage", type, "XSDataString")
-		self.__type = type
-	def getDebuginfo(self): return self.__debuginfo
-	def setDebuginfo(self, debuginfo):
-		checkType("XSDataMessage", "setDebuginfo", debuginfo, "XSDataString")
-		self.__debuginfo = debuginfo
-	def delDebuginfo(self): self.__debuginfo = None
-	# Properties
-	debuginfo = property(getDebuginfo, setDebuginfo, delDebuginfo, "Property for debuginfo")
-	def getLevel(self): return self.__level
-	def setLevel(self, level):
-		checkType("XSDataMessage", "setLevel", level, "XSDataString")
-		self.__level = level
-	def delLevel(self): self.__level = None
-	# Properties
-	level = property(getLevel, setLevel, delLevel, "Property for level")
-	def getText(self): return self.__text
-	def setText(self, text):
-		checkType("XSDataMessage", "setText", text, "XSDataString")
-		self.__text = text
-	def delText(self): self.__text = None
-	# Properties
-	text = property(getText, setText, delText, "Property for text")
-	def getType(self): return self.__type
-	def setType(self, type):
-		checkType("XSDataMessage", "setType", type, "XSDataString")
-		self.__type = type
-	def delType(self): self.__type = None
-	# Properties
-	type = property(getType, setType, delType, "Property for type")
-	def export(self, outfile, level, name_='XSDataMessage'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataMessage'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__debuginfo is not None:
-			self.debuginfo.export(outfile, level, name_='debuginfo')
-		else:
-			warnEmptyAttribute("debuginfo", "XSDataString")
-		if self.__level is not None:
-			self.level.export(outfile, level, name_='level')
-		else:
-			warnEmptyAttribute("level", "XSDataString")
-		if self.__text is not None:
-			self.text.export(outfile, level, name_='text')
-		else:
-			warnEmptyAttribute("text", "XSDataString")
-		if self.__type is not None:
-			self.type.export(outfile, level, name_='type')
-		else:
-			warnEmptyAttribute("type", "XSDataString")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'debuginfo':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setDebuginfo(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'level':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setLevel(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'text':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setText(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'type':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setType(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataMessage" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataMessage' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataMessage is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataMessage.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataMessage()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataMessage" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataMessage()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """This message class is used (amongst other messages) for warning and error messages."""
+        def __init__(self, type=None, text=None, level=None, debuginfo=None):
+                XSData.__init__(self, )
+                checkType("XSDataMessage", "Constructor of XSDataMessage", debuginfo, "XSDataString")
+                self.__debuginfo = debuginfo
+                checkType("XSDataMessage", "Constructor of XSDataMessage", level, "XSDataString")
+                self.__level = level
+                checkType("XSDataMessage", "Constructor of XSDataMessage", text, "XSDataString")
+                self.__text = text
+                checkType("XSDataMessage", "Constructor of XSDataMessage", type, "XSDataString")
+                self.__type = type
+        def getDebuginfo(self): return self.__debuginfo
+        def setDebuginfo(self, debuginfo):
+                checkType("XSDataMessage", "setDebuginfo", debuginfo, "XSDataString")
+                self.__debuginfo = debuginfo
+        def delDebuginfo(self): self.__debuginfo = None
+        # Properties
+        debuginfo = property(getDebuginfo, setDebuginfo, delDebuginfo, "Property for debuginfo")
+        def getLevel(self): return self.__level
+        def setLevel(self, level):
+                checkType("XSDataMessage", "setLevel", level, "XSDataString")
+                self.__level = level
+        def delLevel(self): self.__level = None
+        # Properties
+        level = property(getLevel, setLevel, delLevel, "Property for level")
+        def getText(self): return self.__text
+        def setText(self, text):
+                checkType("XSDataMessage", "setText", text, "XSDataString")
+                self.__text = text
+        def delText(self): self.__text = None
+        # Properties
+        text = property(getText, setText, delText, "Property for text")
+        def getType(self): return self.__type
+        def setType(self, type):
+                checkType("XSDataMessage", "setType", type, "XSDataString")
+                self.__type = type
+        def delType(self): self.__type = None
+        # Properties
+        type = property(getType, setType, delType, "Property for type")
+        def export(self, outfile, level, name_='XSDataMessage'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataMessage'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__debuginfo is not None:
+                        self.debuginfo.export(outfile, level, name_='debuginfo')
+                else:
+                        warnEmptyAttribute("debuginfo", "XSDataString")
+                if self.__level is not None:
+                        self.level.export(outfile, level, name_='level')
+                else:
+                        warnEmptyAttribute("level", "XSDataString")
+                if self.__text is not None:
+                        self.text.export(outfile, level, name_='text')
+                else:
+                        warnEmptyAttribute("text", "XSDataString")
+                if self.__type is not None:
+                        self.type.export(outfile, level, name_='type')
+                else:
+                        warnEmptyAttribute("type", "XSDataString")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'debuginfo':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setDebuginfo(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'level':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setLevel(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'text':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setText(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'type':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setType(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataMessage" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataMessage' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataMessage is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataMessage.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataMessage()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataMessage" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataMessage()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataMessage
 
 class XSDataStatus(XSData):
-	"""This class contains all data related to the execution of a plugin."""
-	def __init__(self, message=None, isSuccess=None, executiveSummary=None, executionInfo=None):
-		XSData.__init__(self, )
-		checkType("XSDataStatus", "Constructor of XSDataStatus", executionInfo, "XSDataExecutionInfo")
-		self.__executionInfo = executionInfo
-		checkType("XSDataStatus", "Constructor of XSDataStatus", executiveSummary, "XSDataString")
-		self.__executiveSummary = executiveSummary
-		checkType("XSDataStatus", "Constructor of XSDataStatus", isSuccess, "XSDataBoolean")
-		self.__isSuccess = isSuccess
-		checkType("XSDataStatus", "Constructor of XSDataStatus", message, "XSDataMessage")
-		self.__message = message
-	def getExecutionInfo(self): return self.__executionInfo
-	def setExecutionInfo(self, executionInfo):
-		checkType("XSDataStatus", "setExecutionInfo", executionInfo, "XSDataExecutionInfo")
-		self.__executionInfo = executionInfo
-	def delExecutionInfo(self): self.__executionInfo = None
-	# Properties
-	executionInfo = property(getExecutionInfo, setExecutionInfo, delExecutionInfo, "Property for executionInfo")
-	def getExecutiveSummary(self): return self.__executiveSummary
-	def setExecutiveSummary(self, executiveSummary):
-		checkType("XSDataStatus", "setExecutiveSummary", executiveSummary, "XSDataString")
-		self.__executiveSummary = executiveSummary
-	def delExecutiveSummary(self): self.__executiveSummary = None
-	# Properties
-	executiveSummary = property(getExecutiveSummary, setExecutiveSummary, delExecutiveSummary, "Property for executiveSummary")
-	def getIsSuccess(self): return self.__isSuccess
-	def setIsSuccess(self, isSuccess):
-		checkType("XSDataStatus", "setIsSuccess", isSuccess, "XSDataBoolean")
-		self.__isSuccess = isSuccess
-	def delIsSuccess(self): self.__isSuccess = None
-	# Properties
-	isSuccess = property(getIsSuccess, setIsSuccess, delIsSuccess, "Property for isSuccess")
-	def getMessage(self): return self.__message
-	def setMessage(self, message):
-		checkType("XSDataStatus", "setMessage", message, "XSDataMessage")
-		self.__message = message
-	def delMessage(self): self.__message = None
-	# Properties
-	message = property(getMessage, setMessage, delMessage, "Property for message")
-	def export(self, outfile, level, name_='XSDataStatus'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataStatus'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__executionInfo is not None:
-			self.executionInfo.export(outfile, level, name_='executionInfo')
-		if self.__executiveSummary is not None:
-			self.executiveSummary.export(outfile, level, name_='executiveSummary')
-		if self.__isSuccess is not None:
-			self.isSuccess.export(outfile, level, name_='isSuccess')
-		else:
-			warnEmptyAttribute("isSuccess", "XSDataBoolean")
-		if self.__message is not None:
-			self.message.export(outfile, level, name_='message')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'executionInfo':
-			obj_ = XSDataExecutionInfo()
-			obj_.build(child_)
-			self.setExecutionInfo(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'executiveSummary':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setExecutiveSummary(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'isSuccess':
-			obj_ = XSDataBoolean()
-			obj_.build(child_)
-			self.setIsSuccess(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'message':
-			obj_ = XSDataMessage()
-			obj_.build(child_)
-			self.setMessage(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataStatus" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataStatus' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataStatus is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataStatus.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataStatus()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataStatus" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataStatus()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """This class contains all data related to the execution of a plugin."""
+        def __init__(self, message=None, isSuccess=None, executiveSummary=None, executionInfo=None):
+                XSData.__init__(self, )
+                checkType("XSDataStatus", "Constructor of XSDataStatus", executionInfo, "XSDataExecutionInfo")
+                self.__executionInfo = executionInfo
+                checkType("XSDataStatus", "Constructor of XSDataStatus", executiveSummary, "XSDataString")
+                self.__executiveSummary = executiveSummary
+                checkType("XSDataStatus", "Constructor of XSDataStatus", isSuccess, "XSDataBoolean")
+                self.__isSuccess = isSuccess
+                checkType("XSDataStatus", "Constructor of XSDataStatus", message, "XSDataMessage")
+                self.__message = message
+        def getExecutionInfo(self): return self.__executionInfo
+        def setExecutionInfo(self, executionInfo):
+                checkType("XSDataStatus", "setExecutionInfo", executionInfo, "XSDataExecutionInfo")
+                self.__executionInfo = executionInfo
+        def delExecutionInfo(self): self.__executionInfo = None
+        # Properties
+        executionInfo = property(getExecutionInfo, setExecutionInfo, delExecutionInfo, "Property for executionInfo")
+        def getExecutiveSummary(self): return self.__executiveSummary
+        def setExecutiveSummary(self, executiveSummary):
+                checkType("XSDataStatus", "setExecutiveSummary", executiveSummary, "XSDataString")
+                self.__executiveSummary = executiveSummary
+        def delExecutiveSummary(self): self.__executiveSummary = None
+        # Properties
+        executiveSummary = property(getExecutiveSummary, setExecutiveSummary, delExecutiveSummary, "Property for executiveSummary")
+        def getIsSuccess(self): return self.__isSuccess
+        def setIsSuccess(self, isSuccess):
+                checkType("XSDataStatus", "setIsSuccess", isSuccess, "XSDataBoolean")
+                self.__isSuccess = isSuccess
+        def delIsSuccess(self): self.__isSuccess = None
+        # Properties
+        isSuccess = property(getIsSuccess, setIsSuccess, delIsSuccess, "Property for isSuccess")
+        def getMessage(self): return self.__message
+        def setMessage(self, message):
+                checkType("XSDataStatus", "setMessage", message, "XSDataMessage")
+                self.__message = message
+        def delMessage(self): self.__message = None
+        # Properties
+        message = property(getMessage, setMessage, delMessage, "Property for message")
+        def export(self, outfile, level, name_='XSDataStatus'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataStatus'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__executionInfo is not None:
+                        self.executionInfo.export(outfile, level, name_='executionInfo')
+                if self.__executiveSummary is not None:
+                        self.executiveSummary.export(outfile, level, name_='executiveSummary')
+                if self.__isSuccess is not None:
+                        self.isSuccess.export(outfile, level, name_='isSuccess')
+                else:
+                        warnEmptyAttribute("isSuccess", "XSDataBoolean")
+                if self.__message is not None:
+                        self.message.export(outfile, level, name_='message')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'executionInfo':
+                        obj_ = XSDataExecutionInfo()
+                        obj_.build(child_)
+                        self.setExecutionInfo(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'executiveSummary':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setExecutiveSummary(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'isSuccess':
+                        obj_ = XSDataBoolean()
+                        obj_.build(child_)
+                        self.setIsSuccess(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'message':
+                        obj_ = XSDataMessage()
+                        obj_.build(child_)
+                        self.setMessage(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataStatus" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataStatus' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataStatus is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataStatus.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataStatus()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataStatus" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataStatus()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataStatus
 
 class XSDataResult(XSData):
-	"""All plugin input and result classes should be derived from these two classes."""
-	def __init__(self, status=None):
-		XSData.__init__(self, )
-		checkType("XSDataResult", "Constructor of XSDataResult", status, "XSDataStatus")
-		self.__status = status
-	def getStatus(self): return self.__status
-	def setStatus(self, status):
-		checkType("XSDataResult", "setStatus", status, "XSDataStatus")
-		self.__status = status
-	def delStatus(self): self.__status = None
-	# Properties
-	status = property(getStatus, setStatus, delStatus, "Property for status")
-	def export(self, outfile, level, name_='XSDataResult'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataResult'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__status is not None:
-			self.status.export(outfile, level, name_='status')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'status':
-			obj_ = XSDataStatus()
-			obj_.build(child_)
-			self.setStatus(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataResult" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataResult' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataResult is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataResult.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataResult()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataResult" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataResult()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """All plugin input and result classes should be derived from these two classes."""
+        def __init__(self, status=None):
+                XSData.__init__(self, )
+                checkType("XSDataResult", "Constructor of XSDataResult", status, "XSDataStatus")
+                self.__status = status
+        def getStatus(self): return self.__status
+        def setStatus(self, status):
+                checkType("XSDataResult", "setStatus", status, "XSDataStatus")
+                self.__status = status
+        def delStatus(self): self.__status = None
+        # Properties
+        status = property(getStatus, setStatus, delStatus, "Property for status")
+        def export(self, outfile, level, name_='XSDataResult'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataResult'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__status is not None:
+                        self.status.export(outfile, level, name_='status')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'status':
+                        obj_ = XSDataStatus()
+                        obj_.build(child_)
+                        self.setStatus(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataResult" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataResult' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataResult is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataResult.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataResult()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataResult" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataResult()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataResult
 
 class XSDataRotation(XSData):
-	"""These are compound object used for linear algebra operations."""
-	def __init__(self, q3=None, q2=None, q1=None, q0=None):
-		XSData.__init__(self, )
-		checkType("XSDataRotation", "Constructor of XSDataRotation", q0, "double")
-		self.__q0 = q0
-		checkType("XSDataRotation", "Constructor of XSDataRotation", q1, "double")
-		self.__q1 = q1
-		checkType("XSDataRotation", "Constructor of XSDataRotation", q2, "double")
-		self.__q2 = q2
-		checkType("XSDataRotation", "Constructor of XSDataRotation", q3, "double")
-		self.__q3 = q3
-	def getQ0(self): return self.__q0
-	def setQ0(self, q0):
-		checkType("XSDataRotation", "setQ0", q0, "double")
-		self.__q0 = q0
-	def delQ0(self): self.__q0 = None
-	# Properties
-	q0 = property(getQ0, setQ0, delQ0, "Property for q0")
-	def getQ1(self): return self.__q1
-	def setQ1(self, q1):
-		checkType("XSDataRotation", "setQ1", q1, "double")
-		self.__q1 = q1
-	def delQ1(self): self.__q1 = None
-	# Properties
-	q1 = property(getQ1, setQ1, delQ1, "Property for q1")
-	def getQ2(self): return self.__q2
-	def setQ2(self, q2):
-		checkType("XSDataRotation", "setQ2", q2, "double")
-		self.__q2 = q2
-	def delQ2(self): self.__q2 = None
-	# Properties
-	q2 = property(getQ2, setQ2, delQ2, "Property for q2")
-	def getQ3(self): return self.__q3
-	def setQ3(self, q3):
-		checkType("XSDataRotation", "setQ3", q3, "double")
-		self.__q3 = q3
-	def delQ3(self): self.__q3 = None
-	# Properties
-	q3 = property(getQ3, setQ3, delQ3, "Property for q3")
-	def export(self, outfile, level, name_='XSDataRotation'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataRotation'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__q0 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<q0>%e</q0>\n' % self.__q0))
-		else:
-			warnEmptyAttribute("q0", "double")
-		if self.__q1 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<q1>%e</q1>\n' % self.__q1))
-		else:
-			warnEmptyAttribute("q1", "double")
-		if self.__q2 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<q2>%e</q2>\n' % self.__q2))
-		else:
-			warnEmptyAttribute("q2", "double")
-		if self.__q3 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<q3>%e</q3>\n' % self.__q3))
-		else:
-			warnEmptyAttribute("q3", "double")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'q0':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__q0 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'q1':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__q1 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'q2':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__q2 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'q3':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__q3 = fval_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataRotation" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataRotation' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataRotation is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataRotation.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataRotation()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataRotation" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataRotation()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These are compound object used for linear algebra operations."""
+        def __init__(self, q3=None, q2=None, q1=None, q0=None):
+                XSData.__init__(self, )
+                checkType("XSDataRotation", "Constructor of XSDataRotation", q0, "double")
+                self.__q0 = q0
+                checkType("XSDataRotation", "Constructor of XSDataRotation", q1, "double")
+                self.__q1 = q1
+                checkType("XSDataRotation", "Constructor of XSDataRotation", q2, "double")
+                self.__q2 = q2
+                checkType("XSDataRotation", "Constructor of XSDataRotation", q3, "double")
+                self.__q3 = q3
+        def getQ0(self): return self.__q0
+        def setQ0(self, q0):
+                checkType("XSDataRotation", "setQ0", q0, "double")
+                self.__q0 = q0
+        def delQ0(self): self.__q0 = None
+        # Properties
+        q0 = property(getQ0, setQ0, delQ0, "Property for q0")
+        def getQ1(self): return self.__q1
+        def setQ1(self, q1):
+                checkType("XSDataRotation", "setQ1", q1, "double")
+                self.__q1 = q1
+        def delQ1(self): self.__q1 = None
+        # Properties
+        q1 = property(getQ1, setQ1, delQ1, "Property for q1")
+        def getQ2(self): return self.__q2
+        def setQ2(self, q2):
+                checkType("XSDataRotation", "setQ2", q2, "double")
+                self.__q2 = q2
+        def delQ2(self): self.__q2 = None
+        # Properties
+        q2 = property(getQ2, setQ2, delQ2, "Property for q2")
+        def getQ3(self): return self.__q3
+        def setQ3(self, q3):
+                checkType("XSDataRotation", "setQ3", q3, "double")
+                self.__q3 = q3
+        def delQ3(self): self.__q3 = None
+        # Properties
+        q3 = property(getQ3, setQ3, delQ3, "Property for q3")
+        def export(self, outfile, level, name_='XSDataRotation'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataRotation'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__q0 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<q0>%e</q0>\n' % self.__q0))
+                else:
+                        warnEmptyAttribute("q0", "double")
+                if self.__q1 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<q1>%e</q1>\n' % self.__q1))
+                else:
+                        warnEmptyAttribute("q1", "double")
+                if self.__q2 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<q2>%e</q2>\n' % self.__q2))
+                else:
+                        warnEmptyAttribute("q2", "double")
+                if self.__q3 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<q3>%e</q3>\n' % self.__q3))
+                else:
+                        warnEmptyAttribute("q3", "double")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'q0':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__q0 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'q1':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__q1 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'q2':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__q2 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'q3':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__q3 = fval_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataRotation" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataRotation' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataRotation is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataRotation.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataRotation()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataRotation" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataRotation()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataRotation
 
 class XSDataSize(XSData):
-	"""These objects use the simple objects described above to create useful structures for the rest for the data model."""
-	def __init__(self, z=None, y=None, x=None):
-		XSData.__init__(self, )
-		checkType("XSDataSize", "Constructor of XSDataSize", x, "XSDataLength")
-		self.__x = x
-		checkType("XSDataSize", "Constructor of XSDataSize", y, "XSDataLength")
-		self.__y = y
-		checkType("XSDataSize", "Constructor of XSDataSize", z, "XSDataLength")
-		self.__z = z
-	def getX(self): return self.__x
-	def setX(self, x):
-		checkType("XSDataSize", "setX", x, "XSDataLength")
-		self.__x = x
-	def delX(self): self.__x = None
-	# Properties
-	x = property(getX, setX, delX, "Property for x")
-	def getY(self): return self.__y
-	def setY(self, y):
-		checkType("XSDataSize", "setY", y, "XSDataLength")
-		self.__y = y
-	def delY(self): self.__y = None
-	# Properties
-	y = property(getY, setY, delY, "Property for y")
-	def getZ(self): return self.__z
-	def setZ(self, z):
-		checkType("XSDataSize", "setZ", z, "XSDataLength")
-		self.__z = z
-	def delZ(self): self.__z = None
-	# Properties
-	z = property(getZ, setZ, delZ, "Property for z")
-	def export(self, outfile, level, name_='XSDataSize'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataSize'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__x is not None:
-			self.x.export(outfile, level, name_='x')
-		else:
-			warnEmptyAttribute("x", "XSDataLength")
-		if self.__y is not None:
-			self.y.export(outfile, level, name_='y')
-		else:
-			warnEmptyAttribute("y", "XSDataLength")
-		if self.__z is not None:
-			self.z.export(outfile, level, name_='z')
-		else:
-			warnEmptyAttribute("z", "XSDataLength")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'x':
-			obj_ = XSDataLength()
-			obj_.build(child_)
-			self.setX(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'y':
-			obj_ = XSDataLength()
-			obj_.build(child_)
-			self.setY(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'z':
-			obj_ = XSDataLength()
-			obj_.build(child_)
-			self.setZ(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataSize" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataSize' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataSize is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataSize.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataSize()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataSize" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataSize()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These objects use the simple objects described above to create useful structures for the rest for the data model."""
+        def __init__(self, z=None, y=None, x=None):
+                XSData.__init__(self, )
+                checkType("XSDataSize", "Constructor of XSDataSize", x, "XSDataLength")
+                self.__x = x
+                checkType("XSDataSize", "Constructor of XSDataSize", y, "XSDataLength")
+                self.__y = y
+                checkType("XSDataSize", "Constructor of XSDataSize", z, "XSDataLength")
+                self.__z = z
+        def getX(self): return self.__x
+        def setX(self, x):
+                checkType("XSDataSize", "setX", x, "XSDataLength")
+                self.__x = x
+        def delX(self): self.__x = None
+        # Properties
+        x = property(getX, setX, delX, "Property for x")
+        def getY(self): return self.__y
+        def setY(self, y):
+                checkType("XSDataSize", "setY", y, "XSDataLength")
+                self.__y = y
+        def delY(self): self.__y = None
+        # Properties
+        y = property(getY, setY, delY, "Property for y")
+        def getZ(self): return self.__z
+        def setZ(self, z):
+                checkType("XSDataSize", "setZ", z, "XSDataLength")
+                self.__z = z
+        def delZ(self): self.__z = None
+        # Properties
+        z = property(getZ, setZ, delZ, "Property for z")
+        def export(self, outfile, level, name_='XSDataSize'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataSize'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__x is not None:
+                        self.x.export(outfile, level, name_='x')
+                else:
+                        warnEmptyAttribute("x", "XSDataLength")
+                if self.__y is not None:
+                        self.y.export(outfile, level, name_='y')
+                else:
+                        warnEmptyAttribute("y", "XSDataLength")
+                if self.__z is not None:
+                        self.z.export(outfile, level, name_='z')
+                else:
+                        warnEmptyAttribute("z", "XSDataLength")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'x':
+                        obj_ = XSDataLength()
+                        obj_.build(child_)
+                        self.setX(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'y':
+                        obj_ = XSDataLength()
+                        obj_.build(child_)
+                        self.setY(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'z':
+                        obj_ = XSDataLength()
+                        obj_.build(child_)
+                        self.setZ(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataSize" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataSize' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataSize is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataSize.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataSize()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataSize" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataSize()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataSize
 
 class XSDataSysteminfo(XSData):
-	"""This class contains information about the system executing the plugin."""
-	def __init__(self, virtualMachine=None, userName=None, operatingSystemType=None, operatingSystem=None, hostName=None, hostIP=None, compiler=None):
-		XSData.__init__(self, )
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", compiler, "XSDataString")
-		self.__compiler = compiler
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", hostIP, "XSDataString")
-		self.__hostIP = hostIP
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", hostName, "XSDataString")
-		self.__hostName = hostName
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", operatingSystem, "XSDataString")
-		self.__operatingSystem = operatingSystem
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", operatingSystemType, "XSDataString")
-		self.__operatingSystemType = operatingSystemType
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", userName, "XSDataString")
-		self.__userName = userName
-		checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", virtualMachine, "XSDataString")
-		self.__virtualMachine = virtualMachine
-	def getCompiler(self): return self.__compiler
-	def setCompiler(self, compiler):
-		checkType("XSDataSysteminfo", "setCompiler", compiler, "XSDataString")
-		self.__compiler = compiler
-	def delCompiler(self): self.__compiler = None
-	# Properties
-	compiler = property(getCompiler, setCompiler, delCompiler, "Property for compiler")
-	def getHostIP(self): return self.__hostIP
-	def setHostIP(self, hostIP):
-		checkType("XSDataSysteminfo", "setHostIP", hostIP, "XSDataString")
-		self.__hostIP = hostIP
-	def delHostIP(self): self.__hostIP = None
-	# Properties
-	hostIP = property(getHostIP, setHostIP, delHostIP, "Property for hostIP")
-	def getHostName(self): return self.__hostName
-	def setHostName(self, hostName):
-		checkType("XSDataSysteminfo", "setHostName", hostName, "XSDataString")
-		self.__hostName = hostName
-	def delHostName(self): self.__hostName = None
-	# Properties
-	hostName = property(getHostName, setHostName, delHostName, "Property for hostName")
-	def getOperatingSystem(self): return self.__operatingSystem
-	def setOperatingSystem(self, operatingSystem):
-		checkType("XSDataSysteminfo", "setOperatingSystem", operatingSystem, "XSDataString")
-		self.__operatingSystem = operatingSystem
-	def delOperatingSystem(self): self.__operatingSystem = None
-	# Properties
-	operatingSystem = property(getOperatingSystem, setOperatingSystem, delOperatingSystem, "Property for operatingSystem")
-	def getOperatingSystemType(self): return self.__operatingSystemType
-	def setOperatingSystemType(self, operatingSystemType):
-		checkType("XSDataSysteminfo", "setOperatingSystemType", operatingSystemType, "XSDataString")
-		self.__operatingSystemType = operatingSystemType
-	def delOperatingSystemType(self): self.__operatingSystemType = None
-	# Properties
-	operatingSystemType = property(getOperatingSystemType, setOperatingSystemType, delOperatingSystemType, "Property for operatingSystemType")
-	def getUserName(self): return self.__userName
-	def setUserName(self, userName):
-		checkType("XSDataSysteminfo", "setUserName", userName, "XSDataString")
-		self.__userName = userName
-	def delUserName(self): self.__userName = None
-	# Properties
-	userName = property(getUserName, setUserName, delUserName, "Property for userName")
-	def getVirtualMachine(self): return self.__virtualMachine
-	def setVirtualMachine(self, virtualMachine):
-		checkType("XSDataSysteminfo", "setVirtualMachine", virtualMachine, "XSDataString")
-		self.__virtualMachine = virtualMachine
-	def delVirtualMachine(self): self.__virtualMachine = None
-	# Properties
-	virtualMachine = property(getVirtualMachine, setVirtualMachine, delVirtualMachine, "Property for virtualMachine")
-	def export(self, outfile, level, name_='XSDataSysteminfo'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataSysteminfo'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__compiler is not None:
-			self.compiler.export(outfile, level, name_='compiler')
-		else:
-			warnEmptyAttribute("compiler", "XSDataString")
-		if self.__hostIP is not None:
-			self.hostIP.export(outfile, level, name_='hostIP')
-		else:
-			warnEmptyAttribute("hostIP", "XSDataString")
-		if self.__hostName is not None:
-			self.hostName.export(outfile, level, name_='hostName')
-		else:
-			warnEmptyAttribute("hostName", "XSDataString")
-		if self.__operatingSystem is not None:
-			self.operatingSystem.export(outfile, level, name_='operatingSystem')
-		else:
-			warnEmptyAttribute("operatingSystem", "XSDataString")
-		if self.__operatingSystemType is not None:
-			self.operatingSystemType.export(outfile, level, name_='operatingSystemType')
-		else:
-			warnEmptyAttribute("operatingSystemType", "XSDataString")
-		if self.__userName is not None:
-			self.userName.export(outfile, level, name_='userName')
-		else:
-			warnEmptyAttribute("userName", "XSDataString")
-		if self.__virtualMachine is not None:
-			self.virtualMachine.export(outfile, level, name_='virtualMachine')
-		else:
-			warnEmptyAttribute("virtualMachine", "XSDataString")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'compiler':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setCompiler(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'hostIP':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setHostIP(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'hostName':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setHostName(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'operatingSystem':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setOperatingSystem(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'operatingSystemType':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setOperatingSystemType(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'userName':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setUserName(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'virtualMachine':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setVirtualMachine(obj_)
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataSysteminfo" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataSysteminfo' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataSysteminfo is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataSysteminfo.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataSysteminfo()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataSysteminfo" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataSysteminfo()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """This class contains information about the system executing the plugin."""
+        def __init__(self, virtualMachine=None, userName=None, operatingSystemType=None, operatingSystem=None, hostName=None, hostIP=None, compiler=None):
+                XSData.__init__(self, )
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", compiler, "XSDataString")
+                self.__compiler = compiler
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", hostIP, "XSDataString")
+                self.__hostIP = hostIP
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", hostName, "XSDataString")
+                self.__hostName = hostName
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", operatingSystem, "XSDataString")
+                self.__operatingSystem = operatingSystem
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", operatingSystemType, "XSDataString")
+                self.__operatingSystemType = operatingSystemType
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", userName, "XSDataString")
+                self.__userName = userName
+                checkType("XSDataSysteminfo", "Constructor of XSDataSysteminfo", virtualMachine, "XSDataString")
+                self.__virtualMachine = virtualMachine
+        def getCompiler(self): return self.__compiler
+        def setCompiler(self, compiler):
+                checkType("XSDataSysteminfo", "setCompiler", compiler, "XSDataString")
+                self.__compiler = compiler
+        def delCompiler(self): self.__compiler = None
+        # Properties
+        compiler = property(getCompiler, setCompiler, delCompiler, "Property for compiler")
+        def getHostIP(self): return self.__hostIP
+        def setHostIP(self, hostIP):
+                checkType("XSDataSysteminfo", "setHostIP", hostIP, "XSDataString")
+                self.__hostIP = hostIP
+        def delHostIP(self): self.__hostIP = None
+        # Properties
+        hostIP = property(getHostIP, setHostIP, delHostIP, "Property for hostIP")
+        def getHostName(self): return self.__hostName
+        def setHostName(self, hostName):
+                checkType("XSDataSysteminfo", "setHostName", hostName, "XSDataString")
+                self.__hostName = hostName
+        def delHostName(self): self.__hostName = None
+        # Properties
+        hostName = property(getHostName, setHostName, delHostName, "Property for hostName")
+        def getOperatingSystem(self): return self.__operatingSystem
+        def setOperatingSystem(self, operatingSystem):
+                checkType("XSDataSysteminfo", "setOperatingSystem", operatingSystem, "XSDataString")
+                self.__operatingSystem = operatingSystem
+        def delOperatingSystem(self): self.__operatingSystem = None
+        # Properties
+        operatingSystem = property(getOperatingSystem, setOperatingSystem, delOperatingSystem, "Property for operatingSystem")
+        def getOperatingSystemType(self): return self.__operatingSystemType
+        def setOperatingSystemType(self, operatingSystemType):
+                checkType("XSDataSysteminfo", "setOperatingSystemType", operatingSystemType, "XSDataString")
+                self.__operatingSystemType = operatingSystemType
+        def delOperatingSystemType(self): self.__operatingSystemType = None
+        # Properties
+        operatingSystemType = property(getOperatingSystemType, setOperatingSystemType, delOperatingSystemType, "Property for operatingSystemType")
+        def getUserName(self): return self.__userName
+        def setUserName(self, userName):
+                checkType("XSDataSysteminfo", "setUserName", userName, "XSDataString")
+                self.__userName = userName
+        def delUserName(self): self.__userName = None
+        # Properties
+        userName = property(getUserName, setUserName, delUserName, "Property for userName")
+        def getVirtualMachine(self): return self.__virtualMachine
+        def setVirtualMachine(self, virtualMachine):
+                checkType("XSDataSysteminfo", "setVirtualMachine", virtualMachine, "XSDataString")
+                self.__virtualMachine = virtualMachine
+        def delVirtualMachine(self): self.__virtualMachine = None
+        # Properties
+        virtualMachine = property(getVirtualMachine, setVirtualMachine, delVirtualMachine, "Property for virtualMachine")
+        def export(self, outfile, level, name_='XSDataSysteminfo'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataSysteminfo'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__compiler is not None:
+                        self.compiler.export(outfile, level, name_='compiler')
+                else:
+                        warnEmptyAttribute("compiler", "XSDataString")
+                if self.__hostIP is not None:
+                        self.hostIP.export(outfile, level, name_='hostIP')
+                else:
+                        warnEmptyAttribute("hostIP", "XSDataString")
+                if self.__hostName is not None:
+                        self.hostName.export(outfile, level, name_='hostName')
+                else:
+                        warnEmptyAttribute("hostName", "XSDataString")
+                if self.__operatingSystem is not None:
+                        self.operatingSystem.export(outfile, level, name_='operatingSystem')
+                else:
+                        warnEmptyAttribute("operatingSystem", "XSDataString")
+                if self.__operatingSystemType is not None:
+                        self.operatingSystemType.export(outfile, level, name_='operatingSystemType')
+                else:
+                        warnEmptyAttribute("operatingSystemType", "XSDataString")
+                if self.__userName is not None:
+                        self.userName.export(outfile, level, name_='userName')
+                else:
+                        warnEmptyAttribute("userName", "XSDataString")
+                if self.__virtualMachine is not None:
+                        self.virtualMachine.export(outfile, level, name_='virtualMachine')
+                else:
+                        warnEmptyAttribute("virtualMachine", "XSDataString")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'compiler':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setCompiler(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'hostIP':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setHostIP(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'hostName':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setHostName(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'operatingSystem':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setOperatingSystem(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'operatingSystemType':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setOperatingSystemType(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'userName':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setUserName(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'virtualMachine':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setVirtualMachine(obj_)
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataSysteminfo" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataSysteminfo' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataSysteminfo is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataSysteminfo.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataSysteminfo()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataSysteminfo" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataSysteminfo()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataSysteminfo
 
 class XSDataVectorDouble(XSData):
-	"""These are compound object used for linear algebra operations."""
-	def __init__(self, v3=None, v2=None, v1=None):
-		XSData.__init__(self, )
-		checkType("XSDataVectorDouble", "Constructor of XSDataVectorDouble", v1, "double")
-		self.__v1 = v1
-		checkType("XSDataVectorDouble", "Constructor of XSDataVectorDouble", v2, "double")
-		self.__v2 = v2
-		checkType("XSDataVectorDouble", "Constructor of XSDataVectorDouble", v3, "double")
-		self.__v3 = v3
-	def getV1(self): return self.__v1
-	def setV1(self, v1):
-		checkType("XSDataVectorDouble", "setV1", v1, "double")
-		self.__v1 = v1
-	def delV1(self): self.__v1 = None
-	# Properties
-	v1 = property(getV1, setV1, delV1, "Property for v1")
-	def getV2(self): return self.__v2
-	def setV2(self, v2):
-		checkType("XSDataVectorDouble", "setV2", v2, "double")
-		self.__v2 = v2
-	def delV2(self): self.__v2 = None
-	# Properties
-	v2 = property(getV2, setV2, delV2, "Property for v2")
-	def getV3(self): return self.__v3
-	def setV3(self, v3):
-		checkType("XSDataVectorDouble", "setV3", v3, "double")
-		self.__v3 = v3
-	def delV3(self): self.__v3 = None
-	# Properties
-	v3 = property(getV3, setV3, delV3, "Property for v3")
-	def export(self, outfile, level, name_='XSDataVectorDouble'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataVectorDouble'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__v1 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<v1>%e</v1>\n' % self.__v1))
-		else:
-			warnEmptyAttribute("v1", "double")
-		if self.__v2 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<v2>%e</v2>\n' % self.__v2))
-		else:
-			warnEmptyAttribute("v2", "double")
-		if self.__v3 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<v3>%e</v3>\n' % self.__v3))
-		else:
-			warnEmptyAttribute("v3", "double")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'v1':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__v1 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'v2':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__v2 = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'v3':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self.__v3 = fval_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataVectorDouble" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataVectorDouble' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataVectorDouble is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataVectorDouble.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataVectorDouble()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataVectorDouble" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataVectorDouble()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These are compound object used for linear algebra operations."""
+        def __init__(self, v3=None, v2=None, v1=None):
+                XSData.__init__(self, )
+                checkType("XSDataVectorDouble", "Constructor of XSDataVectorDouble", v1, "double")
+                self.__v1 = v1
+                checkType("XSDataVectorDouble", "Constructor of XSDataVectorDouble", v2, "double")
+                self.__v2 = v2
+                checkType("XSDataVectorDouble", "Constructor of XSDataVectorDouble", v3, "double")
+                self.__v3 = v3
+        def getV1(self): return self.__v1
+        def setV1(self, v1):
+                checkType("XSDataVectorDouble", "setV1", v1, "double")
+                self.__v1 = v1
+        def delV1(self): self.__v1 = None
+        # Properties
+        v1 = property(getV1, setV1, delV1, "Property for v1")
+        def getV2(self): return self.__v2
+        def setV2(self, v2):
+                checkType("XSDataVectorDouble", "setV2", v2, "double")
+                self.__v2 = v2
+        def delV2(self): self.__v2 = None
+        # Properties
+        v2 = property(getV2, setV2, delV2, "Property for v2")
+        def getV3(self): return self.__v3
+        def setV3(self, v3):
+                checkType("XSDataVectorDouble", "setV3", v3, "double")
+                self.__v3 = v3
+        def delV3(self): self.__v3 = None
+        # Properties
+        v3 = property(getV3, setV3, delV3, "Property for v3")
+        def export(self, outfile, level, name_='XSDataVectorDouble'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataVectorDouble'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__v1 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<v1>%e</v1>\n' % self.__v1))
+                else:
+                        warnEmptyAttribute("v1", "double")
+                if self.__v2 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<v2>%e</v2>\n' % self.__v2))
+                else:
+                        warnEmptyAttribute("v2", "double")
+                if self.__v3 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<v3>%e</v3>\n' % self.__v3))
+                else:
+                        warnEmptyAttribute("v3", "double")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'v1':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__v1 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'v2':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__v2 = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'v3':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self.__v3 = fval_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataVectorDouble" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataVectorDouble' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataVectorDouble is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataVectorDouble.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataVectorDouble()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataVectorDouble" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataVectorDouble()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataVectorDouble
 
 class XSDataVectorInteger(XSData):
-	"""These are compound object used for linear algebra operations."""
-	def __init__(self, v3=None, v2=None, v1=None):
-		XSData.__init__(self, )
-		checkType("XSDataVectorInteger", "Constructor of XSDataVectorInteger", v1, "integer")
-		self.__v1 = v1
-		checkType("XSDataVectorInteger", "Constructor of XSDataVectorInteger", v2, "integer")
-		self.__v2 = v2
-		checkType("XSDataVectorInteger", "Constructor of XSDataVectorInteger", v3, "integer")
-		self.__v3 = v3
-	def getV1(self): return self.__v1
-	def setV1(self, v1):
-		checkType("XSDataVectorInteger", "setV1", v1, "integer")
-		self.__v1 = v1
-	def delV1(self): self.__v1 = None
-	# Properties
-	v1 = property(getV1, setV1, delV1, "Property for v1")
-	def getV2(self): return self.__v2
-	def setV2(self, v2):
-		checkType("XSDataVectorInteger", "setV2", v2, "integer")
-		self.__v2 = v2
-	def delV2(self): self.__v2 = None
-	# Properties
-	v2 = property(getV2, setV2, delV2, "Property for v2")
-	def getV3(self): return self.__v3
-	def setV3(self, v3):
-		checkType("XSDataVectorInteger", "setV3", v3, "integer")
-		self.__v3 = v3
-	def delV3(self): self.__v3 = None
-	# Properties
-	v3 = property(getV3, setV3, delV3, "Property for v3")
-	def export(self, outfile, level, name_='XSDataVectorInteger'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataVectorInteger'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self.__v1 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<v1>%d</v1>\n' % self.__v1))
-		else:
-			warnEmptyAttribute("v1", "integer")
-		if self.__v2 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<v2>%d</v2>\n' % self.__v2))
-		else:
-			warnEmptyAttribute("v2", "integer")
-		if self.__v3 is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<v3>%d</v3>\n' % self.__v3))
-		else:
-			warnEmptyAttribute("v3", "integer")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'v1':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__v1 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'v2':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__v2 = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'v3':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self.__v3 = ival_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataVectorInteger" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataVectorInteger' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataVectorInteger is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataVectorInteger.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataVectorInteger()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataVectorInteger" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataVectorInteger()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These are compound object used for linear algebra operations."""
+        def __init__(self, v3=None, v2=None, v1=None):
+                XSData.__init__(self, )
+                checkType("XSDataVectorInteger", "Constructor of XSDataVectorInteger", v1, "integer")
+                self.__v1 = v1
+                checkType("XSDataVectorInteger", "Constructor of XSDataVectorInteger", v2, "integer")
+                self.__v2 = v2
+                checkType("XSDataVectorInteger", "Constructor of XSDataVectorInteger", v3, "integer")
+                self.__v3 = v3
+        def getV1(self): return self.__v1
+        def setV1(self, v1):
+                checkType("XSDataVectorInteger", "setV1", v1, "integer")
+                self.__v1 = v1
+        def delV1(self): self.__v1 = None
+        # Properties
+        v1 = property(getV1, setV1, delV1, "Property for v1")
+        def getV2(self): return self.__v2
+        def setV2(self, v2):
+                checkType("XSDataVectorInteger", "setV2", v2, "integer")
+                self.__v2 = v2
+        def delV2(self): self.__v2 = None
+        # Properties
+        v2 = property(getV2, setV2, delV2, "Property for v2")
+        def getV3(self): return self.__v3
+        def setV3(self, v3):
+                checkType("XSDataVectorInteger", "setV3", v3, "integer")
+                self.__v3 = v3
+        def delV3(self): self.__v3 = None
+        # Properties
+        v3 = property(getV3, setV3, delV3, "Property for v3")
+        def export(self, outfile, level, name_='XSDataVectorInteger'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataVectorInteger'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self.__v1 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<v1>%d</v1>\n' % self.__v1))
+                else:
+                        warnEmptyAttribute("v1", "integer")
+                if self.__v2 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<v2>%d</v2>\n' % self.__v2))
+                else:
+                        warnEmptyAttribute("v2", "integer")
+                if self.__v3 is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<v3>%d</v3>\n' % self.__v3))
+                else:
+                        warnEmptyAttribute("v3", "integer")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'v1':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__v1 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'v2':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__v2 = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'v3':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self.__v3 = ival_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataVectorInteger" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataVectorInteger' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataVectorInteger is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataVectorInteger.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataVectorInteger()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataVectorInteger" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataVectorInteger()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataVectorInteger
 
 class XSDataDate(XSDataString):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None):
-		XSDataString.__init__(self, value)
-	def export(self, outfile, level, name_='XSDataDate'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataDate'):
-		XSDataString.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataString.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataDate" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataDate' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataDate is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataDate.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataDate()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataDate" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataDate()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None):
+                XSDataString.__init__(self, value)
+        def export(self, outfile, level, name_='XSDataDate'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataDate'):
+                XSDataString.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataString.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataDate" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataDate' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataDate is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataDate.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataDate()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataDate" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataDate()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataDate
 
 class XSDataDoubleWithUnit(XSDataDouble):
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDouble.__init__(self, value)
-		checkType("XSDataDoubleWithUnit", "Constructor of XSDataDoubleWithUnit", error, "XSDataDouble")
-		self.__error = error
-		checkType("XSDataDoubleWithUnit", "Constructor of XSDataDoubleWithUnit", unit, "XSDataString")
-		self.__unit = unit
-	def getError(self): return self.__error
-	def setError(self, error):
-		checkType("XSDataDoubleWithUnit", "setError", error, "XSDataDouble")
-		self.__error = error
-	def delError(self): self.__error = None
-	# Properties
-	error = property(getError, setError, delError, "Property for error")
-	def getUnit(self): return self.__unit
-	def setUnit(self, unit):
-		checkType("XSDataDoubleWithUnit", "setUnit", unit, "XSDataString")
-		self.__unit = unit
-	def delUnit(self): self.__unit = None
-	# Properties
-	unit = property(getUnit, setUnit, delUnit, "Property for unit")
-	def export(self, outfile, level, name_='XSDataDoubleWithUnit'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataDoubleWithUnit'):
-		XSDataDouble.exportChildren(self, outfile, level, name_)
-		if self.__error is not None:
-			self.error.export(outfile, level, name_='error')
-		if self.__unit is not None:
-			self.unit.export(outfile, level, name_='unit')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'error':
-			obj_ = XSDataDouble()
-			obj_.build(child_)
-			self.setError(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'unit':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setUnit(obj_)
-		XSDataDouble.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataDoubleWithUnit" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataDoubleWithUnit' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataDoubleWithUnit is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataDoubleWithUnit.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataDoubleWithUnit()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataDoubleWithUnit" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataDoubleWithUnit()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDouble.__init__(self, value)
+                checkType("XSDataDoubleWithUnit", "Constructor of XSDataDoubleWithUnit", error, "XSDataDouble")
+                self.__error = error
+                checkType("XSDataDoubleWithUnit", "Constructor of XSDataDoubleWithUnit", unit, "XSDataString")
+                self.__unit = unit
+        def getError(self): return self.__error
+        def setError(self, error):
+                checkType("XSDataDoubleWithUnit", "setError", error, "XSDataDouble")
+                self.__error = error
+        def delError(self): self.__error = None
+        # Properties
+        error = property(getError, setError, delError, "Property for error")
+        def getUnit(self): return self.__unit
+        def setUnit(self, unit):
+                checkType("XSDataDoubleWithUnit", "setUnit", unit, "XSDataString")
+                self.__unit = unit
+        def delUnit(self): self.__unit = None
+        # Properties
+        unit = property(getUnit, setUnit, delUnit, "Property for unit")
+        def export(self, outfile, level, name_='XSDataDoubleWithUnit'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataDoubleWithUnit'):
+                XSDataDouble.exportChildren(self, outfile, level, name_)
+                if self.__error is not None:
+                        self.error.export(outfile, level, name_='error')
+                if self.__unit is not None:
+                        self.unit.export(outfile, level, name_='unit')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'error':
+                        obj_ = XSDataDouble()
+                        obj_.build(child_)
+                        self.setError(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'unit':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setUnit(obj_)
+                XSDataDouble.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataDoubleWithUnit" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataDoubleWithUnit' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataDoubleWithUnit is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataDoubleWithUnit.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataDoubleWithUnit()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataDoubleWithUnit" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataDoubleWithUnit()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataDoubleWithUnit
 
 class XSDataImage(XSDataFile):
-	"""These objects use the simple objects described above to create useful structures for the rest for the data model."""
-	def __init__(self, path=None, number=None, date=None):
-		XSDataFile.__init__(self, path)
-		checkType("XSDataImage", "Constructor of XSDataImage", date, "XSDataString")
-		self.__date = date
-		checkType("XSDataImage", "Constructor of XSDataImage", number, "XSDataInteger")
-		self.__number = number
-	def getDate(self): return self.__date
-	def setDate(self, date):
-		checkType("XSDataImage", "setDate", date, "XSDataString")
-		self.__date = date
-	def delDate(self): self.__date = None
-	# Properties
-	date = property(getDate, setDate, delDate, "Property for date")
-	def getNumber(self): return self.__number
-	def setNumber(self, number):
-		checkType("XSDataImage", "setNumber", number, "XSDataInteger")
-		self.__number = number
-	def delNumber(self): self.__number = None
-	# Properties
-	number = property(getNumber, setNumber, delNumber, "Property for number")
-	def export(self, outfile, level, name_='XSDataImage'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataImage'):
-		XSDataFile.exportChildren(self, outfile, level, name_)
-		if self.__date is not None:
-			self.date.export(outfile, level, name_='date')
-		if self.__number is not None:
-			self.number.export(outfile, level, name_='number')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'date':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setDate(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'number':
-			obj_ = XSDataInteger()
-			obj_.build(child_)
-			self.setNumber(obj_)
-		XSDataFile.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataImage" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataImage' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataImage is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataImage.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataImage()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataImage" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataImage()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These objects use the simple objects described above to create useful structures for the rest for the data model."""
+        def __init__(self, path=None, number=None, date=None):
+                XSDataFile.__init__(self, path)
+                checkType("XSDataImage", "Constructor of XSDataImage", date, "XSDataString")
+                self.__date = date
+                checkType("XSDataImage", "Constructor of XSDataImage", number, "XSDataInteger")
+                self.__number = number
+        def getDate(self): return self.__date
+        def setDate(self, date):
+                checkType("XSDataImage", "setDate", date, "XSDataString")
+                self.__date = date
+        def delDate(self): self.__date = None
+        # Properties
+        date = property(getDate, setDate, delDate, "Property for date")
+        def getNumber(self): return self.__number
+        def setNumber(self, number):
+                checkType("XSDataImage", "setNumber", number, "XSDataInteger")
+                self.__number = number
+        def delNumber(self): self.__number = None
+        # Properties
+        number = property(getNumber, setNumber, delNumber, "Property for number")
+        def export(self, outfile, level, name_='XSDataImage'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataImage'):
+                XSDataFile.exportChildren(self, outfile, level, name_)
+                if self.__date is not None:
+                        self.date.export(outfile, level, name_='date')
+                if self.__number is not None:
+                        self.number.export(outfile, level, name_='number')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'date':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setDate(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'number':
+                        obj_ = XSDataInteger()
+                        obj_.build(child_)
+                        self.setNumber(obj_)
+                XSDataFile.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataImage" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataImage' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataImage is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataImage.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataImage()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataImage" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataImage()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataImage
 
 class XSDataMatrix(XSDataMatrixDouble):
-	"""XSDataMatrix is deprecated and should be replaced with XSDataMatrixDouble."""
-	def __init__(self, m33=None, m32=None, m31=None, m23=None, m22=None, m21=None, m13=None, m12=None, m11=None):
-		XSDataMatrixDouble.__init__(self, m33, m32, m31, m23, m22, m21, m13, m12, m11)
-	def export(self, outfile, level, name_='XSDataMatrix'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataMatrix'):
-		XSDataMatrixDouble.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataMatrixDouble.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataMatrix" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataMatrix' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataMatrix is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataMatrix.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataMatrix()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataMatrix" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataMatrix()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """XSDataMatrix is deprecated and should be replaced with XSDataMatrixDouble."""
+        def __init__(self, m33=None, m32=None, m31=None, m23=None, m22=None, m21=None, m13=None, m12=None, m11=None):
+                XSDataMatrixDouble.__init__(self, m33, m32, m31, m23, m22, m21, m13, m12, m11)
+        def export(self, outfile, level, name_='XSDataMatrix'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataMatrix'):
+                XSDataMatrixDouble.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataMatrixDouble.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataMatrix" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataMatrix' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataMatrix is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataMatrix.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataMatrix()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataMatrix" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataMatrix()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataMatrix
 
 class XSDataUnitVector(XSDataVectorDouble):
-	"""<<Invariant>>
+        """<<Invariant>>
 {abs(v1**2.0 + v3**2.0-1.0) < epsilon}"""
-	def __init__(self, v3=None, v2=None, v1=None):
-		XSDataVectorDouble.__init__(self, v3, v2, v1)
-	def export(self, outfile, level, name_='XSDataUnitVector'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataUnitVector'):
-		XSDataVectorDouble.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataVectorDouble.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataUnitVector" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataUnitVector' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataUnitVector is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataUnitVector.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataUnitVector()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataUnitVector" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataUnitVector()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, v3=None, v2=None, v1=None):
+                XSDataVectorDouble.__init__(self, v3, v2, v1)
+        def export(self, outfile, level, name_='XSDataUnitVector'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataUnitVector'):
+                XSDataVectorDouble.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataVectorDouble.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataUnitVector" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataUnitVector' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataUnitVector is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataUnitVector.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataUnitVector()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataUnitVector" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataUnitVector()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataUnitVector
 
 class XSDataAbsorbedDoseRate(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataAbsorbedDoseRate'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataAbsorbedDoseRate'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataAbsorbedDoseRate" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataAbsorbedDoseRate' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataAbsorbedDoseRate is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataAbsorbedDoseRate.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataAbsorbedDoseRate()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataAbsorbedDoseRate" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataAbsorbedDoseRate()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataAbsorbedDoseRate'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataAbsorbedDoseRate'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataAbsorbedDoseRate" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataAbsorbedDoseRate' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataAbsorbedDoseRate is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataAbsorbedDoseRate.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataAbsorbedDoseRate()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataAbsorbedDoseRate" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataAbsorbedDoseRate()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataAbsorbedDoseRate
 
 class XSDataAngularSpeed(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataAngularSpeed'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataAngularSpeed'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataAngularSpeed" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataAngularSpeed' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataAngularSpeed is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataAngularSpeed.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataAngularSpeed()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataAngularSpeed" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataAngularSpeed()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataAngularSpeed'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataAngularSpeed'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataAngularSpeed" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataAngularSpeed' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataAngularSpeed is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataAngularSpeed.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataAngularSpeed()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataAngularSpeed" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataAngularSpeed()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataAngularSpeed
 
 class XSDataFlux(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataFlux'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataFlux'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataFlux" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataFlux' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataFlux is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataFlux.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataFlux()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataFlux" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataFlux()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataFlux'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataFlux'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataFlux" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataFlux' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataFlux is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataFlux.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataFlux()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataFlux" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataFlux()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataFlux
 
 class XSDataLength(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataLength'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataLength'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataLength" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataLength' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataLength is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataLength.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataLength()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataLength" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataLength()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataLength'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataLength'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataLength" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataLength' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataLength is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataLength.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataLength()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataLength" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataLength()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataLength
 
 class XSDataSpeed(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataSpeed'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataSpeed'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataSpeed" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataSpeed' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataSpeed is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataSpeed.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataSpeed()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataSpeed" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataSpeed()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataSpeed'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataSpeed'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataSpeed" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataSpeed' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataSpeed is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataSpeed.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataSpeed()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataSpeed" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataSpeed()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataSpeed
 
 class XSDataTime(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataTime'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataTime'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataTime" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataTime' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataTime is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataTime.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataTime()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataTime" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataTime()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataTime'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataTime'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataTime" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataTime' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataTime is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataTime.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataTime()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataTime" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataTime()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataTime
 
 class XSDataWavelength(XSDataDoubleWithUnit):
-	"""These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
-	def __init__(self, value=None, unit=None, error=None):
-		XSDataDoubleWithUnit.__init__(self, value, unit, error)
-	def export(self, outfile, level, name_='XSDataWavelength'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataWavelength'):
-		XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		pass
-		XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataWavelength" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataWavelength' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataWavelength is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataWavelength.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataWavelength()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataWavelength" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataWavelength()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        """These simple objects that use built-in types are basically aimed to be used by the rest of the data model objects."""
+        def __init__(self, value=None, unit=None, error=None):
+                XSDataDoubleWithUnit.__init__(self, value, unit, error)
+        def export(self, outfile, level, name_='XSDataWavelength'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataWavelength'):
+                XSDataDoubleWithUnit.exportChildren(self, outfile, level, name_)
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                pass
+                XSDataDoubleWithUnit.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataWavelength" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataWavelength' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataWavelength is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataWavelength.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataWavelength()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataWavelength" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataWavelength()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataWavelength
 
 

--- a/HardwareObjects/XSDataMXCuBEv1_3.py
+++ b/HardwareObjects/XSDataMXCuBEv1_3.py
@@ -28,29 +28,29 @@ dictLocation = { \
 }
 
 try:
-	from XSDataCommon import XSData
-	from XSDataCommon import XSDataDictionary
-	from XSDataCommon import XSDataFile
-	from XSDataCommon import XSDataInput
-	from XSDataCommon import XSDataInteger
-	from XSDataCommon import XSDataResult
-	from XSDataCommon import XSDataString
-	from XSDataMXv1 import XSDataCollectionPlan
-	from XSDataMXv1 import XSDataDiffractionPlan
-	from XSDataMXv1 import XSDataExperimentalCondition
-	from XSDataMXv1 import XSDataInputCharacterisation
-	from XSDataMXv1 import XSDataResultCharacterisation
-	from XSDataMXv1 import XSDataSampleCrystalMM
+        from XSDataCommon import XSData
+        from XSDataCommon import XSDataDictionary
+        from XSDataCommon import XSDataFile
+        from XSDataCommon import XSDataInput
+        from XSDataCommon import XSDataInteger
+        from XSDataCommon import XSDataResult
+        from XSDataCommon import XSDataString
+        from XSDataMXv1 import XSDataCollectionPlan
+        from XSDataMXv1 import XSDataDiffractionPlan
+        from XSDataMXv1 import XSDataExperimentalCondition
+        from XSDataMXv1 import XSDataInputCharacterisation
+        from XSDataMXv1 import XSDataResultCharacterisation
+        from XSDataMXv1 import XSDataSampleCrystalMM
 except ImportError as error:
-	if strEdnaHome is not None:
-		for strXsdName in dictLocation:
-			strXsdModule = strXsdName + ".py"
-			strRootdir = os.path.dirname(os.path.abspath(os.path.join(strEdnaHome, dictLocation[strXsdName])))
-			for strRoot, listDirs, listFiles in os.walk(strRootdir):
-				if strXsdModule in listFiles:
-					sys.path.append(strRoot)
-	else:
-		raise error
+        if strEdnaHome is not None:
+                for strXsdName in dictLocation:
+                        strXsdModule = strXsdName + ".py"
+                        strRootdir = os.path.dirname(os.path.abspath(os.path.join(strEdnaHome, dictLocation[strXsdName])))
+                        for strRoot, listDirs, listFiles in os.walk(strRootdir):
+                                if strXsdModule in listFiles:
+                                        sys.path.append(strRoot)
+        else:
+                raise error
 from XSDataCommon import XSData
 from XSDataCommon import XSDataDictionary
 from XSDataCommon import XSDataFile
@@ -74,24 +74,24 @@ from XSDataMXv1 import XSDataSampleCrystalMM
 
 # Compabiltity between Python 2 and 3:
 if sys.version.startswith('3'):
-	unicode = str
-	from io import StringIO
+        unicode = str
+        from io import StringIO
 else:
-	from StringIO import StringIO
+        from StringIO import StringIO
 
 
 def showIndent(outfile, level):
-	for idx in range(level):
-		outfile.write(unicode('    '))
+        for idx in range(level):
+                outfile.write(unicode('    '))
 
 
 def checkType(_strClassName, _strMethodName, _value, _strExpectedType):
-	if not _strExpectedType in ["float", "double", "string", "boolean", "integer"]:
-		if _value != None:
-			if _value.__class__.__name__ != _strExpectedType:
-				strMessage = "ERROR! %s.%s argument is not %s but %s" % (_strClassName, _strMethodName, _strExpectedType, _value.__class__.__name__)
-				print(strMessage)
-				#raise BaseException(strMessage)
+        if not _strExpectedType in ["float", "double", "string", "boolean", "integer"]:
+                if _value != None:
+                        if _value.__class__.__name__ != _strExpectedType:
+                                strMessage = "ERROR! %s.%s argument is not %s but %s" % (_strClassName, _strMethodName, _strExpectedType, _value.__class__.__name__)
+                                print(strMessage)
+                                #raise BaseException(strMessage)
 #	elif _value is None:
 #		strMessage = "ERROR! %s.%s argument which should be %s is None" % (_strClassName, _strMethodName, _strExpectedType)
 #		print(strMessage)
@@ -99,55 +99,55 @@ def checkType(_strClassName, _strMethodName, _value, _strExpectedType):
 
 
 def warnEmptyAttribute(_strName, _strTypeName):
-	if not _strTypeName in ["float", "double", "string", "boolean", "integer"]:
-		print("Warning! Non-optional attribute %s of type %s is None!" % (_strName, _strTypeName))
+        if not _strTypeName in ["float", "double", "string", "boolean", "integer"]:
+                print("Warning! Non-optional attribute %s of type %s is None!" % (_strName, _strTypeName))
 
 class MixedContainer(object):
-	# Constants for category:
-	CategoryNone = 0
-	CategoryText = 1
-	CategorySimple = 2
-	CategoryComplex = 3
-	# Constants for content_type:
-	TypeNone = 0
-	TypeText = 1
-	TypeString = 2
-	TypeInteger = 3
-	TypeFloat = 4
-	TypeDecimal = 5
-	TypeDouble = 6
-	TypeBoolean = 7
-	def __init__(self, category, content_type, name, value):
-		self.category = category
-		self.content_type = content_type
-		self.name = name
-		self.value = value
-	def getCategory(self):
-		return self.category
-	def getContenttype(self, content_type):
-		return self.content_type
-	def getValue(self):
-		return self.value
-	def getName(self):
-		return self.name
-	def export(self, outfile, level, name):
-		if self.category == MixedContainer.CategoryText:
-			outfile.write(self.value)
-		elif self.category == MixedContainer.CategorySimple:
-			self.exportSimple(outfile, level, name)
-		else:	 # category == MixedContainer.CategoryComplex
-			self.value.export(outfile, level, name)
-	def exportSimple(self, outfile, level, name):
-		if self.content_type == MixedContainer.TypeString:
-			outfile.write(unicode('<%s>%s</%s>' % (self.name, self.value, self.name)))
-		elif self.content_type == MixedContainer.TypeInteger or \
-				self.content_type == MixedContainer.TypeBoolean:
-			outfile.write(unicode('<%s>%d</%s>' % (self.name, self.value, self.name)))
-		elif self.content_type == MixedContainer.TypeFloat or \
-				self.content_type == MixedContainer.TypeDecimal:
-			outfile.write(unicode('<%s>%f</%s>' % (self.name, self.value, self.name)))
-		elif self.content_type == MixedContainer.TypeDouble:
-			outfile.write(unicode('<%s>%g</%s>' % (self.name, self.value, self.name)))
+        # Constants for category:
+        CategoryNone = 0
+        CategoryText = 1
+        CategorySimple = 2
+        CategoryComplex = 3
+        # Constants for content_type:
+        TypeNone = 0
+        TypeText = 1
+        TypeString = 2
+        TypeInteger = 3
+        TypeFloat = 4
+        TypeDecimal = 5
+        TypeDouble = 6
+        TypeBoolean = 7
+        def __init__(self, category, content_type, name, value):
+                self.category = category
+                self.content_type = content_type
+                self.name = name
+                self.value = value
+        def getCategory(self):
+                return self.category
+        def getContenttype(self, content_type):
+                return self.content_type
+        def getValue(self):
+                return self.value
+        def getName(self):
+                return self.name
+        def export(self, outfile, level, name):
+                if self.category == MixedContainer.CategoryText:
+                        outfile.write(self.value)
+                elif self.category == MixedContainer.CategorySimple:
+                        self.exportSimple(outfile, level, name)
+                else:         # category == MixedContainer.CategoryComplex
+                        self.value.export(outfile, level, name)
+        def exportSimple(self, outfile, level, name):
+                if self.content_type == MixedContainer.TypeString:
+                        outfile.write(unicode('<%s>%s</%s>' % (self.name, self.value, self.name)))
+                elif self.content_type == MixedContainer.TypeInteger or \
+                                self.content_type == MixedContainer.TypeBoolean:
+                        outfile.write(unicode('<%s>%d</%s>' % (self.name, self.value, self.name)))
+                elif self.content_type == MixedContainer.TypeFloat or \
+                                self.content_type == MixedContainer.TypeDecimal:
+                        outfile.write(unicode('<%s>%f</%s>' % (self.name, self.value, self.name)))
+                elif self.content_type == MixedContainer.TypeDouble:
+                        outfile.write(unicode('<%s>%g</%s>' % (self.name, self.value, self.name)))
 
 #
 # Data representation classes.
@@ -155,1430 +155,1430 @@ class MixedContainer(object):
 
 
 class XSDataMXCuBEDataSet(object):
-	def __init__(self, imageFile=None):
-	
-	
-		if imageFile is None:
-			self._imageFile = []
-		else:
-			checkType("XSDataMXCuBEDataSet", "Constructor of XSDataMXCuBEDataSet", imageFile, "list")
-			self._imageFile = imageFile
-	def getImageFile(self): return self._imageFile
-	def setImageFile(self, imageFile):
-		checkType("XSDataMXCuBEDataSet", "setImageFile", imageFile, "list")
-		self._imageFile = imageFile
-	def delImageFile(self): self._imageFile = None
-	# Properties
-	imageFile = property(getImageFile, setImageFile, delImageFile, "Property for imageFile")
-	def addImageFile(self, value):
-		checkType("XSDataMXCuBEDataSet", "setImageFile", value, "XSDataFile")
-		self._imageFile.append(value)
-	def insertImageFile(self, index, value):
-		checkType("XSDataMXCuBEDataSet", "setImageFile", value, "XSDataFile")
-		self._imageFile[index] = value
-	def export(self, outfile, level, name_='XSDataMXCuBEDataSet'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataMXCuBEDataSet'):
-		pass
-		for imageFile_ in self.getImageFile():
-			imageFile_.export(outfile, level, name_='imageFile')
-		if self.getImageFile() == []:
-			warnEmptyAttribute("imageFile", "XSDataFile")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'imageFile':
-			obj_ = XSDataFile()
-			obj_.build(child_)
-			self.imageFile.append(obj_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataMXCuBEDataSet" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataMXCuBEDataSet' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataMXCuBEDataSet is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataMXCuBEDataSet.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataMXCuBEDataSet()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataMXCuBEDataSet" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataMXCuBEDataSet()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, imageFile=None):
+
+
+                if imageFile is None:
+                        self._imageFile = []
+                else:
+                        checkType("XSDataMXCuBEDataSet", "Constructor of XSDataMXCuBEDataSet", imageFile, "list")
+                        self._imageFile = imageFile
+        def getImageFile(self): return self._imageFile
+        def setImageFile(self, imageFile):
+                checkType("XSDataMXCuBEDataSet", "setImageFile", imageFile, "list")
+                self._imageFile = imageFile
+        def delImageFile(self): self._imageFile = None
+        # Properties
+        imageFile = property(getImageFile, setImageFile, delImageFile, "Property for imageFile")
+        def addImageFile(self, value):
+                checkType("XSDataMXCuBEDataSet", "setImageFile", value, "XSDataFile")
+                self._imageFile.append(value)
+        def insertImageFile(self, index, value):
+                checkType("XSDataMXCuBEDataSet", "setImageFile", value, "XSDataFile")
+                self._imageFile[index] = value
+        def export(self, outfile, level, name_='XSDataMXCuBEDataSet'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataMXCuBEDataSet'):
+                pass
+                for imageFile_ in self.getImageFile():
+                        imageFile_.export(outfile, level, name_='imageFile')
+                if self.getImageFile() == []:
+                        warnEmptyAttribute("imageFile", "XSDataFile")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'imageFile':
+                        obj_ = XSDataFile()
+                        obj_.build(child_)
+                        self.imageFile.append(obj_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataMXCuBEDataSet" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataMXCuBEDataSet' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataMXCuBEDataSet is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataMXCuBEDataSet.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataMXCuBEDataSet()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataMXCuBEDataSet" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataMXCuBEDataSet()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataMXCuBEDataSet
 
 class XSDataMXCuBEParameters(XSData):
-	def __init__(self, transmission=None, output_file=None, current_osc_start=None, current_energy=None, directory=None, number_passes=None, anomalous=None, phiStart=None, current_wavelength=None, run_number=None, residues=None, current_detdistance=None, number_images=None, inverse_beam=None, processing=None, kappaStart=None, template=None, first_image=None, osc_range=None, comments=None, mad_energies=None, detector_mode=None, sum_images=None, process_directory=None, osc_start=None, overlap=None, prefix=None, mad_4_energy=None, mad_3_energy=None, mad_2_energy=None, mad_1_energy=None, beam_size_y=None, beam_size_x=None, y_beam=None, x_beam=None, resolution_at_corner=None, resolution=None, exposure_time=None, blSampleId=None, sessionId=None):
-		XSData.__init__(self, )
-	
-	
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", sessionId, "integer")
-		self._sessionId = sessionId
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", blSampleId, "integer")
-		self._blSampleId = blSampleId
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", exposure_time, "float")
-		self._exposure_time = exposure_time
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", resolution, "float")
-		self._resolution = resolution
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", resolution_at_corner, "float")
-		self._resolution_at_corner = resolution_at_corner
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", x_beam, "float")
-		self._x_beam = x_beam
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", y_beam, "float")
-		self._y_beam = y_beam
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", beam_size_x, "float")
-		self._beam_size_x = beam_size_x
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", beam_size_y, "float")
-		self._beam_size_y = beam_size_y
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_1_energy, "float")
-		self._mad_1_energy = mad_1_energy
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_2_energy, "float")
-		self._mad_2_energy = mad_2_energy
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_3_energy, "float")
-		self._mad_3_energy = mad_3_energy
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_4_energy, "float")
-		self._mad_4_energy = mad_4_energy
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", prefix, "string")
-		self._prefix = prefix
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", overlap, "float")
-		self._overlap = overlap
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", osc_start, "float")
-		self._osc_start = osc_start
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", process_directory, "string")
-		self._process_directory = process_directory
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", sum_images, "float")
-		self._sum_images = sum_images
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", detector_mode, "string")
-		self._detector_mode = detector_mode
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_energies, "string")
-		self._mad_energies = mad_energies
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", comments, "string")
-		self._comments = comments
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", osc_range, "float")
-		self._osc_range = osc_range
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", first_image, "integer")
-		self._first_image = first_image
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", template, "string")
-		self._template = template
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", kappaStart, "float")
-		self._kappaStart = kappaStart
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", processing, "boolean")
-		self._processing = processing
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", inverse_beam, "float")
-		self._inverse_beam = inverse_beam
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", number_images, "integer")
-		self._number_images = number_images
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_detdistance, "float")
-		self._current_detdistance = current_detdistance
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", residues, "string")
-		self._residues = residues
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", run_number, "integer")
-		self._run_number = run_number
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_wavelength, "float")
-		self._current_wavelength = current_wavelength
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", phiStart, "float")
-		self._phiStart = phiStart
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", anomalous, "boolean")
-		self._anomalous = anomalous
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", number_passes, "integer")
-		self._number_passes = number_passes
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", directory, "string")
-		self._directory = directory
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_energy, "float")
-		self._current_energy = current_energy
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_osc_start, "float")
-		self._current_osc_start = current_osc_start
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", output_file, "string")
-		self._output_file = output_file
-		checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", transmission, "float")
-		self._transmission = transmission
-	def getSessionId(self): return self._sessionId
-	def setSessionId(self, sessionId):
-		checkType("XSDataMXCuBEParameters", "setSessionId", sessionId, "integer")
-		self._sessionId = sessionId
-	def delSessionId(self): self._sessionId = None
-	# Properties
-	sessionId = property(getSessionId, setSessionId, delSessionId, "Property for sessionId")
-	def getBlSampleId(self): return self._blSampleId
-	def setBlSampleId(self, blSampleId):
-		checkType("XSDataMXCuBEParameters", "setBlSampleId", blSampleId, "integer")
-		self._blSampleId = blSampleId
-	def delBlSampleId(self): self._blSampleId = None
-	# Properties
-	blSampleId = property(getBlSampleId, setBlSampleId, delBlSampleId, "Property for blSampleId")
-	def getExposure_time(self): return self._exposure_time
-	def setExposure_time(self, exposure_time):
-		checkType("XSDataMXCuBEParameters", "setExposure_time", exposure_time, "float")
-		self._exposure_time = exposure_time
-	def delExposure_time(self): self._exposure_time = None
-	# Properties
-	exposure_time = property(getExposure_time, setExposure_time, delExposure_time, "Property for exposure_time")
-	def getResolution(self): return self._resolution
-	def setResolution(self, resolution):
-		checkType("XSDataMXCuBEParameters", "setResolution", resolution, "float")
-		self._resolution = resolution
-	def delResolution(self): self._resolution = None
-	# Properties
-	resolution = property(getResolution, setResolution, delResolution, "Property for resolution")
-	def getResolution_at_corner(self): return self._resolution_at_corner
-	def setResolution_at_corner(self, resolution_at_corner):
-		checkType("XSDataMXCuBEParameters", "setResolution_at_corner", resolution_at_corner, "float")
-		self._resolution_at_corner = resolution_at_corner
-	def delResolution_at_corner(self): self._resolution_at_corner = None
-	# Properties
-	resolution_at_corner = property(getResolution_at_corner, setResolution_at_corner, delResolution_at_corner, "Property for resolution_at_corner")
-	def getX_beam(self): return self._x_beam
-	def setX_beam(self, x_beam):
-		checkType("XSDataMXCuBEParameters", "setX_beam", x_beam, "float")
-		self._x_beam = x_beam
-	def delX_beam(self): self._x_beam = None
-	# Properties
-	x_beam = property(getX_beam, setX_beam, delX_beam, "Property for x_beam")
-	def getY_beam(self): return self._y_beam
-	def setY_beam(self, y_beam):
-		checkType("XSDataMXCuBEParameters", "setY_beam", y_beam, "float")
-		self._y_beam = y_beam
-	def delY_beam(self): self._y_beam = None
-	# Properties
-	y_beam = property(getY_beam, setY_beam, delY_beam, "Property for y_beam")
-	def getBeam_size_x(self): return self._beam_size_x
-	def setBeam_size_x(self, beam_size_x):
-		checkType("XSDataMXCuBEParameters", "setBeam_size_x", beam_size_x, "float")
-		self._beam_size_x = beam_size_x
-	def delBeam_size_x(self): self._beam_size_x = None
-	# Properties
-	beam_size_x = property(getBeam_size_x, setBeam_size_x, delBeam_size_x, "Property for beam_size_x")
-	def getBeam_size_y(self): return self._beam_size_y
-	def setBeam_size_y(self, beam_size_y):
-		checkType("XSDataMXCuBEParameters", "setBeam_size_y", beam_size_y, "float")
-		self._beam_size_y = beam_size_y
-	def delBeam_size_y(self): self._beam_size_y = None
-	# Properties
-	beam_size_y = property(getBeam_size_y, setBeam_size_y, delBeam_size_y, "Property for beam_size_y")
-	def getMad_1_energy(self): return self._mad_1_energy
-	def setMad_1_energy(self, mad_1_energy):
-		checkType("XSDataMXCuBEParameters", "setMad_1_energy", mad_1_energy, "float")
-		self._mad_1_energy = mad_1_energy
-	def delMad_1_energy(self): self._mad_1_energy = None
-	# Properties
-	mad_1_energy = property(getMad_1_energy, setMad_1_energy, delMad_1_energy, "Property for mad_1_energy")
-	def getMad_2_energy(self): return self._mad_2_energy
-	def setMad_2_energy(self, mad_2_energy):
-		checkType("XSDataMXCuBEParameters", "setMad_2_energy", mad_2_energy, "float")
-		self._mad_2_energy = mad_2_energy
-	def delMad_2_energy(self): self._mad_2_energy = None
-	# Properties
-	mad_2_energy = property(getMad_2_energy, setMad_2_energy, delMad_2_energy, "Property for mad_2_energy")
-	def getMad_3_energy(self): return self._mad_3_energy
-	def setMad_3_energy(self, mad_3_energy):
-		checkType("XSDataMXCuBEParameters", "setMad_3_energy", mad_3_energy, "float")
-		self._mad_3_energy = mad_3_energy
-	def delMad_3_energy(self): self._mad_3_energy = None
-	# Properties
-	mad_3_energy = property(getMad_3_energy, setMad_3_energy, delMad_3_energy, "Property for mad_3_energy")
-	def getMad_4_energy(self): return self._mad_4_energy
-	def setMad_4_energy(self, mad_4_energy):
-		checkType("XSDataMXCuBEParameters", "setMad_4_energy", mad_4_energy, "float")
-		self._mad_4_energy = mad_4_energy
-	def delMad_4_energy(self): self._mad_4_energy = None
-	# Properties
-	mad_4_energy = property(getMad_4_energy, setMad_4_energy, delMad_4_energy, "Property for mad_4_energy")
-	def getPrefix(self): return self._prefix
-	def setPrefix(self, prefix):
-		checkType("XSDataMXCuBEParameters", "setPrefix", prefix, "string")
-		self._prefix = prefix
-	def delPrefix(self): self._prefix = None
-	# Properties
-	prefix = property(getPrefix, setPrefix, delPrefix, "Property for prefix")
-	def getOverlap(self): return self._overlap
-	def setOverlap(self, overlap):
-		checkType("XSDataMXCuBEParameters", "setOverlap", overlap, "float")
-		self._overlap = overlap
-	def delOverlap(self): self._overlap = None
-	# Properties
-	overlap = property(getOverlap, setOverlap, delOverlap, "Property for overlap")
-	def getOsc_start(self): return self._osc_start
-	def setOsc_start(self, osc_start):
-		checkType("XSDataMXCuBEParameters", "setOsc_start", osc_start, "float")
-		self._osc_start = osc_start
-	def delOsc_start(self): self._osc_start = None
-	# Properties
-	osc_start = property(getOsc_start, setOsc_start, delOsc_start, "Property for osc_start")
-	def getProcess_directory(self): return self._process_directory
-	def setProcess_directory(self, process_directory):
-		checkType("XSDataMXCuBEParameters", "setProcess_directory", process_directory, "string")
-		self._process_directory = process_directory
-	def delProcess_directory(self): self._process_directory = None
-	# Properties
-	process_directory = property(getProcess_directory, setProcess_directory, delProcess_directory, "Property for process_directory")
-	def getSum_images(self): return self._sum_images
-	def setSum_images(self, sum_images):
-		checkType("XSDataMXCuBEParameters", "setSum_images", sum_images, "float")
-		self._sum_images = sum_images
-	def delSum_images(self): self._sum_images = None
-	# Properties
-	sum_images = property(getSum_images, setSum_images, delSum_images, "Property for sum_images")
-	def getDetector_mode(self): return self._detector_mode
-	def setDetector_mode(self, detector_mode):
-		checkType("XSDataMXCuBEParameters", "setDetector_mode", detector_mode, "string")
-		self._detector_mode = detector_mode
-	def delDetector_mode(self): self._detector_mode = None
-	# Properties
-	detector_mode = property(getDetector_mode, setDetector_mode, delDetector_mode, "Property for detector_mode")
-	def getMad_energies(self): return self._mad_energies
-	def setMad_energies(self, mad_energies):
-		checkType("XSDataMXCuBEParameters", "setMad_energies", mad_energies, "string")
-		self._mad_energies = mad_energies
-	def delMad_energies(self): self._mad_energies = None
-	# Properties
-	mad_energies = property(getMad_energies, setMad_energies, delMad_energies, "Property for mad_energies")
-	def getComments(self): return self._comments
-	def setComments(self, comments):
-		checkType("XSDataMXCuBEParameters", "setComments", comments, "string")
-		self._comments = comments
-	def delComments(self): self._comments = None
-	# Properties
-	comments = property(getComments, setComments, delComments, "Property for comments")
-	def getOsc_range(self): return self._osc_range
-	def setOsc_range(self, osc_range):
-		checkType("XSDataMXCuBEParameters", "setOsc_range", osc_range, "float")
-		self._osc_range = osc_range
-	def delOsc_range(self): self._osc_range = None
-	# Properties
-	osc_range = property(getOsc_range, setOsc_range, delOsc_range, "Property for osc_range")
-	def getFirst_image(self): return self._first_image
-	def setFirst_image(self, first_image):
-		checkType("XSDataMXCuBEParameters", "setFirst_image", first_image, "integer")
-		self._first_image = first_image
-	def delFirst_image(self): self._first_image = None
-	# Properties
-	first_image = property(getFirst_image, setFirst_image, delFirst_image, "Property for first_image")
-	def getTemplate(self): return self._template
-	def setTemplate(self, template):
-		checkType("XSDataMXCuBEParameters", "setTemplate", template, "string")
-		self._template = template
-	def delTemplate(self): self._template = None
-	# Properties
-	template = property(getTemplate, setTemplate, delTemplate, "Property for template")
-	def getKappaStart(self): return self._kappaStart
-	def setKappaStart(self, kappaStart):
-		checkType("XSDataMXCuBEParameters", "setKappaStart", kappaStart, "float")
-		self._kappaStart = kappaStart
-	def delKappaStart(self): self._kappaStart = None
-	# Properties
-	kappaStart = property(getKappaStart, setKappaStart, delKappaStart, "Property for kappaStart")
-	def getProcessing(self): return self._processing
-	def setProcessing(self, processing):
-		checkType("XSDataMXCuBEParameters", "setProcessing", processing, "boolean")
-		self._processing = processing
-	def delProcessing(self): self._processing = None
-	# Properties
-	processing = property(getProcessing, setProcessing, delProcessing, "Property for processing")
-	def getInverse_beam(self): return self._inverse_beam
-	def setInverse_beam(self, inverse_beam):
-		checkType("XSDataMXCuBEParameters", "setInverse_beam", inverse_beam, "float")
-		self._inverse_beam = inverse_beam
-	def delInverse_beam(self): self._inverse_beam = None
-	# Properties
-	inverse_beam = property(getInverse_beam, setInverse_beam, delInverse_beam, "Property for inverse_beam")
-	def getNumber_images(self): return self._number_images
-	def setNumber_images(self, number_images):
-		checkType("XSDataMXCuBEParameters", "setNumber_images", number_images, "integer")
-		self._number_images = number_images
-	def delNumber_images(self): self._number_images = None
-	# Properties
-	number_images = property(getNumber_images, setNumber_images, delNumber_images, "Property for number_images")
-	def getCurrent_detdistance(self): return self._current_detdistance
-	def setCurrent_detdistance(self, current_detdistance):
-		checkType("XSDataMXCuBEParameters", "setCurrent_detdistance", current_detdistance, "float")
-		self._current_detdistance = current_detdistance
-	def delCurrent_detdistance(self): self._current_detdistance = None
-	# Properties
-	current_detdistance = property(getCurrent_detdistance, setCurrent_detdistance, delCurrent_detdistance, "Property for current_detdistance")
-	def getResidues(self): return self._residues
-	def setResidues(self, residues):
-		checkType("XSDataMXCuBEParameters", "setResidues", residues, "string")
-		self._residues = residues
-	def delResidues(self): self._residues = None
-	# Properties
-	residues = property(getResidues, setResidues, delResidues, "Property for residues")
-	def getRun_number(self): return self._run_number
-	def setRun_number(self, run_number):
-		checkType("XSDataMXCuBEParameters", "setRun_number", run_number, "integer")
-		self._run_number = run_number
-	def delRun_number(self): self._run_number = None
-	# Properties
-	run_number = property(getRun_number, setRun_number, delRun_number, "Property for run_number")
-	def getCurrent_wavelength(self): return self._current_wavelength
-	def setCurrent_wavelength(self, current_wavelength):
-		checkType("XSDataMXCuBEParameters", "setCurrent_wavelength", current_wavelength, "float")
-		self._current_wavelength = current_wavelength
-	def delCurrent_wavelength(self): self._current_wavelength = None
-	# Properties
-	current_wavelength = property(getCurrent_wavelength, setCurrent_wavelength, delCurrent_wavelength, "Property for current_wavelength")
-	def getPhiStart(self): return self._phiStart
-	def setPhiStart(self, phiStart):
-		checkType("XSDataMXCuBEParameters", "setPhiStart", phiStart, "float")
-		self._phiStart = phiStart
-	def delPhiStart(self): self._phiStart = None
-	# Properties
-	phiStart = property(getPhiStart, setPhiStart, delPhiStart, "Property for phiStart")
-	def getAnomalous(self): return self._anomalous
-	def setAnomalous(self, anomalous):
-		checkType("XSDataMXCuBEParameters", "setAnomalous", anomalous, "boolean")
-		self._anomalous = anomalous
-	def delAnomalous(self): self._anomalous = None
-	# Properties
-	anomalous = property(getAnomalous, setAnomalous, delAnomalous, "Property for anomalous")
-	def getNumber_passes(self): return self._number_passes
-	def setNumber_passes(self, number_passes):
-		checkType("XSDataMXCuBEParameters", "setNumber_passes", number_passes, "integer")
-		self._number_passes = number_passes
-	def delNumber_passes(self): self._number_passes = None
-	# Properties
-	number_passes = property(getNumber_passes, setNumber_passes, delNumber_passes, "Property for number_passes")
-	def getDirectory(self): return self._directory
-	def setDirectory(self, directory):
-		checkType("XSDataMXCuBEParameters", "setDirectory", directory, "string")
-		self._directory = directory
-	def delDirectory(self): self._directory = None
-	# Properties
-	directory = property(getDirectory, setDirectory, delDirectory, "Property for directory")
-	def getCurrent_energy(self): return self._current_energy
-	def setCurrent_energy(self, current_energy):
-		checkType("XSDataMXCuBEParameters", "setCurrent_energy", current_energy, "float")
-		self._current_energy = current_energy
-	def delCurrent_energy(self): self._current_energy = None
-	# Properties
-	current_energy = property(getCurrent_energy, setCurrent_energy, delCurrent_energy, "Property for current_energy")
-	def getCurrent_osc_start(self): return self._current_osc_start
-	def setCurrent_osc_start(self, current_osc_start):
-		checkType("XSDataMXCuBEParameters", "setCurrent_osc_start", current_osc_start, "float")
-		self._current_osc_start = current_osc_start
-	def delCurrent_osc_start(self): self._current_osc_start = None
-	# Properties
-	current_osc_start = property(getCurrent_osc_start, setCurrent_osc_start, delCurrent_osc_start, "Property for current_osc_start")
-	def getOutput_file(self): return self._output_file
-	def setOutput_file(self, output_file):
-		checkType("XSDataMXCuBEParameters", "setOutput_file", output_file, "string")
-		self._output_file = output_file
-	def delOutput_file(self): self._output_file = None
-	# Properties
-	output_file = property(getOutput_file, setOutput_file, delOutput_file, "Property for output_file")
-	def getTransmission(self): return self._transmission
-	def setTransmission(self, transmission):
-		checkType("XSDataMXCuBEParameters", "setTransmission", transmission, "float")
-		self._transmission = transmission
-	def delTransmission(self): self._transmission = None
-	# Properties
-	transmission = property(getTransmission, setTransmission, delTransmission, "Property for transmission")
-	def export(self, outfile, level, name_='XSDataMXCuBEParameters'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataMXCuBEParameters'):
-		XSData.exportChildren(self, outfile, level, name_)
-		if self._sessionId is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<sessionId>%d</sessionId>\n' % self._sessionId))
-		else:
-			warnEmptyAttribute("sessionId", "integer")
-		if self._blSampleId is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<blSampleId>%d</blSampleId>\n' % self._blSampleId))
-		else:
-			warnEmptyAttribute("blSampleId", "integer")
-		if self._exposure_time is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<exposure_time>%e</exposure_time>\n' % self._exposure_time))
-		else:
-			warnEmptyAttribute("exposure_time", "float")
-		if self._resolution is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<resolution>%e</resolution>\n' % self._resolution))
-		else:
-			warnEmptyAttribute("resolution", "float")
-		if self._resolution_at_corner is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<resolution_at_corner>%e</resolution_at_corner>\n' % self._resolution_at_corner))
-		else:
-			warnEmptyAttribute("resolution_at_corner", "float")
-		if self._x_beam is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<x_beam>%e</x_beam>\n' % self._x_beam))
-		else:
-			warnEmptyAttribute("x_beam", "float")
-		if self._y_beam is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<y_beam>%e</y_beam>\n' % self._y_beam))
-		else:
-			warnEmptyAttribute("y_beam", "float")
-		if self._beam_size_x is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<beam_size_x>%e</beam_size_x>\n' % self._beam_size_x))
-		else:
-			warnEmptyAttribute("beam_size_x", "float")
-		if self._beam_size_y is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<beam_size_y>%e</beam_size_y>\n' % self._beam_size_y))
-		else:
-			warnEmptyAttribute("beam_size_y", "float")
-		if self._mad_1_energy is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<mad_1_energy>%e</mad_1_energy>\n' % self._mad_1_energy))
-		else:
-			warnEmptyAttribute("mad_1_energy", "float")
-		if self._mad_2_energy is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<mad_2_energy>%e</mad_2_energy>\n' % self._mad_2_energy))
-		else:
-			warnEmptyAttribute("mad_2_energy", "float")
-		if self._mad_3_energy is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<mad_3_energy>%e</mad_3_energy>\n' % self._mad_3_energy))
-		else:
-			warnEmptyAttribute("mad_3_energy", "float")
-		if self._mad_4_energy is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<mad_4_energy>%e</mad_4_energy>\n' % self._mad_4_energy))
-		else:
-			warnEmptyAttribute("mad_4_energy", "float")
-		if self._prefix is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<prefix>%s</prefix>\n' % self._prefix))
-		else:
-			warnEmptyAttribute("prefix", "string")
-		if self._overlap is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<overlap>%e</overlap>\n' % self._overlap))
-		else:
-			warnEmptyAttribute("overlap", "float")
-		if self._osc_start is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<osc_start>%e</osc_start>\n' % self._osc_start))
-		else:
-			warnEmptyAttribute("osc_start", "float")
-		if self._process_directory is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<process_directory>%s</process_directory>\n' % self._process_directory))
-		else:
-			warnEmptyAttribute("process_directory", "string")
-		if self._sum_images is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<sum_images>%e</sum_images>\n' % self._sum_images))
-		else:
-			warnEmptyAttribute("sum_images", "float")
-		if self._detector_mode is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<detector_mode>%s</detector_mode>\n' % self._detector_mode))
-		else:
-			warnEmptyAttribute("detector_mode", "string")
-		if self._mad_energies is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<mad_energies>%s</mad_energies>\n' % self._mad_energies))
-		else:
-			warnEmptyAttribute("mad_energies", "string")
-		if self._comments is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<comments>%s</comments>\n' % self._comments))
-		else:
-			warnEmptyAttribute("comments", "string")
-		if self._osc_range is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<osc_range>%e</osc_range>\n' % self._osc_range))
-		else:
-			warnEmptyAttribute("osc_range", "float")
-		if self._first_image is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<first_image>%d</first_image>\n' % self._first_image))
-		else:
-			warnEmptyAttribute("first_image", "integer")
-		if self._template is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<template>%s</template>\n' % self._template))
-		else:
-			warnEmptyAttribute("template", "string")
-		if self._kappaStart is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<kappaStart>%e</kappaStart>\n' % self._kappaStart))
-		else:
-			warnEmptyAttribute("kappaStart", "float")
-		if self._processing is not None:
-			showIndent(outfile, level)
-			if self._processing:
-				outfile.write(unicode('<processing>true</processing>\n'))
-			else:
-				outfile.write(unicode('<processing>false</processing>\n'))
-		else:
-			warnEmptyAttribute("processing", "boolean")
-		if self._inverse_beam is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<inverse_beam>%e</inverse_beam>\n' % self._inverse_beam))
-		else:
-			warnEmptyAttribute("inverse_beam", "float")
-		if self._number_images is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<number_images>%d</number_images>\n' % self._number_images))
-		else:
-			warnEmptyAttribute("number_images", "integer")
-		if self._current_detdistance is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<current_detdistance>%e</current_detdistance>\n' % self._current_detdistance))
-		else:
-			warnEmptyAttribute("current_detdistance", "float")
-		if self._residues is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<residues>%s</residues>\n' % self._residues))
-		else:
-			warnEmptyAttribute("residues", "string")
-		if self._run_number is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<run_number>%d</run_number>\n' % self._run_number))
-		else:
-			warnEmptyAttribute("run_number", "integer")
-		if self._current_wavelength is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<current_wavelength>%e</current_wavelength>\n' % self._current_wavelength))
-		else:
-			warnEmptyAttribute("current_wavelength", "float")
-		if self._phiStart is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<phiStart>%e</phiStart>\n' % self._phiStart))
-		else:
-			warnEmptyAttribute("phiStart", "float")
-		if self._anomalous is not None:
-			showIndent(outfile, level)
-			if self._anomalous:
-				outfile.write(unicode('<anomalous>true</anomalous>\n'))
-			else:
-				outfile.write(unicode('<anomalous>false</anomalous>\n'))
-		else:
-			warnEmptyAttribute("anomalous", "boolean")
-		if self._number_passes is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<number_passes>%d</number_passes>\n' % self._number_passes))
-		else:
-			warnEmptyAttribute("number_passes", "integer")
-		if self._directory is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<directory>%s</directory>\n' % self._directory))
-		else:
-			warnEmptyAttribute("directory", "string")
-		if self._current_energy is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<current_energy>%e</current_energy>\n' % self._current_energy))
-		else:
-			warnEmptyAttribute("current_energy", "float")
-		if self._current_osc_start is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<current_osc_start>%e</current_osc_start>\n' % self._current_osc_start))
-		else:
-			warnEmptyAttribute("current_osc_start", "float")
-		if self._output_file is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<output_file>%s</output_file>\n' % self._output_file))
-		else:
-			warnEmptyAttribute("output_file", "string")
-		if self._transmission is not None:
-			showIndent(outfile, level)
-			outfile.write(unicode('<transmission>%e</transmission>\n' % self._transmission))
-		else:
-			warnEmptyAttribute("transmission", "float")
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'sessionId':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self._sessionId = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'blSampleId':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self._blSampleId = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'exposure_time':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._exposure_time = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'resolution':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._resolution = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'resolution_at_corner':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._resolution_at_corner = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'x_beam':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._x_beam = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'y_beam':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._y_beam = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'beam_size_x':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._beam_size_x = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'beam_size_y':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._beam_size_y = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'mad_1_energy':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._mad_1_energy = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'mad_2_energy':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._mad_2_energy = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'mad_3_energy':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._mad_3_energy = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'mad_4_energy':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._mad_4_energy = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'prefix':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._prefix = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'overlap':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._overlap = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'osc_start':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._osc_start = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'process_directory':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._process_directory = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'sum_images':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._sum_images = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'detector_mode':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._detector_mode = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'mad_energies':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._mad_energies = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'comments':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._comments = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'osc_range':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._osc_range = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'first_image':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self._first_image = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'template':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._template = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'kappaStart':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._kappaStart = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'processing':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				if sval_ in ('True', 'true', '1'):
-					ival_ = True
-				elif sval_ in ('False', 'false', '0'):
-					ival_ = False
-				else:
-					raise ValueError('requires boolean -- %s' % child_.toxml())
-				self._processing = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'inverse_beam':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._inverse_beam = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'number_images':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self._number_images = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'current_detdistance':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._current_detdistance = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'residues':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._residues = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'run_number':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self._run_number = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'current_wavelength':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._current_wavelength = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'phiStart':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._phiStart = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'anomalous':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				if sval_ in ('True', 'true', '1'):
-					ival_ = True
-				elif sval_ in ('False', 'false', '0'):
-					ival_ = False
-				else:
-					raise ValueError('requires boolean -- %s' % child_.toxml())
-				self._anomalous = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'number_passes':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					ival_ = int(sval_)
-				except ValueError:
-					raise ValueError('requires integer -- %s' % child_.toxml())
-				self._number_passes = ival_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'directory':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._directory = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'current_energy':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._current_energy = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'current_osc_start':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._current_osc_start = fval_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'output_file':
-			value_ = ''
-			for text__content_ in child_.childNodes:
-				if text__content_.nodeValue is not None:
-					value_ += text__content_.nodeValue
-			self._output_file = value_
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'transmission':
-			if child_.firstChild:
-				sval_ = child_.firstChild.nodeValue
-				try:
-					fval_ = float(sval_)
-				except ValueError:
-					raise ValueError('requires float (or double) -- %s' % child_.toxml())
-				self._transmission = fval_
-		XSData.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataMXCuBEParameters" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataMXCuBEParameters' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataMXCuBEParameters is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataMXCuBEParameters.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataMXCuBEParameters()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataMXCuBEParameters" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataMXCuBEParameters()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, transmission=None, output_file=None, current_osc_start=None, current_energy=None, directory=None, number_passes=None, anomalous=None, phiStart=None, current_wavelength=None, run_number=None, residues=None, current_detdistance=None, number_images=None, inverse_beam=None, processing=None, kappaStart=None, template=None, first_image=None, osc_range=None, comments=None, mad_energies=None, detector_mode=None, sum_images=None, process_directory=None, osc_start=None, overlap=None, prefix=None, mad_4_energy=None, mad_3_energy=None, mad_2_energy=None, mad_1_energy=None, beam_size_y=None, beam_size_x=None, y_beam=None, x_beam=None, resolution_at_corner=None, resolution=None, exposure_time=None, blSampleId=None, sessionId=None):
+                XSData.__init__(self, )
+
+
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", sessionId, "integer")
+                self._sessionId = sessionId
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", blSampleId, "integer")
+                self._blSampleId = blSampleId
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", exposure_time, "float")
+                self._exposure_time = exposure_time
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", resolution, "float")
+                self._resolution = resolution
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", resolution_at_corner, "float")
+                self._resolution_at_corner = resolution_at_corner
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", x_beam, "float")
+                self._x_beam = x_beam
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", y_beam, "float")
+                self._y_beam = y_beam
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", beam_size_x, "float")
+                self._beam_size_x = beam_size_x
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", beam_size_y, "float")
+                self._beam_size_y = beam_size_y
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_1_energy, "float")
+                self._mad_1_energy = mad_1_energy
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_2_energy, "float")
+                self._mad_2_energy = mad_2_energy
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_3_energy, "float")
+                self._mad_3_energy = mad_3_energy
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_4_energy, "float")
+                self._mad_4_energy = mad_4_energy
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", prefix, "string")
+                self._prefix = prefix
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", overlap, "float")
+                self._overlap = overlap
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", osc_start, "float")
+                self._osc_start = osc_start
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", process_directory, "string")
+                self._process_directory = process_directory
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", sum_images, "float")
+                self._sum_images = sum_images
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", detector_mode, "string")
+                self._detector_mode = detector_mode
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", mad_energies, "string")
+                self._mad_energies = mad_energies
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", comments, "string")
+                self._comments = comments
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", osc_range, "float")
+                self._osc_range = osc_range
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", first_image, "integer")
+                self._first_image = first_image
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", template, "string")
+                self._template = template
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", kappaStart, "float")
+                self._kappaStart = kappaStart
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", processing, "boolean")
+                self._processing = processing
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", inverse_beam, "float")
+                self._inverse_beam = inverse_beam
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", number_images, "integer")
+                self._number_images = number_images
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_detdistance, "float")
+                self._current_detdistance = current_detdistance
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", residues, "string")
+                self._residues = residues
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", run_number, "integer")
+                self._run_number = run_number
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_wavelength, "float")
+                self._current_wavelength = current_wavelength
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", phiStart, "float")
+                self._phiStart = phiStart
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", anomalous, "boolean")
+                self._anomalous = anomalous
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", number_passes, "integer")
+                self._number_passes = number_passes
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", directory, "string")
+                self._directory = directory
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_energy, "float")
+                self._current_energy = current_energy
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", current_osc_start, "float")
+                self._current_osc_start = current_osc_start
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", output_file, "string")
+                self._output_file = output_file
+                checkType("XSDataMXCuBEParameters", "Constructor of XSDataMXCuBEParameters", transmission, "float")
+                self._transmission = transmission
+        def getSessionId(self): return self._sessionId
+        def setSessionId(self, sessionId):
+                checkType("XSDataMXCuBEParameters", "setSessionId", sessionId, "integer")
+                self._sessionId = sessionId
+        def delSessionId(self): self._sessionId = None
+        # Properties
+        sessionId = property(getSessionId, setSessionId, delSessionId, "Property for sessionId")
+        def getBlSampleId(self): return self._blSampleId
+        def setBlSampleId(self, blSampleId):
+                checkType("XSDataMXCuBEParameters", "setBlSampleId", blSampleId, "integer")
+                self._blSampleId = blSampleId
+        def delBlSampleId(self): self._blSampleId = None
+        # Properties
+        blSampleId = property(getBlSampleId, setBlSampleId, delBlSampleId, "Property for blSampleId")
+        def getExposure_time(self): return self._exposure_time
+        def setExposure_time(self, exposure_time):
+                checkType("XSDataMXCuBEParameters", "setExposure_time", exposure_time, "float")
+                self._exposure_time = exposure_time
+        def delExposure_time(self): self._exposure_time = None
+        # Properties
+        exposure_time = property(getExposure_time, setExposure_time, delExposure_time, "Property for exposure_time")
+        def getResolution(self): return self._resolution
+        def setResolution(self, resolution):
+                checkType("XSDataMXCuBEParameters", "setResolution", resolution, "float")
+                self._resolution = resolution
+        def delResolution(self): self._resolution = None
+        # Properties
+        resolution = property(getResolution, setResolution, delResolution, "Property for resolution")
+        def getResolution_at_corner(self): return self._resolution_at_corner
+        def setResolution_at_corner(self, resolution_at_corner):
+                checkType("XSDataMXCuBEParameters", "setResolution_at_corner", resolution_at_corner, "float")
+                self._resolution_at_corner = resolution_at_corner
+        def delResolution_at_corner(self): self._resolution_at_corner = None
+        # Properties
+        resolution_at_corner = property(getResolution_at_corner, setResolution_at_corner, delResolution_at_corner, "Property for resolution_at_corner")
+        def getX_beam(self): return self._x_beam
+        def setX_beam(self, x_beam):
+                checkType("XSDataMXCuBEParameters", "setX_beam", x_beam, "float")
+                self._x_beam = x_beam
+        def delX_beam(self): self._x_beam = None
+        # Properties
+        x_beam = property(getX_beam, setX_beam, delX_beam, "Property for x_beam")
+        def getY_beam(self): return self._y_beam
+        def setY_beam(self, y_beam):
+                checkType("XSDataMXCuBEParameters", "setY_beam", y_beam, "float")
+                self._y_beam = y_beam
+        def delY_beam(self): self._y_beam = None
+        # Properties
+        y_beam = property(getY_beam, setY_beam, delY_beam, "Property for y_beam")
+        def getBeam_size_x(self): return self._beam_size_x
+        def setBeam_size_x(self, beam_size_x):
+                checkType("XSDataMXCuBEParameters", "setBeam_size_x", beam_size_x, "float")
+                self._beam_size_x = beam_size_x
+        def delBeam_size_x(self): self._beam_size_x = None
+        # Properties
+        beam_size_x = property(getBeam_size_x, setBeam_size_x, delBeam_size_x, "Property for beam_size_x")
+        def getBeam_size_y(self): return self._beam_size_y
+        def setBeam_size_y(self, beam_size_y):
+                checkType("XSDataMXCuBEParameters", "setBeam_size_y", beam_size_y, "float")
+                self._beam_size_y = beam_size_y
+        def delBeam_size_y(self): self._beam_size_y = None
+        # Properties
+        beam_size_y = property(getBeam_size_y, setBeam_size_y, delBeam_size_y, "Property for beam_size_y")
+        def getMad_1_energy(self): return self._mad_1_energy
+        def setMad_1_energy(self, mad_1_energy):
+                checkType("XSDataMXCuBEParameters", "setMad_1_energy", mad_1_energy, "float")
+                self._mad_1_energy = mad_1_energy
+        def delMad_1_energy(self): self._mad_1_energy = None
+        # Properties
+        mad_1_energy = property(getMad_1_energy, setMad_1_energy, delMad_1_energy, "Property for mad_1_energy")
+        def getMad_2_energy(self): return self._mad_2_energy
+        def setMad_2_energy(self, mad_2_energy):
+                checkType("XSDataMXCuBEParameters", "setMad_2_energy", mad_2_energy, "float")
+                self._mad_2_energy = mad_2_energy
+        def delMad_2_energy(self): self._mad_2_energy = None
+        # Properties
+        mad_2_energy = property(getMad_2_energy, setMad_2_energy, delMad_2_energy, "Property for mad_2_energy")
+        def getMad_3_energy(self): return self._mad_3_energy
+        def setMad_3_energy(self, mad_3_energy):
+                checkType("XSDataMXCuBEParameters", "setMad_3_energy", mad_3_energy, "float")
+                self._mad_3_energy = mad_3_energy
+        def delMad_3_energy(self): self._mad_3_energy = None
+        # Properties
+        mad_3_energy = property(getMad_3_energy, setMad_3_energy, delMad_3_energy, "Property for mad_3_energy")
+        def getMad_4_energy(self): return self._mad_4_energy
+        def setMad_4_energy(self, mad_4_energy):
+                checkType("XSDataMXCuBEParameters", "setMad_4_energy", mad_4_energy, "float")
+                self._mad_4_energy = mad_4_energy
+        def delMad_4_energy(self): self._mad_4_energy = None
+        # Properties
+        mad_4_energy = property(getMad_4_energy, setMad_4_energy, delMad_4_energy, "Property for mad_4_energy")
+        def getPrefix(self): return self._prefix
+        def setPrefix(self, prefix):
+                checkType("XSDataMXCuBEParameters", "setPrefix", prefix, "string")
+                self._prefix = prefix
+        def delPrefix(self): self._prefix = None
+        # Properties
+        prefix = property(getPrefix, setPrefix, delPrefix, "Property for prefix")
+        def getOverlap(self): return self._overlap
+        def setOverlap(self, overlap):
+                checkType("XSDataMXCuBEParameters", "setOverlap", overlap, "float")
+                self._overlap = overlap
+        def delOverlap(self): self._overlap = None
+        # Properties
+        overlap = property(getOverlap, setOverlap, delOverlap, "Property for overlap")
+        def getOsc_start(self): return self._osc_start
+        def setOsc_start(self, osc_start):
+                checkType("XSDataMXCuBEParameters", "setOsc_start", osc_start, "float")
+                self._osc_start = osc_start
+        def delOsc_start(self): self._osc_start = None
+        # Properties
+        osc_start = property(getOsc_start, setOsc_start, delOsc_start, "Property for osc_start")
+        def getProcess_directory(self): return self._process_directory
+        def setProcess_directory(self, process_directory):
+                checkType("XSDataMXCuBEParameters", "setProcess_directory", process_directory, "string")
+                self._process_directory = process_directory
+        def delProcess_directory(self): self._process_directory = None
+        # Properties
+        process_directory = property(getProcess_directory, setProcess_directory, delProcess_directory, "Property for process_directory")
+        def getSum_images(self): return self._sum_images
+        def setSum_images(self, sum_images):
+                checkType("XSDataMXCuBEParameters", "setSum_images", sum_images, "float")
+                self._sum_images = sum_images
+        def delSum_images(self): self._sum_images = None
+        # Properties
+        sum_images = property(getSum_images, setSum_images, delSum_images, "Property for sum_images")
+        def getDetector_mode(self): return self._detector_mode
+        def setDetector_mode(self, detector_mode):
+                checkType("XSDataMXCuBEParameters", "setDetector_mode", detector_mode, "string")
+                self._detector_mode = detector_mode
+        def delDetector_mode(self): self._detector_mode = None
+        # Properties
+        detector_mode = property(getDetector_mode, setDetector_mode, delDetector_mode, "Property for detector_mode")
+        def getMad_energies(self): return self._mad_energies
+        def setMad_energies(self, mad_energies):
+                checkType("XSDataMXCuBEParameters", "setMad_energies", mad_energies, "string")
+                self._mad_energies = mad_energies
+        def delMad_energies(self): self._mad_energies = None
+        # Properties
+        mad_energies = property(getMad_energies, setMad_energies, delMad_energies, "Property for mad_energies")
+        def getComments(self): return self._comments
+        def setComments(self, comments):
+                checkType("XSDataMXCuBEParameters", "setComments", comments, "string")
+                self._comments = comments
+        def delComments(self): self._comments = None
+        # Properties
+        comments = property(getComments, setComments, delComments, "Property for comments")
+        def getOsc_range(self): return self._osc_range
+        def setOsc_range(self, osc_range):
+                checkType("XSDataMXCuBEParameters", "setOsc_range", osc_range, "float")
+                self._osc_range = osc_range
+        def delOsc_range(self): self._osc_range = None
+        # Properties
+        osc_range = property(getOsc_range, setOsc_range, delOsc_range, "Property for osc_range")
+        def getFirst_image(self): return self._first_image
+        def setFirst_image(self, first_image):
+                checkType("XSDataMXCuBEParameters", "setFirst_image", first_image, "integer")
+                self._first_image = first_image
+        def delFirst_image(self): self._first_image = None
+        # Properties
+        first_image = property(getFirst_image, setFirst_image, delFirst_image, "Property for first_image")
+        def getTemplate(self): return self._template
+        def setTemplate(self, template):
+                checkType("XSDataMXCuBEParameters", "setTemplate", template, "string")
+                self._template = template
+        def delTemplate(self): self._template = None
+        # Properties
+        template = property(getTemplate, setTemplate, delTemplate, "Property for template")
+        def getKappaStart(self): return self._kappaStart
+        def setKappaStart(self, kappaStart):
+                checkType("XSDataMXCuBEParameters", "setKappaStart", kappaStart, "float")
+                self._kappaStart = kappaStart
+        def delKappaStart(self): self._kappaStart = None
+        # Properties
+        kappaStart = property(getKappaStart, setKappaStart, delKappaStart, "Property for kappaStart")
+        def getProcessing(self): return self._processing
+        def setProcessing(self, processing):
+                checkType("XSDataMXCuBEParameters", "setProcessing", processing, "boolean")
+                self._processing = processing
+        def delProcessing(self): self._processing = None
+        # Properties
+        processing = property(getProcessing, setProcessing, delProcessing, "Property for processing")
+        def getInverse_beam(self): return self._inverse_beam
+        def setInverse_beam(self, inverse_beam):
+                checkType("XSDataMXCuBEParameters", "setInverse_beam", inverse_beam, "float")
+                self._inverse_beam = inverse_beam
+        def delInverse_beam(self): self._inverse_beam = None
+        # Properties
+        inverse_beam = property(getInverse_beam, setInverse_beam, delInverse_beam, "Property for inverse_beam")
+        def getNumber_images(self): return self._number_images
+        def setNumber_images(self, number_images):
+                checkType("XSDataMXCuBEParameters", "setNumber_images", number_images, "integer")
+                self._number_images = number_images
+        def delNumber_images(self): self._number_images = None
+        # Properties
+        number_images = property(getNumber_images, setNumber_images, delNumber_images, "Property for number_images")
+        def getCurrent_detdistance(self): return self._current_detdistance
+        def setCurrent_detdistance(self, current_detdistance):
+                checkType("XSDataMXCuBEParameters", "setCurrent_detdistance", current_detdistance, "float")
+                self._current_detdistance = current_detdistance
+        def delCurrent_detdistance(self): self._current_detdistance = None
+        # Properties
+        current_detdistance = property(getCurrent_detdistance, setCurrent_detdistance, delCurrent_detdistance, "Property for current_detdistance")
+        def getResidues(self): return self._residues
+        def setResidues(self, residues):
+                checkType("XSDataMXCuBEParameters", "setResidues", residues, "string")
+                self._residues = residues
+        def delResidues(self): self._residues = None
+        # Properties
+        residues = property(getResidues, setResidues, delResidues, "Property for residues")
+        def getRun_number(self): return self._run_number
+        def setRun_number(self, run_number):
+                checkType("XSDataMXCuBEParameters", "setRun_number", run_number, "integer")
+                self._run_number = run_number
+        def delRun_number(self): self._run_number = None
+        # Properties
+        run_number = property(getRun_number, setRun_number, delRun_number, "Property for run_number")
+        def getCurrent_wavelength(self): return self._current_wavelength
+        def setCurrent_wavelength(self, current_wavelength):
+                checkType("XSDataMXCuBEParameters", "setCurrent_wavelength", current_wavelength, "float")
+                self._current_wavelength = current_wavelength
+        def delCurrent_wavelength(self): self._current_wavelength = None
+        # Properties
+        current_wavelength = property(getCurrent_wavelength, setCurrent_wavelength, delCurrent_wavelength, "Property for current_wavelength")
+        def getPhiStart(self): return self._phiStart
+        def setPhiStart(self, phiStart):
+                checkType("XSDataMXCuBEParameters", "setPhiStart", phiStart, "float")
+                self._phiStart = phiStart
+        def delPhiStart(self): self._phiStart = None
+        # Properties
+        phiStart = property(getPhiStart, setPhiStart, delPhiStart, "Property for phiStart")
+        def getAnomalous(self): return self._anomalous
+        def setAnomalous(self, anomalous):
+                checkType("XSDataMXCuBEParameters", "setAnomalous", anomalous, "boolean")
+                self._anomalous = anomalous
+        def delAnomalous(self): self._anomalous = None
+        # Properties
+        anomalous = property(getAnomalous, setAnomalous, delAnomalous, "Property for anomalous")
+        def getNumber_passes(self): return self._number_passes
+        def setNumber_passes(self, number_passes):
+                checkType("XSDataMXCuBEParameters", "setNumber_passes", number_passes, "integer")
+                self._number_passes = number_passes
+        def delNumber_passes(self): self._number_passes = None
+        # Properties
+        number_passes = property(getNumber_passes, setNumber_passes, delNumber_passes, "Property for number_passes")
+        def getDirectory(self): return self._directory
+        def setDirectory(self, directory):
+                checkType("XSDataMXCuBEParameters", "setDirectory", directory, "string")
+                self._directory = directory
+        def delDirectory(self): self._directory = None
+        # Properties
+        directory = property(getDirectory, setDirectory, delDirectory, "Property for directory")
+        def getCurrent_energy(self): return self._current_energy
+        def setCurrent_energy(self, current_energy):
+                checkType("XSDataMXCuBEParameters", "setCurrent_energy", current_energy, "float")
+                self._current_energy = current_energy
+        def delCurrent_energy(self): self._current_energy = None
+        # Properties
+        current_energy = property(getCurrent_energy, setCurrent_energy, delCurrent_energy, "Property for current_energy")
+        def getCurrent_osc_start(self): return self._current_osc_start
+        def setCurrent_osc_start(self, current_osc_start):
+                checkType("XSDataMXCuBEParameters", "setCurrent_osc_start", current_osc_start, "float")
+                self._current_osc_start = current_osc_start
+        def delCurrent_osc_start(self): self._current_osc_start = None
+        # Properties
+        current_osc_start = property(getCurrent_osc_start, setCurrent_osc_start, delCurrent_osc_start, "Property for current_osc_start")
+        def getOutput_file(self): return self._output_file
+        def setOutput_file(self, output_file):
+                checkType("XSDataMXCuBEParameters", "setOutput_file", output_file, "string")
+                self._output_file = output_file
+        def delOutput_file(self): self._output_file = None
+        # Properties
+        output_file = property(getOutput_file, setOutput_file, delOutput_file, "Property for output_file")
+        def getTransmission(self): return self._transmission
+        def setTransmission(self, transmission):
+                checkType("XSDataMXCuBEParameters", "setTransmission", transmission, "float")
+                self._transmission = transmission
+        def delTransmission(self): self._transmission = None
+        # Properties
+        transmission = property(getTransmission, setTransmission, delTransmission, "Property for transmission")
+        def export(self, outfile, level, name_='XSDataMXCuBEParameters'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataMXCuBEParameters'):
+                XSData.exportChildren(self, outfile, level, name_)
+                if self._sessionId is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<sessionId>%d</sessionId>\n' % self._sessionId))
+                else:
+                        warnEmptyAttribute("sessionId", "integer")
+                if self._blSampleId is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<blSampleId>%d</blSampleId>\n' % self._blSampleId))
+                else:
+                        warnEmptyAttribute("blSampleId", "integer")
+                if self._exposure_time is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<exposure_time>%e</exposure_time>\n' % self._exposure_time))
+                else:
+                        warnEmptyAttribute("exposure_time", "float")
+                if self._resolution is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<resolution>%e</resolution>\n' % self._resolution))
+                else:
+                        warnEmptyAttribute("resolution", "float")
+                if self._resolution_at_corner is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<resolution_at_corner>%e</resolution_at_corner>\n' % self._resolution_at_corner))
+                else:
+                        warnEmptyAttribute("resolution_at_corner", "float")
+                if self._x_beam is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<x_beam>%e</x_beam>\n' % self._x_beam))
+                else:
+                        warnEmptyAttribute("x_beam", "float")
+                if self._y_beam is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<y_beam>%e</y_beam>\n' % self._y_beam))
+                else:
+                        warnEmptyAttribute("y_beam", "float")
+                if self._beam_size_x is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<beam_size_x>%e</beam_size_x>\n' % self._beam_size_x))
+                else:
+                        warnEmptyAttribute("beam_size_x", "float")
+                if self._beam_size_y is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<beam_size_y>%e</beam_size_y>\n' % self._beam_size_y))
+                else:
+                        warnEmptyAttribute("beam_size_y", "float")
+                if self._mad_1_energy is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<mad_1_energy>%e</mad_1_energy>\n' % self._mad_1_energy))
+                else:
+                        warnEmptyAttribute("mad_1_energy", "float")
+                if self._mad_2_energy is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<mad_2_energy>%e</mad_2_energy>\n' % self._mad_2_energy))
+                else:
+                        warnEmptyAttribute("mad_2_energy", "float")
+                if self._mad_3_energy is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<mad_3_energy>%e</mad_3_energy>\n' % self._mad_3_energy))
+                else:
+                        warnEmptyAttribute("mad_3_energy", "float")
+                if self._mad_4_energy is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<mad_4_energy>%e</mad_4_energy>\n' % self._mad_4_energy))
+                else:
+                        warnEmptyAttribute("mad_4_energy", "float")
+                if self._prefix is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<prefix>%s</prefix>\n' % self._prefix))
+                else:
+                        warnEmptyAttribute("prefix", "string")
+                if self._overlap is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<overlap>%e</overlap>\n' % self._overlap))
+                else:
+                        warnEmptyAttribute("overlap", "float")
+                if self._osc_start is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<osc_start>%e</osc_start>\n' % self._osc_start))
+                else:
+                        warnEmptyAttribute("osc_start", "float")
+                if self._process_directory is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<process_directory>%s</process_directory>\n' % self._process_directory))
+                else:
+                        warnEmptyAttribute("process_directory", "string")
+                if self._sum_images is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<sum_images>%e</sum_images>\n' % self._sum_images))
+                else:
+                        warnEmptyAttribute("sum_images", "float")
+                if self._detector_mode is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<detector_mode>%s</detector_mode>\n' % self._detector_mode))
+                else:
+                        warnEmptyAttribute("detector_mode", "string")
+                if self._mad_energies is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<mad_energies>%s</mad_energies>\n' % self._mad_energies))
+                else:
+                        warnEmptyAttribute("mad_energies", "string")
+                if self._comments is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<comments>%s</comments>\n' % self._comments))
+                else:
+                        warnEmptyAttribute("comments", "string")
+                if self._osc_range is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<osc_range>%e</osc_range>\n' % self._osc_range))
+                else:
+                        warnEmptyAttribute("osc_range", "float")
+                if self._first_image is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<first_image>%d</first_image>\n' % self._first_image))
+                else:
+                        warnEmptyAttribute("first_image", "integer")
+                if self._template is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<template>%s</template>\n' % self._template))
+                else:
+                        warnEmptyAttribute("template", "string")
+                if self._kappaStart is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<kappaStart>%e</kappaStart>\n' % self._kappaStart))
+                else:
+                        warnEmptyAttribute("kappaStart", "float")
+                if self._processing is not None:
+                        showIndent(outfile, level)
+                        if self._processing:
+                                outfile.write(unicode('<processing>true</processing>\n'))
+                        else:
+                                outfile.write(unicode('<processing>false</processing>\n'))
+                else:
+                        warnEmptyAttribute("processing", "boolean")
+                if self._inverse_beam is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<inverse_beam>%e</inverse_beam>\n' % self._inverse_beam))
+                else:
+                        warnEmptyAttribute("inverse_beam", "float")
+                if self._number_images is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<number_images>%d</number_images>\n' % self._number_images))
+                else:
+                        warnEmptyAttribute("number_images", "integer")
+                if self._current_detdistance is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<current_detdistance>%e</current_detdistance>\n' % self._current_detdistance))
+                else:
+                        warnEmptyAttribute("current_detdistance", "float")
+                if self._residues is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<residues>%s</residues>\n' % self._residues))
+                else:
+                        warnEmptyAttribute("residues", "string")
+                if self._run_number is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<run_number>%d</run_number>\n' % self._run_number))
+                else:
+                        warnEmptyAttribute("run_number", "integer")
+                if self._current_wavelength is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<current_wavelength>%e</current_wavelength>\n' % self._current_wavelength))
+                else:
+                        warnEmptyAttribute("current_wavelength", "float")
+                if self._phiStart is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<phiStart>%e</phiStart>\n' % self._phiStart))
+                else:
+                        warnEmptyAttribute("phiStart", "float")
+                if self._anomalous is not None:
+                        showIndent(outfile, level)
+                        if self._anomalous:
+                                outfile.write(unicode('<anomalous>true</anomalous>\n'))
+                        else:
+                                outfile.write(unicode('<anomalous>false</anomalous>\n'))
+                else:
+                        warnEmptyAttribute("anomalous", "boolean")
+                if self._number_passes is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<number_passes>%d</number_passes>\n' % self._number_passes))
+                else:
+                        warnEmptyAttribute("number_passes", "integer")
+                if self._directory is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<directory>%s</directory>\n' % self._directory))
+                else:
+                        warnEmptyAttribute("directory", "string")
+                if self._current_energy is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<current_energy>%e</current_energy>\n' % self._current_energy))
+                else:
+                        warnEmptyAttribute("current_energy", "float")
+                if self._current_osc_start is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<current_osc_start>%e</current_osc_start>\n' % self._current_osc_start))
+                else:
+                        warnEmptyAttribute("current_osc_start", "float")
+                if self._output_file is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<output_file>%s</output_file>\n' % self._output_file))
+                else:
+                        warnEmptyAttribute("output_file", "string")
+                if self._transmission is not None:
+                        showIndent(outfile, level)
+                        outfile.write(unicode('<transmission>%e</transmission>\n' % self._transmission))
+                else:
+                        warnEmptyAttribute("transmission", "float")
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'sessionId':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self._sessionId = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'blSampleId':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self._blSampleId = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'exposure_time':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._exposure_time = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'resolution':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._resolution = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'resolution_at_corner':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._resolution_at_corner = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'x_beam':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._x_beam = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'y_beam':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._y_beam = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'beam_size_x':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._beam_size_x = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'beam_size_y':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._beam_size_y = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'mad_1_energy':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._mad_1_energy = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'mad_2_energy':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._mad_2_energy = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'mad_3_energy':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._mad_3_energy = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'mad_4_energy':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._mad_4_energy = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'prefix':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._prefix = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'overlap':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._overlap = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'osc_start':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._osc_start = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'process_directory':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._process_directory = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'sum_images':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._sum_images = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'detector_mode':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._detector_mode = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'mad_energies':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._mad_energies = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'comments':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._comments = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'osc_range':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._osc_range = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'first_image':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self._first_image = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'template':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._template = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'kappaStart':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._kappaStart = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'processing':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                if sval_ in ('True', 'true', '1'):
+                                        ival_ = True
+                                elif sval_ in ('False', 'false', '0'):
+                                        ival_ = False
+                                else:
+                                        raise ValueError('requires boolean -- %s' % child_.toxml())
+                                self._processing = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'inverse_beam':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._inverse_beam = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'number_images':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self._number_images = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'current_detdistance':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._current_detdistance = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'residues':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._residues = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'run_number':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self._run_number = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'current_wavelength':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._current_wavelength = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'phiStart':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._phiStart = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'anomalous':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                if sval_ in ('True', 'true', '1'):
+                                        ival_ = True
+                                elif sval_ in ('False', 'false', '0'):
+                                        ival_ = False
+                                else:
+                                        raise ValueError('requires boolean -- %s' % child_.toxml())
+                                self._anomalous = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'number_passes':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        ival_ = int(sval_)
+                                except ValueError:
+                                        raise ValueError('requires integer -- %s' % child_.toxml())
+                                self._number_passes = ival_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'directory':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._directory = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'current_energy':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._current_energy = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'current_osc_start':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._current_osc_start = fval_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'output_file':
+                        value_ = ''
+                        for text__content_ in child_.childNodes:
+                                if text__content_.nodeValue is not None:
+                                        value_ += text__content_.nodeValue
+                        self._output_file = value_
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'transmission':
+                        if child_.firstChild:
+                                sval_ = child_.firstChild.nodeValue
+                                try:
+                                        fval_ = float(sval_)
+                                except ValueError:
+                                        raise ValueError('requires float (or double) -- %s' % child_.toxml())
+                                self._transmission = fval_
+                XSData.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataMXCuBEParameters" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataMXCuBEParameters' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataMXCuBEParameters is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataMXCuBEParameters.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataMXCuBEParameters()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataMXCuBEParameters" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataMXCuBEParameters()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataMXCuBEParameters
 
 class XSDataInputMXCuBE(XSDataInput):
-	def __init__(self, configuration=None, dataSet=None, sample=None, outputFileDirectory=None, experimentalCondition=None, diffractionPlan=None, dataCollectionId=None, characterisationInput=None):
-		XSDataInput.__init__(self, configuration)
-	
-	
-		checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", characterisationInput, "XSDataInputCharacterisation")
-		self._characterisationInput = characterisationInput
-		checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", dataCollectionId, "XSDataInteger")
-		self._dataCollectionId = dataCollectionId
-		checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", diffractionPlan, "XSDataDiffractionPlan")
-		self._diffractionPlan = diffractionPlan
-		checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", experimentalCondition, "XSDataExperimentalCondition")
-		self._experimentalCondition = experimentalCondition
-		checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", outputFileDirectory, "XSDataFile")
-		self._outputFileDirectory = outputFileDirectory
-		checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", sample, "XSDataSampleCrystalMM")
-		self._sample = sample
-		if dataSet is None:
-			self._dataSet = []
-		else:
-			checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", dataSet, "list")
-			self._dataSet = dataSet
-	def getCharacterisationInput(self): return self._characterisationInput
-	def setCharacterisationInput(self, characterisationInput):
-		checkType("XSDataInputMXCuBE", "setCharacterisationInput", characterisationInput, "XSDataInputCharacterisation")
-		self._characterisationInput = characterisationInput
-	def delCharacterisationInput(self): self._characterisationInput = None
-	# Properties
-	characterisationInput = property(getCharacterisationInput, setCharacterisationInput, delCharacterisationInput, "Property for characterisationInput")
-	def getDataCollectionId(self): return self._dataCollectionId
-	def setDataCollectionId(self, dataCollectionId):
-		checkType("XSDataInputMXCuBE", "setDataCollectionId", dataCollectionId, "XSDataInteger")
-		self._dataCollectionId = dataCollectionId
-	def delDataCollectionId(self): self._dataCollectionId = None
-	# Properties
-	dataCollectionId = property(getDataCollectionId, setDataCollectionId, delDataCollectionId, "Property for dataCollectionId")
-	def getDiffractionPlan(self): return self._diffractionPlan
-	def setDiffractionPlan(self, diffractionPlan):
-		checkType("XSDataInputMXCuBE", "setDiffractionPlan", diffractionPlan, "XSDataDiffractionPlan")
-		self._diffractionPlan = diffractionPlan
-	def delDiffractionPlan(self): self._diffractionPlan = None
-	# Properties
-	diffractionPlan = property(getDiffractionPlan, setDiffractionPlan, delDiffractionPlan, "Property for diffractionPlan")
-	def getExperimentalCondition(self): return self._experimentalCondition
-	def setExperimentalCondition(self, experimentalCondition):
-		checkType("XSDataInputMXCuBE", "setExperimentalCondition", experimentalCondition, "XSDataExperimentalCondition")
-		self._experimentalCondition = experimentalCondition
-	def delExperimentalCondition(self): self._experimentalCondition = None
-	# Properties
-	experimentalCondition = property(getExperimentalCondition, setExperimentalCondition, delExperimentalCondition, "Property for experimentalCondition")
-	def getOutputFileDirectory(self): return self._outputFileDirectory
-	def setOutputFileDirectory(self, outputFileDirectory):
-		checkType("XSDataInputMXCuBE", "setOutputFileDirectory", outputFileDirectory, "XSDataFile")
-		self._outputFileDirectory = outputFileDirectory
-	def delOutputFileDirectory(self): self._outputFileDirectory = None
-	# Properties
-	outputFileDirectory = property(getOutputFileDirectory, setOutputFileDirectory, delOutputFileDirectory, "Property for outputFileDirectory")
-	def getSample(self): return self._sample
-	def setSample(self, sample):
-		checkType("XSDataInputMXCuBE", "setSample", sample, "XSDataSampleCrystalMM")
-		self._sample = sample
-	def delSample(self): self._sample = None
-	# Properties
-	sample = property(getSample, setSample, delSample, "Property for sample")
-	def getDataSet(self): return self._dataSet
-	def setDataSet(self, dataSet):
-		checkType("XSDataInputMXCuBE", "setDataSet", dataSet, "list")
-		self._dataSet = dataSet
-	def delDataSet(self): self._dataSet = None
-	# Properties
-	dataSet = property(getDataSet, setDataSet, delDataSet, "Property for dataSet")
-	def addDataSet(self, value):
-		checkType("XSDataInputMXCuBE", "setDataSet", value, "XSDataMXCuBEDataSet")
-		self._dataSet.append(value)
-	def insertDataSet(self, index, value):
-		checkType("XSDataInputMXCuBE", "setDataSet", value, "XSDataMXCuBEDataSet")
-		self._dataSet[index] = value
-	def export(self, outfile, level, name_='XSDataInputMXCuBE'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataInputMXCuBE'):
-		XSDataInput.exportChildren(self, outfile, level, name_)
-		if self._characterisationInput is not None:
-			self.characterisationInput.export(outfile, level, name_='characterisationInput')
-		if self._dataCollectionId is not None:
-			self.dataCollectionId.export(outfile, level, name_='dataCollectionId')
-		if self._diffractionPlan is not None:
-			self.diffractionPlan.export(outfile, level, name_='diffractionPlan')
-		if self._experimentalCondition is not None:
-			self.experimentalCondition.export(outfile, level, name_='experimentalCondition')
-		if self._outputFileDirectory is not None:
-			self.outputFileDirectory.export(outfile, level, name_='outputFileDirectory')
-		if self._sample is not None:
-			self.sample.export(outfile, level, name_='sample')
-		for dataSet_ in self.getDataSet():
-			dataSet_.export(outfile, level, name_='dataSet')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'characterisationInput':
-			obj_ = XSDataInputCharacterisation()
-			obj_.build(child_)
-			self.setCharacterisationInput(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'dataCollectionId':
-			obj_ = XSDataInteger()
-			obj_.build(child_)
-			self.setDataCollectionId(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'diffractionPlan':
-			obj_ = XSDataDiffractionPlan()
-			obj_.build(child_)
-			self.setDiffractionPlan(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'experimentalCondition':
-			obj_ = XSDataExperimentalCondition()
-			obj_.build(child_)
-			self.setExperimentalCondition(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'outputFileDirectory':
-			obj_ = XSDataFile()
-			obj_.build(child_)
-			self.setOutputFileDirectory(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'sample':
-			obj_ = XSDataSampleCrystalMM()
-			obj_.build(child_)
-			self.setSample(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'dataSet':
-			obj_ = XSDataMXCuBEDataSet()
-			obj_.build(child_)
-			self.dataSet.append(obj_)
-		XSDataInput.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataInputMXCuBE" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataInputMXCuBE' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataInputMXCuBE is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataInputMXCuBE.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataInputMXCuBE()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataInputMXCuBE" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataInputMXCuBE()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, configuration=None, dataSet=None, sample=None, outputFileDirectory=None, experimentalCondition=None, diffractionPlan=None, dataCollectionId=None, characterisationInput=None):
+                XSDataInput.__init__(self, configuration)
+
+
+                checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", characterisationInput, "XSDataInputCharacterisation")
+                self._characterisationInput = characterisationInput
+                checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", dataCollectionId, "XSDataInteger")
+                self._dataCollectionId = dataCollectionId
+                checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", diffractionPlan, "XSDataDiffractionPlan")
+                self._diffractionPlan = diffractionPlan
+                checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", experimentalCondition, "XSDataExperimentalCondition")
+                self._experimentalCondition = experimentalCondition
+                checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", outputFileDirectory, "XSDataFile")
+                self._outputFileDirectory = outputFileDirectory
+                checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", sample, "XSDataSampleCrystalMM")
+                self._sample = sample
+                if dataSet is None:
+                        self._dataSet = []
+                else:
+                        checkType("XSDataInputMXCuBE", "Constructor of XSDataInputMXCuBE", dataSet, "list")
+                        self._dataSet = dataSet
+        def getCharacterisationInput(self): return self._characterisationInput
+        def setCharacterisationInput(self, characterisationInput):
+                checkType("XSDataInputMXCuBE", "setCharacterisationInput", characterisationInput, "XSDataInputCharacterisation")
+                self._characterisationInput = characterisationInput
+        def delCharacterisationInput(self): self._characterisationInput = None
+        # Properties
+        characterisationInput = property(getCharacterisationInput, setCharacterisationInput, delCharacterisationInput, "Property for characterisationInput")
+        def getDataCollectionId(self): return self._dataCollectionId
+        def setDataCollectionId(self, dataCollectionId):
+                checkType("XSDataInputMXCuBE", "setDataCollectionId", dataCollectionId, "XSDataInteger")
+                self._dataCollectionId = dataCollectionId
+        def delDataCollectionId(self): self._dataCollectionId = None
+        # Properties
+        dataCollectionId = property(getDataCollectionId, setDataCollectionId, delDataCollectionId, "Property for dataCollectionId")
+        def getDiffractionPlan(self): return self._diffractionPlan
+        def setDiffractionPlan(self, diffractionPlan):
+                checkType("XSDataInputMXCuBE", "setDiffractionPlan", diffractionPlan, "XSDataDiffractionPlan")
+                self._diffractionPlan = diffractionPlan
+        def delDiffractionPlan(self): self._diffractionPlan = None
+        # Properties
+        diffractionPlan = property(getDiffractionPlan, setDiffractionPlan, delDiffractionPlan, "Property for diffractionPlan")
+        def getExperimentalCondition(self): return self._experimentalCondition
+        def setExperimentalCondition(self, experimentalCondition):
+                checkType("XSDataInputMXCuBE", "setExperimentalCondition", experimentalCondition, "XSDataExperimentalCondition")
+                self._experimentalCondition = experimentalCondition
+        def delExperimentalCondition(self): self._experimentalCondition = None
+        # Properties
+        experimentalCondition = property(getExperimentalCondition, setExperimentalCondition, delExperimentalCondition, "Property for experimentalCondition")
+        def getOutputFileDirectory(self): return self._outputFileDirectory
+        def setOutputFileDirectory(self, outputFileDirectory):
+                checkType("XSDataInputMXCuBE", "setOutputFileDirectory", outputFileDirectory, "XSDataFile")
+                self._outputFileDirectory = outputFileDirectory
+        def delOutputFileDirectory(self): self._outputFileDirectory = None
+        # Properties
+        outputFileDirectory = property(getOutputFileDirectory, setOutputFileDirectory, delOutputFileDirectory, "Property for outputFileDirectory")
+        def getSample(self): return self._sample
+        def setSample(self, sample):
+                checkType("XSDataInputMXCuBE", "setSample", sample, "XSDataSampleCrystalMM")
+                self._sample = sample
+        def delSample(self): self._sample = None
+        # Properties
+        sample = property(getSample, setSample, delSample, "Property for sample")
+        def getDataSet(self): return self._dataSet
+        def setDataSet(self, dataSet):
+                checkType("XSDataInputMXCuBE", "setDataSet", dataSet, "list")
+                self._dataSet = dataSet
+        def delDataSet(self): self._dataSet = None
+        # Properties
+        dataSet = property(getDataSet, setDataSet, delDataSet, "Property for dataSet")
+        def addDataSet(self, value):
+                checkType("XSDataInputMXCuBE", "setDataSet", value, "XSDataMXCuBEDataSet")
+                self._dataSet.append(value)
+        def insertDataSet(self, index, value):
+                checkType("XSDataInputMXCuBE", "setDataSet", value, "XSDataMXCuBEDataSet")
+                self._dataSet[index] = value
+        def export(self, outfile, level, name_='XSDataInputMXCuBE'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataInputMXCuBE'):
+                XSDataInput.exportChildren(self, outfile, level, name_)
+                if self._characterisationInput is not None:
+                        self.characterisationInput.export(outfile, level, name_='characterisationInput')
+                if self._dataCollectionId is not None:
+                        self.dataCollectionId.export(outfile, level, name_='dataCollectionId')
+                if self._diffractionPlan is not None:
+                        self.diffractionPlan.export(outfile, level, name_='diffractionPlan')
+                if self._experimentalCondition is not None:
+                        self.experimentalCondition.export(outfile, level, name_='experimentalCondition')
+                if self._outputFileDirectory is not None:
+                        self.outputFileDirectory.export(outfile, level, name_='outputFileDirectory')
+                if self._sample is not None:
+                        self.sample.export(outfile, level, name_='sample')
+                for dataSet_ in self.getDataSet():
+                        dataSet_.export(outfile, level, name_='dataSet')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'characterisationInput':
+                        obj_ = XSDataInputCharacterisation()
+                        obj_.build(child_)
+                        self.setCharacterisationInput(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'dataCollectionId':
+                        obj_ = XSDataInteger()
+                        obj_.build(child_)
+                        self.setDataCollectionId(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'diffractionPlan':
+                        obj_ = XSDataDiffractionPlan()
+                        obj_.build(child_)
+                        self.setDiffractionPlan(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'experimentalCondition':
+                        obj_ = XSDataExperimentalCondition()
+                        obj_.build(child_)
+                        self.setExperimentalCondition(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'outputFileDirectory':
+                        obj_ = XSDataFile()
+                        obj_.build(child_)
+                        self.setOutputFileDirectory(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'sample':
+                        obj_ = XSDataSampleCrystalMM()
+                        obj_.build(child_)
+                        self.setSample(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'dataSet':
+                        obj_ = XSDataMXCuBEDataSet()
+                        obj_.build(child_)
+                        self.dataSet.append(obj_)
+                XSDataInput.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataInputMXCuBE" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataInputMXCuBE' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataInputMXCuBE is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataInputMXCuBE.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataInputMXCuBE()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataInputMXCuBE" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataInputMXCuBE()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataInputMXCuBE
 
 class XSDataResultMXCuBE(XSDataResult):
-	def __init__(self, status=None, screeningId=None, htmlPage=None, outputFileDictionary=None, listOfOutputFiles=None, collectionPlan=None, characterisationResult=None, characterisationExecutiveSummary=None):
-		XSDataResult.__init__(self, status)
-	
-	
-		checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", characterisationExecutiveSummary, "XSDataString")
-		self._characterisationExecutiveSummary = characterisationExecutiveSummary
-		checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", characterisationResult, "XSDataResultCharacterisation")
-		self._characterisationResult = characterisationResult
-		if collectionPlan is None:
-			self._collectionPlan = []
-		else:
-			checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", collectionPlan, "list")
-			self._collectionPlan = collectionPlan
-		checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", listOfOutputFiles, "XSDataString")
-		self._listOfOutputFiles = listOfOutputFiles
-		checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", outputFileDictionary, "XSDataDictionary")
-		self._outputFileDictionary = outputFileDictionary
-		checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", htmlPage, "XSDataFile")
-		self._htmlPage = htmlPage
-		checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", screeningId, "XSDataInteger")
-		self._screeningId = screeningId
-	def getCharacterisationExecutiveSummary(self): return self._characterisationExecutiveSummary
-	def setCharacterisationExecutiveSummary(self, characterisationExecutiveSummary):
-		checkType("XSDataResultMXCuBE", "setCharacterisationExecutiveSummary", characterisationExecutiveSummary, "XSDataString")
-		self._characterisationExecutiveSummary = characterisationExecutiveSummary
-	def delCharacterisationExecutiveSummary(self): self._characterisationExecutiveSummary = None
-	# Properties
-	characterisationExecutiveSummary = property(getCharacterisationExecutiveSummary, setCharacterisationExecutiveSummary, delCharacterisationExecutiveSummary, "Property for characterisationExecutiveSummary")
-	def getCharacterisationResult(self): return self._characterisationResult
-	def setCharacterisationResult(self, characterisationResult):
-		checkType("XSDataResultMXCuBE", "setCharacterisationResult", characterisationResult, "XSDataResultCharacterisation")
-		self._characterisationResult = characterisationResult
-	def delCharacterisationResult(self): self._characterisationResult = None
-	# Properties
-	characterisationResult = property(getCharacterisationResult, setCharacterisationResult, delCharacterisationResult, "Property for characterisationResult")
-	def getCollectionPlan(self): return self._collectionPlan
-	def setCollectionPlan(self, collectionPlan):
-		checkType("XSDataResultMXCuBE", "setCollectionPlan", collectionPlan, "list")
-		self._collectionPlan = collectionPlan
-	def delCollectionPlan(self): self._collectionPlan = None
-	# Properties
-	collectionPlan = property(getCollectionPlan, setCollectionPlan, delCollectionPlan, "Property for collectionPlan")
-	def addCollectionPlan(self, value):
-		checkType("XSDataResultMXCuBE", "setCollectionPlan", value, "XSDataCollectionPlan")
-		self._collectionPlan.append(value)
-	def insertCollectionPlan(self, index, value):
-		checkType("XSDataResultMXCuBE", "setCollectionPlan", value, "XSDataCollectionPlan")
-		self._collectionPlan[index] = value
-	def getListOfOutputFiles(self): return self._listOfOutputFiles
-	def setListOfOutputFiles(self, listOfOutputFiles):
-		checkType("XSDataResultMXCuBE", "setListOfOutputFiles", listOfOutputFiles, "XSDataString")
-		self._listOfOutputFiles = listOfOutputFiles
-	def delListOfOutputFiles(self): self._listOfOutputFiles = None
-	# Properties
-	listOfOutputFiles = property(getListOfOutputFiles, setListOfOutputFiles, delListOfOutputFiles, "Property for listOfOutputFiles")
-	def getOutputFileDictionary(self): return self._outputFileDictionary
-	def setOutputFileDictionary(self, outputFileDictionary):
-		checkType("XSDataResultMXCuBE", "setOutputFileDictionary", outputFileDictionary, "XSDataDictionary")
-		self._outputFileDictionary = outputFileDictionary
-	def delOutputFileDictionary(self): self._outputFileDictionary = None
-	# Properties
-	outputFileDictionary = property(getOutputFileDictionary, setOutputFileDictionary, delOutputFileDictionary, "Property for outputFileDictionary")
-	def getHtmlPage(self): return self._htmlPage
-	def setHtmlPage(self, htmlPage):
-		checkType("XSDataResultMXCuBE", "setHtmlPage", htmlPage, "XSDataFile")
-		self._htmlPage = htmlPage
-	def delHtmlPage(self): self._htmlPage = None
-	# Properties
-	htmlPage = property(getHtmlPage, setHtmlPage, delHtmlPage, "Property for htmlPage")
-	def getScreeningId(self): return self._screeningId
-	def setScreeningId(self, screeningId):
-		checkType("XSDataResultMXCuBE", "setScreeningId", screeningId, "XSDataInteger")
-		self._screeningId = screeningId
-	def delScreeningId(self): self._screeningId = None
-	# Properties
-	screeningId = property(getScreeningId, setScreeningId, delScreeningId, "Property for screeningId")
-	def export(self, outfile, level, name_='XSDataResultMXCuBE'):
-		showIndent(outfile, level)
-		outfile.write(unicode('<%s>\n' % name_))
-		self.exportChildren(outfile, level + 1, name_)
-		showIndent(outfile, level)
-		outfile.write(unicode('</%s>\n' % name_))
-	def exportChildren(self, outfile, level, name_='XSDataResultMXCuBE'):
-		XSDataResult.exportChildren(self, outfile, level, name_)
-		if self._characterisationExecutiveSummary is not None:
-			self.characterisationExecutiveSummary.export(outfile, level, name_='characterisationExecutiveSummary')
-		if self._characterisationResult is not None:
-			self.characterisationResult.export(outfile, level, name_='characterisationResult')
-		for collectionPlan_ in self.getCollectionPlan():
-			collectionPlan_.export(outfile, level, name_='collectionPlan')
-		if self._listOfOutputFiles is not None:
-			self.listOfOutputFiles.export(outfile, level, name_='listOfOutputFiles')
-		if self._outputFileDictionary is not None:
-			self.outputFileDictionary.export(outfile, level, name_='outputFileDictionary')
-		if self._htmlPage is not None:
-			self.htmlPage.export(outfile, level, name_='htmlPage')
-		if self._screeningId is not None:
-			self.screeningId.export(outfile, level, name_='screeningId')
-	def build(self, node_):
-		for child_ in node_.childNodes:
-			nodeName_ = child_.nodeName.split(':')[-1]
-			self.buildChildren(child_, nodeName_)
-	def buildChildren(self, child_, nodeName_):
-		if child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'characterisationExecutiveSummary':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setCharacterisationExecutiveSummary(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'characterisationResult':
-			obj_ = XSDataResultCharacterisation()
-			obj_.build(child_)
-			self.setCharacterisationResult(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'collectionPlan':
-			obj_ = XSDataCollectionPlan()
-			obj_.build(child_)
-			self.collectionPlan.append(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'listOfOutputFiles':
-			obj_ = XSDataString()
-			obj_.build(child_)
-			self.setListOfOutputFiles(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'outputFileDictionary':
-			obj_ = XSDataDictionary()
-			obj_.build(child_)
-			self.setOutputFileDictionary(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'htmlPage':
-			obj_ = XSDataFile()
-			obj_.build(child_)
-			self.setHtmlPage(obj_)
-		elif child_.nodeType == Node.ELEMENT_NODE and \
-			nodeName_ == 'screeningId':
-			obj_ = XSDataInteger()
-			obj_.build(child_)
-			self.setScreeningId(obj_)
-		XSDataResult.buildChildren(self, child_, nodeName_)
-	#Method for marshalling an object
-	def marshal( self ):
-		oStreamString = StringIO()
-		oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
-		self.export( oStreamString, 0, name_="XSDataResultMXCuBE" )
-		oStringXML = oStreamString.getvalue()
-		oStreamString.close()
-		return oStringXML
-	#Only to export the entire XML tree to a file stream on disk
-	def exportToFile( self, _outfileName ):
-		outfile = open( _outfileName, "w" )
-		outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
-		self.export( outfile, 0, name_='XSDataResultMXCuBE' )
-		outfile.close()
-	#Deprecated method, replaced by exportToFile
-	def outputFile( self, _outfileName ):
-		print("WARNING: Method outputFile in class XSDataResultMXCuBE is deprecated, please use instead exportToFile!")
-		self.exportToFile(_outfileName)
-	#Method for making a copy in a new instance
-	def copy( self ):
-		return XSDataResultMXCuBE.parseString(self.marshal())
-	#Static method for parsing a string
-	def parseString( _inString ):
-		doc = minidom.parseString(_inString)
-		rootNode = doc.documentElement
-		rootObj = XSDataResultMXCuBE()
-		rootObj.build(rootNode)
-		# Check that all minOccurs are obeyed by marshalling the created object
-		oStreamString = StringIO()
-		rootObj.export( oStreamString, 0, name_="XSDataResultMXCuBE" )
-		oStreamString.close()
-		return rootObj
-	parseString = staticmethod( parseString )
-	#Static method for parsing a file
-	def parseFile( _inFilePath ):
-		doc = minidom.parse(_inFilePath)
-		rootNode = doc.documentElement
-		rootObj = XSDataResultMXCuBE()
-		rootObj.build(rootNode)
-		return rootObj
-	parseFile = staticmethod( parseFile )
+        def __init__(self, status=None, screeningId=None, htmlPage=None, outputFileDictionary=None, listOfOutputFiles=None, collectionPlan=None, characterisationResult=None, characterisationExecutiveSummary=None):
+                XSDataResult.__init__(self, status)
+
+
+                checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", characterisationExecutiveSummary, "XSDataString")
+                self._characterisationExecutiveSummary = characterisationExecutiveSummary
+                checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", characterisationResult, "XSDataResultCharacterisation")
+                self._characterisationResult = characterisationResult
+                if collectionPlan is None:
+                        self._collectionPlan = []
+                else:
+                        checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", collectionPlan, "list")
+                        self._collectionPlan = collectionPlan
+                checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", listOfOutputFiles, "XSDataString")
+                self._listOfOutputFiles = listOfOutputFiles
+                checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", outputFileDictionary, "XSDataDictionary")
+                self._outputFileDictionary = outputFileDictionary
+                checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", htmlPage, "XSDataFile")
+                self._htmlPage = htmlPage
+                checkType("XSDataResultMXCuBE", "Constructor of XSDataResultMXCuBE", screeningId, "XSDataInteger")
+                self._screeningId = screeningId
+        def getCharacterisationExecutiveSummary(self): return self._characterisationExecutiveSummary
+        def setCharacterisationExecutiveSummary(self, characterisationExecutiveSummary):
+                checkType("XSDataResultMXCuBE", "setCharacterisationExecutiveSummary", characterisationExecutiveSummary, "XSDataString")
+                self._characterisationExecutiveSummary = characterisationExecutiveSummary
+        def delCharacterisationExecutiveSummary(self): self._characterisationExecutiveSummary = None
+        # Properties
+        characterisationExecutiveSummary = property(getCharacterisationExecutiveSummary, setCharacterisationExecutiveSummary, delCharacterisationExecutiveSummary, "Property for characterisationExecutiveSummary")
+        def getCharacterisationResult(self): return self._characterisationResult
+        def setCharacterisationResult(self, characterisationResult):
+                checkType("XSDataResultMXCuBE", "setCharacterisationResult", characterisationResult, "XSDataResultCharacterisation")
+                self._characterisationResult = characterisationResult
+        def delCharacterisationResult(self): self._characterisationResult = None
+        # Properties
+        characterisationResult = property(getCharacterisationResult, setCharacterisationResult, delCharacterisationResult, "Property for characterisationResult")
+        def getCollectionPlan(self): return self._collectionPlan
+        def setCollectionPlan(self, collectionPlan):
+                checkType("XSDataResultMXCuBE", "setCollectionPlan", collectionPlan, "list")
+                self._collectionPlan = collectionPlan
+        def delCollectionPlan(self): self._collectionPlan = None
+        # Properties
+        collectionPlan = property(getCollectionPlan, setCollectionPlan, delCollectionPlan, "Property for collectionPlan")
+        def addCollectionPlan(self, value):
+                checkType("XSDataResultMXCuBE", "setCollectionPlan", value, "XSDataCollectionPlan")
+                self._collectionPlan.append(value)
+        def insertCollectionPlan(self, index, value):
+                checkType("XSDataResultMXCuBE", "setCollectionPlan", value, "XSDataCollectionPlan")
+                self._collectionPlan[index] = value
+        def getListOfOutputFiles(self): return self._listOfOutputFiles
+        def setListOfOutputFiles(self, listOfOutputFiles):
+                checkType("XSDataResultMXCuBE", "setListOfOutputFiles", listOfOutputFiles, "XSDataString")
+                self._listOfOutputFiles = listOfOutputFiles
+        def delListOfOutputFiles(self): self._listOfOutputFiles = None
+        # Properties
+        listOfOutputFiles = property(getListOfOutputFiles, setListOfOutputFiles, delListOfOutputFiles, "Property for listOfOutputFiles")
+        def getOutputFileDictionary(self): return self._outputFileDictionary
+        def setOutputFileDictionary(self, outputFileDictionary):
+                checkType("XSDataResultMXCuBE", "setOutputFileDictionary", outputFileDictionary, "XSDataDictionary")
+                self._outputFileDictionary = outputFileDictionary
+        def delOutputFileDictionary(self): self._outputFileDictionary = None
+        # Properties
+        outputFileDictionary = property(getOutputFileDictionary, setOutputFileDictionary, delOutputFileDictionary, "Property for outputFileDictionary")
+        def getHtmlPage(self): return self._htmlPage
+        def setHtmlPage(self, htmlPage):
+                checkType("XSDataResultMXCuBE", "setHtmlPage", htmlPage, "XSDataFile")
+                self._htmlPage = htmlPage
+        def delHtmlPage(self): self._htmlPage = None
+        # Properties
+        htmlPage = property(getHtmlPage, setHtmlPage, delHtmlPage, "Property for htmlPage")
+        def getScreeningId(self): return self._screeningId
+        def setScreeningId(self, screeningId):
+                checkType("XSDataResultMXCuBE", "setScreeningId", screeningId, "XSDataInteger")
+                self._screeningId = screeningId
+        def delScreeningId(self): self._screeningId = None
+        # Properties
+        screeningId = property(getScreeningId, setScreeningId, delScreeningId, "Property for screeningId")
+        def export(self, outfile, level, name_='XSDataResultMXCuBE'):
+                showIndent(outfile, level)
+                outfile.write(unicode('<%s>\n' % name_))
+                self.exportChildren(outfile, level + 1, name_)
+                showIndent(outfile, level)
+                outfile.write(unicode('</%s>\n' % name_))
+        def exportChildren(self, outfile, level, name_='XSDataResultMXCuBE'):
+                XSDataResult.exportChildren(self, outfile, level, name_)
+                if self._characterisationExecutiveSummary is not None:
+                        self.characterisationExecutiveSummary.export(outfile, level, name_='characterisationExecutiveSummary')
+                if self._characterisationResult is not None:
+                        self.characterisationResult.export(outfile, level, name_='characterisationResult')
+                for collectionPlan_ in self.getCollectionPlan():
+                        collectionPlan_.export(outfile, level, name_='collectionPlan')
+                if self._listOfOutputFiles is not None:
+                        self.listOfOutputFiles.export(outfile, level, name_='listOfOutputFiles')
+                if self._outputFileDictionary is not None:
+                        self.outputFileDictionary.export(outfile, level, name_='outputFileDictionary')
+                if self._htmlPage is not None:
+                        self.htmlPage.export(outfile, level, name_='htmlPage')
+                if self._screeningId is not None:
+                        self.screeningId.export(outfile, level, name_='screeningId')
+        def build(self, node_):
+                for child_ in node_.childNodes:
+                        nodeName_ = child_.nodeName.split(':')[-1]
+                        self.buildChildren(child_, nodeName_)
+        def buildChildren(self, child_, nodeName_):
+                if child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'characterisationExecutiveSummary':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setCharacterisationExecutiveSummary(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'characterisationResult':
+                        obj_ = XSDataResultCharacterisation()
+                        obj_.build(child_)
+                        self.setCharacterisationResult(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'collectionPlan':
+                        obj_ = XSDataCollectionPlan()
+                        obj_.build(child_)
+                        self.collectionPlan.append(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'listOfOutputFiles':
+                        obj_ = XSDataString()
+                        obj_.build(child_)
+                        self.setListOfOutputFiles(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'outputFileDictionary':
+                        obj_ = XSDataDictionary()
+                        obj_.build(child_)
+                        self.setOutputFileDictionary(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'htmlPage':
+                        obj_ = XSDataFile()
+                        obj_.build(child_)
+                        self.setHtmlPage(obj_)
+                elif child_.nodeType == Node.ELEMENT_NODE and \
+                        nodeName_ == 'screeningId':
+                        obj_ = XSDataInteger()
+                        obj_.build(child_)
+                        self.setScreeningId(obj_)
+                XSDataResult.buildChildren(self, child_, nodeName_)
+        #Method for marshalling an object
+        def marshal( self ):
+                oStreamString = StringIO()
+                oStreamString.write(unicode('<?xml version="1.0" ?>\n'))
+                self.export( oStreamString, 0, name_="XSDataResultMXCuBE" )
+                oStringXML = oStreamString.getvalue()
+                oStreamString.close()
+                return oStringXML
+        #Only to export the entire XML tree to a file stream on disk
+        def exportToFile( self, _outfileName ):
+                outfile = open( _outfileName, "w" )
+                outfile.write(unicode('<?xml version=\"1.0\" ?>\n'))
+                self.export( outfile, 0, name_='XSDataResultMXCuBE' )
+                outfile.close()
+        #Deprecated method, replaced by exportToFile
+        def outputFile( self, _outfileName ):
+                print("WARNING: Method outputFile in class XSDataResultMXCuBE is deprecated, please use instead exportToFile!")
+                self.exportToFile(_outfileName)
+        #Method for making a copy in a new instance
+        def copy( self ):
+                return XSDataResultMXCuBE.parseString(self.marshal())
+        #Static method for parsing a string
+        def parseString( _inString ):
+                doc = minidom.parseString(_inString)
+                rootNode = doc.documentElement
+                rootObj = XSDataResultMXCuBE()
+                rootObj.build(rootNode)
+                # Check that all minOccurs are obeyed by marshalling the created object
+                oStreamString = StringIO()
+                rootObj.export( oStreamString, 0, name_="XSDataResultMXCuBE" )
+                oStreamString.close()
+                return rootObj
+        parseString = staticmethod( parseString )
+        #Static method for parsing a file
+        def parseFile( _inFilePath ):
+                doc = minidom.parse(_inFilePath)
+                rootNode = doc.documentElement
+                rootObj = XSDataResultMXCuBE()
+                rootObj.build(rootNode)
+                return rootObj
+        parseFile = staticmethod( parseFile )
 # end class XSDataResultMXCuBE
 
 

--- a/HardwareObjects/autoprocessing.py
+++ b/HardwareObjects/autoprocessing.py
@@ -35,7 +35,7 @@ def start(programs, processEvent, paramsDict):
             allowed_events = program.getProperty("event").split(" ")
             if processEvent in allowed_events:
                 executable = program.getProperty('executable')
-		
+
                 if os.path.isfile(executable):
                     if processEvent == "end_multicollect":
                         endOfLineToExecute = grouped_processing("end_multicollect", paramsDict)
@@ -56,12 +56,12 @@ def start(programs, processEvent, paramsDict):
                             cell_opt = ''
 
                         endOfLineToExecute = ' -path ' + paramsDict["xds_dir"] +\
-					     ' -mode ' + processEvent +\
-					     ' -datacollectionID ' + str(dataCollectionId) +\
-					     ' -residues ' + str(residues) +\
-					     ' -anomalous ' + str(anomalous) +\
-					     sg_opt + cell_opt #+\
-					     #(paramsDict["inverse_beam"] and ' -inverse' or '')
+                                             ' -mode ' + processEvent +\
+                                             ' -datacollectionID ' + str(dataCollectionId) +\
+                                             ' -residues ' + str(residues) +\
+                                             ' -anomalous ' + str(anomalous) +\
+                                             sg_opt + cell_opt #+\
+                                             #(paramsDict["inverse_beam"] and ' -inverse' or '')
                     lineToExecute = executable + endOfLineToExecute + ' 2>&1 > /dev/null &'
                     logging.info("Process event %s, executing %s" % (processEvent,str(lineToExecute)))
 

--- a/HardwareObjects/detectors/TacoADSC.py
+++ b/HardwareObjects/detectors/TacoADSC.py
@@ -158,7 +158,7 @@ class ADSC:
         return -1
 
     def set_transmission(self, transmission_percent):
-    	pass
+        pass
 
     def get_transmission(self):
         return 100

--- a/HardwareObjects/detectors/TacoMar.py
+++ b/HardwareObjects/detectors/TacoMar.py
@@ -70,8 +70,8 @@ class Mar225:
         self.header["dataset_comments"] = comment
         self.header["file_comments"] = ""
         self.current_filename = ""
-	self.current_thumbnail2 = ""
-	self.current_thumbnail1 = ""
+        self.current_thumbnail2 = ""
+        self.current_thumbnail1 = ""
 
         self.stop()
 

--- a/HardwareObjects/queue_entry.py
+++ b/HardwareObjects/queue_entry.py
@@ -446,9 +446,8 @@ class TaskGroupQueueEntry(BaseQueueEntry):
             # checked if interleave is set. For this implementation
             # interleave is just possible for discreet data collections
             ref_num_images = 0
-            children_data_model_list =  self._data_model.get_children()
 
-            for child_data_model in children_data_model_list: 
+            for child_data_model in self._data_model.get_children():
                 if isinstance(child_data_model, queue_model_objects.DataCollection):
                     num_images = child_data_model.acquisitions[0].\
                         acquisition_parameters.num_images

--- a/HardwareObjects/queue_model_objects_v1.py
+++ b/HardwareObjects/queue_model_objects_v1.py
@@ -48,9 +48,9 @@ class TaskNode(object):
     def get_children(self):
         """
         :returns: The children of this node.
-        :rtype: List of TaskNode objects.
+        :rtype: Tuple of TaskNode objects.
         """
-        return self._children
+        return tuple(self._children)
 
     def get_parent(self):
         """

--- a/HardwareObjects/sample_changer/Cats90.py
+++ b/HardwareObjects/sample_changer/Cats90.py
@@ -308,7 +308,7 @@ class Cats90(SampleChanger):
             while self._chnCurrentPhase.getValue() != 'Centring':
                 if timeout > 60:
                     logging.info("waited for too long, change to centring mode manually")
-		    return
+                    return
                 time.sleep(1)
                 timeout+=1
                 logging.info("current phase is " + self._chnCurrentPhase.getValue())

--- a/HardwareObjects/sample_changer/CatsBessy.py
+++ b/HardwareObjects/sample_changer/CatsBessy.py
@@ -35,7 +35,7 @@ class Basket(Container):
         return str(basket_number)
 
     def clearInfo(self):
-	self.getContainer()._reset_basket_info(self.getIndex()+1)
+        self.getContainer()._reset_basket_info(self.getIndex()+1)
         self.getContainer()._triggerInfoChangedEvent()
 
 
@@ -180,7 +180,7 @@ class CatsBessy(SampleChanger):
         self._executeServerTask(self._reset)
 
     def clearBasketInfo(self, basket):
-	self._reset_basket_info(basket)
+        self._reset_basket_info(basket)
 
     #########################           PRIVATE           #########################        
     def _updateOperationMode(self, value):

--- a/HardwareObjects/sample_changer/Container.py
+++ b/HardwareObjects/sample_changer/Container.py
@@ -136,7 +136,7 @@ class Container(Component):
     def clearInfo(self):
         Component._resetDirty(self)
         for c in self.getComponents():
-            c.clearInfo()  	
+            c.clearInfo()
     
     #########################           PROTECTED           #########################
     

--- a/HardwareObjects/sample_changer/Robodiff.py
+++ b/HardwareObjects/sample_changer/Robodiff.py
@@ -42,7 +42,7 @@ class Basket(Container):
         return self.getContainer()
 
     def clearInfo(self):
-	self.getContainer()._reset_basket_info(self.getIndex()+1)
+        self.getContainer()._reset_basket_info(self.getIndex()+1)
         self.getContainer()._triggerInfoChangedEvent()
 
 

--- a/HardwareObjects/sample_changer/Sample.py
+++ b/HardwareObjects/sample_changer/Sample.py
@@ -42,7 +42,7 @@ class Sample(Component):
         Returns a dictionary with sample changer specific sample properties 
         :rtype: dictionary
         """        
-        return self.properties
+        return self.properties.copy()
     
     def hasProperty(self, name):
         """

--- a/Server/__init__.py
+++ b/Server/__init__.py
@@ -191,9 +191,9 @@ class SpecServerConnection(SpecServer.BaseSpecRequestHandler):
                 for i in range(len(ret)):
                     dict = {}
                     dict.update(ret[i])
-	 	    	
+
                     tmp = ''
-		    if '__children__' in dict:
+                    if '__children__' in dict:
                       for childpath, childname in list(dict['__children__'].items()):
                         tmp += childname + ':' + childpath + ' '
                       tmp.strip()

--- a/TacoDevice_MTSafe.py
+++ b/TacoDevice_MTSafe.py
@@ -53,7 +53,7 @@ Dev_Exception = RuntimeError
 #			     }
 #		  }
 # .....
-			   
+
 Tab_dev = {}
 
 #--------------------------------------------------------------
@@ -75,38 +75,38 @@ Tab_dev = {}
 #			     }
 #		  }
 # .....
-			   
+
 # Dictionnary for the correspondance between type number (in ascii
 # representation) and a string for user
 Tab_dev_type= { '0' :'void                         ',
-		'1' :'boolean                      ',
-		'70':'unsigned short               ',
-		'2' :'short                        ',
-		'71':'unsigned long                ',
-		'3' :'long                         ',
-		'4' :'float                        ',
-		'5' :'double                       ',
-		'6' :'string                       ',
-		'27':'(long,float)                 ',
-		'7' :'(float,float)                ',
-		'8' :'(short,float,float           ',
-		'22':'(long,long)                  ',
-		'23':'(double,double)              ',
-		'9' :'list of char                 ',
-		'24':'list of string               ',
-		'72':'list of unsigned short       ',
-		'10':'list of short                ',
-		'69':'list of unsigned long        ',
-		'11':'list of long                 ',
-		'12':'list of float                ',
-		'68':'list of double               ',
-		'25':'list of (float,float)        ',
-		'73':'list of (short,float,float)  ',
-		'45':'list of ((long,long)         ',
-		'47':'opaque                       ',
-		'46':'((8 long),(8 float),(8 long))',
-		'54':'(long,long)                  ',
-		'55':'(long,float)                 '
+                '1' :'boolean                      ',
+                '70':'unsigned short               ',
+                '2' :'short                        ',
+                '71':'unsigned long                ',
+                '3' :'long                         ',
+                '4' :'float                        ',
+                '5' :'double                       ',
+                '6' :'string                       ',
+                '27':'(long,float)                 ',
+                '7' :'(float,float)                ',
+                '8' :'(short,float,float           ',
+                '22':'(long,long)                  ',
+                '23':'(double,double)              ',
+                '9' :'list of char                 ',
+                '24':'list of string               ',
+                '72':'list of unsigned short       ',
+                '10':'list of short                ',
+                '69':'list of unsigned long        ',
+                '11':'list of long                 ',
+                '12':'list of float                ',
+                '68':'list of double               ',
+                '25':'list of (float,float)        ',
+                '73':'list of (short,float,float)  ',
+                '45':'list of ((long,long)         ',
+                '47':'opaque                       ',
+                '46':'((8 long),(8 float),(8 long))',
+                '54':'(long,long)                  ',
+                '55':'(long,float)                 '
 }
 
 Tab_dev_type_unk =   '<unknown>                    '
@@ -272,12 +272,12 @@ def dev_tcpudp(mdevname,mode):
          print(loc_c_pt)
       if (mode != "tcp") and (mode != "udp"):
          print('usage: dev_tcpudp(<device_name>,udp|tcp)')
-	 return 0
+         return 0
       try:
          ret = esrf_tcpudp(loc_c_pt,mode)
       except:
          raise Dev_Exception("dev_tcpudp: error on esrf_tcpudp for device %s" % mdevname)
-	 return 0
+         return 0
    else:
       print("dev_tcpudp: no device %s defined" % mdevname)
       return 0
@@ -302,22 +302,22 @@ def dev_timeout(mdevname,*mtime):
          print(loc_c_pt)
       if (mtime == ()):
          print('dev_timeout readmode ')
-	 try:
-	    ret = esrf_timeout(loc_c_pt)
-	 except:
+         try:
+            ret = esrf_timeout(loc_c_pt)
+         except:
             raise Dev_Exception('error on esrf_timeout for device ' + mdevname)
-	    return 0
-	 return ret
+            return 0
+         return ret
       else:
          itime = mtime[0]
-	 if type(itime) == int or type(itime) == float:
+         if type(itime) == int or type(itime) == float:
             print('dev_timeout set mode %f' % itime)
-	    try:
-	       ret = esrf_timeout(loc_c_pt,itime)
-	    except:
+            try:
+               ret = esrf_timeout(loc_c_pt,itime)
+            except:
                raise Dev_Exception('error on esrf_timeout for device ' + mdevname)
-	       return 0	    
-	    return ret
+               return 0
+            return ret
    else:
       print("dev_timeout: no device %s defined" % mdevname)
       return 0
@@ -413,20 +413,20 @@ def dev_io(mdevname,mdevcommand,*parin,**kw):
          raise AttributeError("dev_io: no command %s for device %s" % (mdevcommand,mdevname))
       else:
          if len(parin) == 1:
-	    if type(parin[0]) == tuple:
-	       parin = parin[0]
-	    elif type(parin[0]) == list:
-	       parin = tuple(parin[0])
+            if type(parin[0]) == tuple:
+               parin = parin[0]
+            elif type(parin[0]) == list:
+               parin = tuple(parin[0])
 
          if Dev_deb[0] == 1:
-	    print('esrf_io arg:')
+            print('esrf_io arg:')
             print((Tab_dev[mdevname]['cobj'],mdevcommand,io_cmd,io_in,io_out,0) + (parin, ))
-	    print('esrf_io dict:')
-	    print(kw)
+            print('esrf_io dict:')
+            print(kw)
 
-	 try:
+         try:
             ret = esrf_io(Tab_dev[mdevname]['cobj'],mdevcommand,io_cmd,io_in,io_out,0, parin, **kw)
-	 except:
+         except:
             raise Dev_Exception("Cannot execute esrf_io %s,%s"%(mdevname, mdevcommand))
          else:
             return ret
@@ -458,28 +458,28 @@ def dev_ioC(mdevname,mdevcommand,**kw):
 #  first check that command exists:
       if mdevcommand in Tab_dev[mdevname]['cmd']:
          io_cmd = Tab_dev[mdevname]['cmd'][mdevcommand][0]
-         io_in  = 0	# void
+         io_in  = 0 # void
          io_out = Tab_dev[mdevname]['cmd'][mdevcommand][1]
          parin2 = (Tab_dev[mdevname]['cobj'],mdevcommand,io_cmd,io_in,io_out,1) + ((),)
          if Dev_deb[0] == 1:
-	    print('esrf_io arg:')
-	    print(parin2)
-	    print('esrf_io dict:')
-	    print(kw)
-	 ret = None
-	 try:
+            print('esrf_io arg:')
+            print(parin2)
+            print('esrf_io dict:')
+            print(kw)
+         ret = None
+         try:
 #	    kw={'out':2}
 #	    kw = {}
             ret = esrf_io(*parin2, **kw)
-	    
+
             if Dev_deb[0] == 1:
-	    	print('returned from esrf_io: %s' % ret)	    
-	 except:
+                print('returned from esrf_io: %s' % ret)
+         except:
             raise Dev_Exception("esrf_ioC: error on device %s" % mdevname)
-	 return ret
+         return ret
       else:
          print("dev_ioC: no command %s for device %s" % (mdevcommand,mdevname))
-	 
+
    else:
       print("dev_ioC: no device %s defined" % mdevname)
 
@@ -574,7 +574,7 @@ class _TacoDevice(object):
             self._monitor_lockObj.release()
             
 
-   def __str__(self):			# for print
+   def __str__(self):    # for print
       print('ds device:         ' + self.devname)
       print(" imported: %d" % self.imported)
       print(" device object : ") 
@@ -592,43 +592,43 @@ class _TacoDevice(object):
 
       if len(locdict) > 0:
          for mykey in list(locdict.keys()):
-	    my_stringtype_in = "%d" % locdict[mykey][1]
-	    my_stringtype_out = "%d" % locdict[mykey][2]
-	    if my_stringtype_in in Tab_dev_type:
-	       myin = Tab_dev_type[my_stringtype_in]
-	    else:
-	       myin = Tab_dev_type_unk
-	    if my_stringtype_out in Tab_dev_type:
-	       myout = Tab_dev_type[my_stringtype_out]
-	    else:
-	       myout = Tab_dev_type_unk	     
-	    print("%s %s %s" % (myin,myout,mykey))
+            my_stringtype_in = "%d" % locdict[mykey][1]
+            my_stringtype_out = "%d" % locdict[mykey][2]
+            if my_stringtype_in in Tab_dev_type:
+               myin = Tab_dev_type[my_stringtype_in]
+            else:
+               myin = Tab_dev_type_unk
+            if my_stringtype_out in Tab_dev_type:
+               myout = Tab_dev_type[my_stringtype_out]
+            else:
+               myout = Tab_dev_type_unk
+            print("%s %s %s" % (myin,myout,mykey))
 
 
    def tcp(self):
       if self.imported == 1:
          ret = dev_tcpudp(self.devname,"tcp")
-	 if ret ==0:
-	    print('error setting tcp on object' + self.devname)
+         if ret ==0:
+            print('error setting tcp on object' + self.devname)
 
 
    def udp(self):
       if self.imported == 1:
          ret = dev_tcpudp(self.devname,"udp")
-	 if ret ==0:
-	    print('error setting udp on object' + self.devname)
+         if ret ==0:
+            print('error setting udp on object' + self.devname)
 
       
    def timeout(self,*mtime):
       if self.imported == 1:
          if mtime == ():
-	    ret = dev_timeout(self.devname)
-	    if Dev_deb[0] == 1:
-	       print('timeout: %f' % ret)
-	    return ret
-	 else:
-	    ret = dev_timeout(self.devname,mtime[0])
-	    return ret
+            ret = dev_timeout(self.devname)
+            if Dev_deb[0] == 1:
+               print('timeout: %f' % ret)
+            return ret
+         else:
+            ret = dev_timeout(self.devname,mtime[0])
+            return ret
 
 
    def __getattr__(self, name):
@@ -650,4 +650,4 @@ class _TacoDevice(object):
                  self.__dict__[name] = newTacoCall
                  return newTacoCall 
          finally:
-	     self._monitor_lockObj.release()
+             self._monitor_lockObj.release()


### PR DESCRIPTION
Changed cases where a get function returned internal lists or dicts to return a copy.

NB1 This is not tested - I do not have a test set-up for master

NB2 Two clear cases were left alone as being too complicated for em to deal with:
BeamInfo.get_beam_info and predefinedPositionsNamesList

Also changed some out-of-place tab indentations to spaces and some CR-LF to CR

Looks like I combined two commits into this one (sooy). The other one is:

I kept coming across files where the indentation had an inconsistent mix of tabs and spaces. The present pull request replaces all tabs globally with 8*' ' (eight spaces).

NB The changes are eyeballed but NOT tested (I do not have a test set-up for master).