### PR TITLE
Fixing 'override data directories' - again

### DIFF
--- a/HardwareObjects/CollectEmulator.py
+++ b/HardwareObjects/CollectEmulator.py
@@ -33,6 +33,13 @@ class CollectEmulator(CollectMockup):
 
         self._counter = 1
 
+    def init(self):
+        CollectMockup.init(self)
+        session_hwobj = self.getObjectByRole("session")
+        if session_hwobj and self.hasObject('override_data_directories'):
+            dirs = self['override_data_directories'].getProperties()
+            session_hwobj.set_base_data_directories(**dirs)
+
     def _get_simcal_input(self, data_collect_parameters, crystal_data):
         """Get ordered dict with simcal input from available data"""
 

--- a/HardwareObjects/Session.py
+++ b/HardwareObjects/Session.py
@@ -62,27 +62,6 @@ class Session(HardwareObject):
         self.suffix = self["file_info"].getProperty("file_suffix")
         self.template = self["file_info"].getProperty("file_template")
 
-        # Override directory names, if parameter_override_file exists.
-        # Intended to allow resetting directories in mock mode,
-        # while keeping the session/xml used for the mocked beamline.
-        override_file = HardwareRepository().findInRepository(parameter_override_file)
-        if override_file:
-            logging.getLogger("HWR").info(
-                "Reading override directory names from %s" % override_file
-            )
-        if override_file:
-            parameters = ET.parse(override_file).getroot()
-            for elem in parameters:
-                tag = elem.tag
-                if tag in (
-                    "base_directory",
-                    "processed_data_base_directory",
-                    "archive_base_directory",
-                ):
-                    val = elem.text.strip()
-                    if val is not None:
-                        self["file_info"].setProperty(tag, val)
-
         base_directory = self["file_info"].getProperty("base_directory")
 
         base_process_directory = self["file_info"].getProperty(


### PR DESCRIPTION
Hi. This should hopefully olve the problem.

NB, note that CollectEmulator is a mock object (I shall move it shortly) and depends on GPhL code.