### PR TITLE
Initial values of beam info

### DIFF
--- a/HardwareObjects/mockup/BeamInfoMockup.py
+++ b/HardwareObjects/mockup/BeamInfoMockup.py
@@ -40,9 +40,17 @@ class BeamInfoMockup(Equipment):
                 "diameterIndexChanged",
                 self.aperture_diameter_changed,
             )
+
+            ad = self.aperture_hwobj.get_diameter_size() / 1000.0
+            self.beam_size_aperture = [ad, ad]
+
         self.slits_hwobj = self.getObjectByRole("slits")
         if self.slits_hwobj is not None:
             self.connect(self.slits_hwobj, "valueChanged", self.slits_gap_changed)
+
+            sx, sy = self.slits_hwobj.get_gaps()
+            self.beam_size_slits = [sx, sy]
+
         self.emit("beamPosChanged", (self.beam_position,))
 
     def aperture_diameter_changed(self, name, size):
@@ -113,6 +121,7 @@ class BeamInfoMockup(Equipment):
             self.beam_info_dict["shape"] = "ellipse"
         else:
             self.beam_info_dict["shape"] = "rectangular"
+
         return self.beam_info_dict
 
     def emit_beam_info_change(self):

--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -61,16 +61,26 @@ def setHardwareRepositoryServer(hwrserver):
         _hwrserver = hwrserver
 
 
-def getHardwareRepository(hwrserver=None):
-    """Return the Singleton instance of the Hardware Repository."""
+def getHardwareRepository(xml_dir=None):
+    """
+    Get the HardwareRepository (singleton) instance, instantiates it if necessary.
+
+    Args:
+        xml_dir (str): Path to XML configuration files for HardwareObject's
+
+    Returns:
+        HardwareRepository: The Singleton instance of HardwareRepository
+                            (in reality __HardwareRepositoryClient)
+    """
     global _instance
 
     if _instance is None:
         if _hwrserver is None:
-            if hwrserver is None:
-                # Default to enviroment variable
+            if xml_dir is None:
+                # Default to environment variable
                 hwrserver = os.path.abspath(os.environ["XML_FILES_PATH"])
-            setHardwareRepositoryServer(hwrserver)
+
+            setHardwareRepositoryServer(xml_dir)
 
         _instance = __HardwareRepositoryClient(_hwrserver)
 


### PR DESCRIPTION
Hi,

Making sure that initial values are set Initializing beam_size_aperture and beam_size_slits members with their corresponding "hardware" values

Marcus