### PR TITLE
Bugfix to handle compression tag correctly

### DIFF
--- a/HardwareObjects/queue_model_objects.py
+++ b/HardwareObjects/queue_model_objects.py
@@ -756,10 +756,14 @@ class Characterisation(TaskNode):
         self.characterisation_software = None
         self.wait_result = None
         self.run_diffraction_plan = None
-        self.diff_plan_compression = True
 
         self.auto_add_diff_plan = True
         self.diffraction_plan = []
+
+    @staticmethod
+    def set_char_compression(state):
+        print("setttt ", state)
+        Characterisation.diff_plan_compression = state
 
     def get_name(self):
         return "%s_%i" % (self._name, self._number)

--- a/HardwareObjects/queue_model_objects.py
+++ b/HardwareObjects/queue_model_objects.py
@@ -762,7 +762,6 @@ class Characterisation(TaskNode):
 
     @staticmethod
     def set_char_compression(state):
-        print("setttt ", state)
         Characterisation.diff_plan_compression = state
 
     def get_name(self):


### PR DESCRIPTION
Added a static method to set compression state for diffraction plan. A corresponding PR to mxcube will be made after this PR has been accepted.