### PR TITLE
Cleaned up setting of HO and brick pythonpath and HWRserver

### DIFF
--- a/HardwareObjects/GphlWorkflow.py
+++ b/HardwareObjects/GphlWorkflow.py
@@ -631,9 +631,14 @@ class GphlWorkflow(HardwareObject, object):
                     logging.getLogger('HWR').debug("Recentring. okp=%s, %s"
                                                    % (okp, sorted(dd.items())))
                 else:
+                    if sweepSetting.translation is None:
+                        xx = "No translation settings."
+                    else:
+                        xx = sorted(
+                            sweepSetting.translation.axisSettings.items()
+                        )
                     logging.getLogger('HWR').debug(
-                        "No recentring. okp=%s, %s"
-                        % (okp, sorted(sweepSetting.translation.axisSettings.items()))
+                        "No recentring. okp=%s, %s" % (okp, xx)
                     )
 
                 goniostatSweepSettings[requestedRotationId] = sweepSetting

--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -39,12 +39,10 @@ def addHardwareObjectsDirs(hoDirs):
     if type(hoDirs) == list:
         newHoDirs = list(filter(os.path.isdir, list(map(os.path.abspath, hoDirs))))
 
-        for newHoDir in newHoDirs:
+        for newHoDir in reversed(newHoDirs):
             if not newHoDir in sys.path:
                 sys.path.insert(0, newHoDir)
 
-default_local_ho_dir = os.environ.get('CUSTOM_HARDWARE_OBJECTS_PATH', '').split(os.path.pathsep)
-addHardwareObjectsDirs(default_local_ho_dir)
 
 def setUserFileDirectory(user_file_directory):
     BaseHardwareObjects.HardwareObjectNode.setUserFileDirectory(user_file_directory)
@@ -60,7 +58,7 @@ def setHardwareRepositoryServer(hwrserver):
 
 def HardwareRepository(hwrserver = None):
     """Return the Singleton instance of the Hardware Repository."""
-    global _instance        
+    global _instance
 
     if _instance is None:
         if _hwrserver is None:

--- a/__init__.py
+++ b/__init__.py
@@ -22,13 +22,8 @@ sys.path.insert(0, getStdHardwareObjectsPath())
 
 hwobj_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                          "HardwareObjects")
-hwobj_dir_list = []
-hwobj_dir_list.append(hwobj_dir)
 
-for sub_dir in ("abstract", "generic", "mockup", "core", "sample_changer", "EMBL"):
-    hwobj_dir_list.append(os.path.join(hwobj_dir, sub_dir))
-
-HardwareRepository.addHardwareObjectsDirs(hwobj_dir_list)
+HardwareRepository.addHardwareObjectsDirs([hwobj_dir])
 
 #
 # create the HardwareRepository logger


### PR DESCRIPTION
Changed so setting is done only in one place, environment variables are not overridden, and bin/mxcube has no hardwiring.

Also GPhL-specific bug fix