### PR TITLE
Cleaned error output and reduced missing channel visibility.

### DIFF
--- a/CommandContainer.py
+++ b/CommandContainer.py
@@ -154,7 +154,7 @@ class CommandContainer:
         channel = self.__channels.get(channelName)
         if channel is None and not optional:
             msg = "Unable to add channel %s" % channelName
-            logging.getLogger("user_level_log").exception(msg)
+            logging.getLogger("user_level_log").error(msg)
             #raise Exception(msg)
         return channel
 

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -248,10 +248,12 @@ class GenericDiffractometer(HardwareObject):
         self.back_light_swtich = self.getObjectByRole('backlightswtich')
 
         # Channels -----------------------------------------------------------
-        try:
-           self.used_channels_list = eval(self.getProperty("used_channels"))
-        except:
-           pass # used the default value
+        ss = self.getProperty("used_channels")
+        if ss:
+            try:
+               self.used_channels_list = eval(ss)
+            except:
+               pass # used the default value
 
         for channel_name in self.used_channels_list:
             self.channel_dict[channel_name] = self.getChannelObject(channel_name)


### PR DESCRIPTION
NB The log output for missing channels is still excessively visible.
See issue #169 

This change avoids an unnecessary error raised (which is anyway covered by except: pass) and reduces teh log level from exception to error.