### PR TITLE
Proposed pylint change (and minor gphl fixes)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,8 +60,11 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
-
+# Below the default disable commands
+# Better to start by enabling all, then decide whether to disable individually.
+# disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
+# bad-continuation diabled because a pylint bug clashes with black formatting
+disable=bad-continuation
 
 [REPORTS]
 

--- a/HardwareObjects/mockup/CollectEmulator.py
+++ b/HardwareObjects/mockup/CollectEmulator.py
@@ -354,7 +354,7 @@ class CollectEmulator(CollectMockup):
         return_code = running_process.wait()
         process = self.gphl_connection_hwobj.collect_emulator_process
         self.gphl_connection_hwobj.collect_emulator_process = None
-        if return_code and process != 'ABORTED':
+        if return_code and process != "ABORTED":
             raise RuntimeError(
                 "simcal process terminated with return code %s" % return_code
             )

--- a/configuration/embl_hh_p14/gphl_beamline_config/instrumentation.nml
+++ b/configuration/embl_hh_p14/gphl_beamline_config/instrumentation.nml
@@ -72,7 +72,7 @@ gonio_centring_axis_names= 'phiy', 'sampx', 'sampy'
 ! beamstop_param_vals=    1.0               -120.0                60.0
 
 ! Taken from http://xds.mpimf-heidelberg.mpg.de/html_doc/INPUT_templates/XDS-PILATUS.INP
-xds_DETECTOR= PILATUS
+xds_DETECTOR= EIGER
 xds_OVERLOAD= 1048500
 
 /

--- a/configuration/embl_hh_p14/gphl_beamline_config/instrumentation.nml
+++ b/configuration/embl_hh_p14/gphl_beamline_config/instrumentation.nml
@@ -1,36 +1,35 @@
 &sdcp_instrument_list
-! Values from Roeland Boer 20180312
+! Values based on P14 config files 20190329 and Gleb email 20170410
 
 calibration_name= 'Initial'
-beamline_name= 'XALOC13'
+beamline_name= 'P14'
 coord_sys_name= 'UNKNOWN'
-! Changed from RB input, but necessary to get images
-nominal_beam_dir= 0.0  -1.0  0.0
+nominal_beam_dir= 0.0  0.0  1.0
 
 beam_sd_deg= 0.03 0.03
-! lambd_sd is a reasonable default (WP), but not specifically determined
 lambda_sd= 0.0002
 pol_plane_n= 0.0 0.0 1.0
 pol_frac= 0.99
 
-det_name= "PILATUS6M"
+det_name= "eiger16m"
 det_x_axis= 1.0  0.0  0.0
-det_y_axis= 0.0  0.0  1.0
-det_qx= 0.172000
-det_qy= 0.172000
+det_y_axis= 0.0  1.0  0.0
+det_qx= 0.075000
+det_qy= 0.075000
 
-det_nx= 2463
-det_ny= 2527
-det_org_x= 1236.0
-det_org_y= 1307.0
+det_nx= 4150
+det_ny= 4371
+det_org_x= 2078.0
+det_org_y= 2180.0
 det_org_dist= 240.581970
+d_sensor= 0.45
 
-! NB nothing given by Ronald Boer in this block
 det_gonio_axis_dirs=  0.0  0.0  1.0
+ ! Detector movement axis
  ! Actual value is irrelevant, since axis is (nominally) parallel to beam
  ! and we don't refine its direction
 det_gonio_axis_datum_settings= 500
-det_gonio_axis_limits= 195 1000
+det_gonio_axis_limits= 0 1000
 det_gonio_axis_names= 'Distance'
 det_gonio_axis_types= 'Translation'
 det_gonio_axis_calibratable = 'False'
@@ -39,28 +38,23 @@ det_gonio_axis_calibratable = 'False'
 det_filename_suffix= '.cbf'
 
 gonio_name= "MiniKappa"
-gonio_axis_dirs= 1.0 0.0 0.0,
+gonio_axis_dirs= 0.0, -1.0, 0.0,
    ! Normalised to sum to 1.0000000 exactly
-   0.915811981182143  -0.2841353  0.28382309,
-   1.0 0.0 0.0
-! NB datum settings given incorrectly in info email
+   0.186051,-0.9135454938310407,0.36169,
+   0.0, -1.0, 0.0,
 gonio_axis_datum_settings= 0 0 0
-gonio_axis_limits= , , 0, 255, , ,
+gonio_axis_limits= , , -5, 240, , ,
 gonio_axis_names= 'phi' 'kappa' 'kappa_phi'
 gonio_axis_scannable= 'True' 'False' 'False'
 gonio_axis_calibratable= 'False' 'True' 'True'
 
-! Nominal centring axis directions with correct signs
-gonio_centring_axis_dirs=  1.0,  0.0,  0.0,
-                           0.0, -1.0,  0.0,
-                           0.0,  0.0,  1.0
+! Nominal centring axis directions
+gonio_centring_axis_dirs=  0.0,  1.0,  0.0,
+                          -0.281085,  0, 0.959683,
+                           0.959683,  0, 0.281085
 ! Actual limits on centring axes
-gonio_centring_axis_limits=  -1.5, 21.55, -2.2, 2.2, -2.55, 2.55
-! NB renamed version is WRONG for ALBA, butnecessary to fit with mock objects
-! gonio_centring_axis_names= 'omegax', 'centx', 'centy'
+gonio_centring_axis_limits=   ,  ,  ,  ,  ,
 gonio_centring_axis_names= 'phiy', 'sampx', 'sampy'
-! At omega=0: centx antiparallel to beam, centy perpendicular.
-! omegax parallel to omega
 
 !? FIXME! Sort out ID30B beamstop on the fly (or delete it?) 
 ! Need beamstop for I04 for now, to get a realistic beamstop shadow


### PR DESCRIPTION
This (proposal for discussion) enables all pylint checks. I think we should start there, and only
disable them in each case when we decide the check should be (temporarily?) ignored. The newly added checks do not dominate the output (see below)

It also disables the 'bad-continuation' check  (C0330 'Wrong continued indentation before block'). 
The problem is that the format generated by black causes a pylint error. According to https://github.com/PyCQA/pylint/issues/289 this is due to a pylint bug that goes back to 2014 and stillis not fixed. The solution seems to be to diable the check and rely on black to get the formatting we want.

For information I ran pylint (off-line) on all of HardwareRepository after making the change. There  are no bad-continuation errors at all. The most common messages are given below - I do not think any of them are obviously to be ignored.

+-------------------------------+------------+
|message id                     |occurrences |
+===============================+============+
|invalid-name                   |8956        |
+-------------------------------+------------+
|missing-docstring              |5392        |
+-------------------------------+------------+
|attribute-defined-outside-init |1583        |
+-------------------------------+------------+
|line-too-long                  |1412        |
+-------------------------------+------------+
|duplicate-code                 |719         |
+-------------------------------+------------+
|unused-argument                |594         |
+-------------------------------+------------+
|logging-not-lazy               |455         |
+-------------------------------+------------+
|no-self-use                    |417         |
+-------------------------------+------------+
|wrong-import-order             |347         |
+-------------------------------+------------+
|protected-access               |290         |
+-------------------------------+------------+
|unused-variable                |272         |
+-------------------------------+------------+
|no-staticmethod-decorator      |268         |
+-------------------------------+------------+
|no-member                      |205         |
+-------------------------------+------------+
|arguments-differ               |189         |
+-------------------------------+------------+
|too-many-arguments             |160         |
+-------------------------------+------------+
|superfluous-parens             |149         |
+-------------------------------+------------+
|undefined-variable             |140         |
+-------------------------------+------------+
|relative-import                |140         |
+-------------------------------+------------+
|unused-wildcard-import         |139         |
+-------------------------------+------------+
|too-many-branches              |138         |
+-------------------------------+------------+
|too-many-public-methods        |115         |
+-------------------------------+------------+
|import-error                   |113         |
+-------------------------------+------------+
|pointless-string-statement     |111         |
+-------------------------------+------------+
|too-many-statements            |106         |
+-------------------------------+------------+
|no-else-return                 |106         |
+-------------------------------+------------+
|len-as-condition               |99          |
+-------------------------------+------------+