### PR TITLE
Generic diffractometer revisited

### DIFF
--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -853,7 +853,10 @@ class GenericDiffractometer(HardwareObject):
         self.wait_device_ready(timeout)
         for motor in motor_positions.keys():
             position = motor_positions[motor]
-            logging.getLogger("HWR").debug(" Moving %s to %s" % (str(motor), position))
+            if type(motor) == str:
+                logging.getLogger("HWR").debug(" Moving %s to %s" % (motor, position))
+            else:
+                logging.getLogger("HWR").debug(" Moving %s to %s" % (str(motor.name()), position))
             if type(motor) in (str, unicode):
                 motor_role = motor
                 motor = self.motor_hwobj_dict.get(motor_role)
@@ -861,8 +864,8 @@ class GenericDiffractometer(HardwareObject):
                 if None in (motor, position):
                     continue
                 motor_positions[motor] = position
-            #self.wait_device_ready(timeout)
             motor.move(position)
+        self.wait_device_ready(timeout)
 
         if self.delay_state_polling is not None and self.delay_state_polling > 0:    
             # delay polling for state in the

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -411,6 +411,11 @@ class GenericDiffractometer(HardwareObject):
         return self.current_state == DiffractometerState.tostring(\
                     DiffractometerState.Ready)
 
+    def wait_device_not_ready(self, timeout=5):
+        with gevent.Timeout(timeout, Exception("Timeout waiting for device not ready")):
+            while self.is_ready():
+                time.sleep(0.01)
+
     def wait_device_ready(self, timeout=30):
         """ Waits when diffractometer status is ready:
 
@@ -729,8 +734,10 @@ class GenericDiffractometer(HardwareObject):
         else:
             self.emit_progress_message("Moving sample to centred position...")
             self.emit_centring_moving()
+
             try:
-                self.move_to_motors_positions(motor_pos)
+                logging.getLogger("HWR").debug("Centring finished. Moving motoros to position %s" % str(motor_pos))
+                self.move_to_motors_positions(motor_pos, wait=True)
             except:
                 logging.exception("Could not move to centred position")
                 self.emit_centring_failed()
@@ -825,6 +832,7 @@ class GenericDiffractometer(HardwareObject):
              self.move_motors, motors_positions)
         self.move_to_motors_positions_procedure.link(self.move_motors_done)
         if wait:
+            self.wait_device_not_ready()
             self.wait_device_ready(10)
   
     def move_motors(self, motor_positions, timeout=15):

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -742,9 +742,13 @@ class GenericDiffractometer(HardwareObject):
                 logging.exception("Could not move to centred position")
                 self.emit_centring_failed()
             else:
-                #if 3 click centring move -180
-                if not self.in_plate_mode():
-                    self.motor_hwobj_dict['phi'].syncMoveRelative(-180)
+                #if 3 click centring move -180. well. dont, in principle the calculated
+                # centred positions include omega to initial position
+                pass
+                #if not self.in_plate_mode():
+                #    logging.getLogger("HWR").debug("Centring finished. Moving omega back to initial position")
+                #    self.motor_hwobj_dict['phi'].syncMoveRelative(-180)
+                #    logging.getLogger("HWR").debug("         Moving omega done")
 
             if self.current_centring_method == GenericDiffractometer.CENTRING_METHOD_AUTO:
                 self.emit("newAutomaticCentringPoint", motor_pos)

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -164,6 +164,9 @@ class GenericDiffractometer(HardwareObject):
         # flag for using sample_centring hwobj or not
         self.use_sample_centring = None
 
+        self.delay_state_polling = None # time to delay for state polling for controllers
+                                        # not updating state inmediately after cmd started
+
         # Internal values -----------------------------------------------------
         self.ready_event = None
         self.head_type = GenericDiffractometer.HEAD_TYPE_MINIKAPPA
@@ -333,6 +336,11 @@ class GenericDiffractometer(HardwareObject):
                       self.motor_hwobj_dict['sampy'])
         except:
            pass # used the default value
+
+	try:
+            self.delay_state_polling = self.getProperty("delay_state_polling")
+        except:
+            pass
 
         # Other parameters ---------------------------------------------------
         try:
@@ -835,6 +843,12 @@ class GenericDiffractometer(HardwareObject):
                     continue
                 motor_positions[motor] = position
             motor.move(position)
+
+        if self.delay_state_polling is not None and self.delay_state_polling > 0:    
+            # delay polling for state in the
+            # case of controller not reporting MOVING inmediately after cmd
+            gevent.sleep(self.delay_state_polling)
+
         self.wait_device_ready(timeout)
 
     def move_motors_done(self, move_motors_procedure):


### PR DESCRIPTION
Revisiting GenericDifractometer:

* Add delay_state_polling property in GenericDiffractometer.
* Backward compatibility for method calls startCentringMethod and acceptCentring (are called from other modules).
* Allow simultaneous move of several motors by starting move on each of them without waiting for them to stop until they are all running.
* Declare stab for get_osc_max_speed().
* Fix value emitted with signal newAutomaticCentringPoint to emit a list-type value.