### PR TITLE
Video bugfix

### DIFF
--- a/HardwareObjects/BeamlineSetup.py
+++ b/HardwareObjects/BeamlineSetup.py
@@ -204,9 +204,8 @@ class BeamlineSetup(HardwareObject):
         :returns: A CharacterisationsParameters object with default parameters.
         """
         input_fname = self.data_analysis_hwobj.edna_default_file
-        hwr_dir = HardwareRepository().getHardwareRepositoryPath()
-
-        with open(os.path.join(hwr_dir, input_fname), 'r') as f:
+        fp = HardwareRepository().findInRepository(input_fname)
+        with open(fp, 'r') as f:
             edna_default_input = ''.join(f.readlines())
 
         edna_input = XSDataInputMXCuBE.parseString(edna_default_input)

--- a/HardwareObjects/DataAnalysis.py
+++ b/HardwareObjects/DataAnalysis.py
@@ -42,9 +42,8 @@ class DataAnalysis(AbstractDataAnalysis.AbstractDataAnalysis, HardwareObject):
         self.collect_obj = self.getObjectByRole("collect")
         self.start_edna_command = self.getProperty("edna_command")
         self.edna_default_file = self.getProperty("edna_default_file")
-        hwr_dir = HardwareRepository().getHardwareRepositoryPath()
-
-        with open(os.path.join(hwr_dir, self.edna_default_file), 'r') as f:
+        fp = HardwareRepository().findInRepository(self.edna_default_file)
+        with open(fp, 'r') as f:
             self.edna_default_input = ''.join(f.readlines())
 
     def get_html_report(self, edna_result):

--- a/HardwareObjects/GenericVideoDevice.py
+++ b/HardwareObjects/GenericVideoDevice.py
@@ -362,7 +362,8 @@ class GenericVideoDevice(Device):
 
     """  Methods to be implemented by the implementing class """
     def get_raw_image_size(self):
-        pass
+        # Must return a two-value list necessary to avoid breaking e.g. ViideoMockup
+        return [None,None]
 
     @abc.abstractmethod
     def get_image(self):

--- a/HardwareObjects/LimaVideo.py
+++ b/HardwareObjects/LimaVideo.py
@@ -46,7 +46,7 @@ class LimaVideo(Device):
         self.gamma_exists = None
 
         self.image_format = None
-        self.image_dimensions = None
+        self.image_dimensions = [None, None]
 
         self.camera = None
         self.interface = None

--- a/HardwareObjects/Qt4_VideoMockup.py
+++ b/HardwareObjects/Qt4_VideoMockup.py
@@ -127,3 +127,6 @@ class Qt4_VideoMockup(GenericVideoDevice):
 
     def get_video_live(self):
         return True
+
+    def get_raw_image_size(self):
+        return list(self.image_dimensions)

--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -251,6 +251,14 @@ class __HardwareRepositoryClient:
                                     "%d ms" % (time_delta.microseconds / 1000),
                                     comment))
 
+        # # Temporary help to get hold of superclasses
+        # import inspect
+        # for cls in inspect.getmro(hwobj_instance.__class__)[1:]:
+        #     tt = ('super', cls.__name__, "0 ms", '@~@~')
+        #     if tt not in  self.hwobj_info_list:
+        #         self.hwobj_info_list.append(tt)
+
+
         return hwobj_instance
 
     def discardHardwareObject(self, hoName):
@@ -325,13 +333,13 @@ class __HardwareRepositoryClient:
 
         raise KeyError
 
-
-    def getHardwareRepositoryPath(self):
-        if self.server:
-            return ""
-        else:
-            path = self.serverAddress[0]
-            return os.path.abspath(path)
+    #  Removed 20181109, as it did not work with multi-directory serverAddress
+    # def getHardwareRepositoryPath(self):
+    #     if self.server:
+    #         return ""
+    #     else:
+    #         path = self.serverAddress[0]
+    #         return os.path.abspath(path)
 
 
     def getHardwareRepositoryFiles(self, startdir = '/'):
@@ -634,7 +642,7 @@ class __HardwareRepositoryClient:
         print "| %s|" % row_format.format(*("Xml", "Class", "Load time", "Comment"))
         print "+","=" * (sum(longest_cols) + 5), "+"
 
-        for row in self.hwobj_info_list:
+        for row in sorted(self.hwobj_info_list):
             print "| %s|" % row_format.format(*row)
         print "+","=" * (sum(longest_cols) + 4), "+"
 

--- a/HardwareRepositoryBrowser.py
+++ b/HardwareRepositoryBrowser.py
@@ -291,14 +291,14 @@ class __HardwareRepositoryClient:
             return self.getHardwareObject(item)
 
         raise KeyError
-    
 
-    def getHardwareRepositoryPath(self):
-       if self.server:
-         return ""
-       else:
-         path = self.serverAddress[0]
-         return os.path.abspath(path)
+    #  Removed 20181109, as it did not work with multi-directory serverAddress
+    # def getHardwareRepositoryPath(self):
+    #    if self.server:
+    #      return ""
+    #    else:
+    #      path = self.serverAddress[0]
+    #      return os.path.abspath(path)
 
 
     def getHardwareRepositoryFiles(self, startdir = '/'):


### PR DESCRIPTION
Fixed bug in image width and height handling that broke the VideoMockup.
NB height and width handling is inconsistent - see relevant Issue.

Replaced getHardwareRepositoryPath with (already existing) findInRepository, as the former did not work with multi-directory repository paths.