### PR TITLE
Fix for pylint, codacy

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -380,3 +380,5 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
 overgeneral-exceptions=Exception
+
+init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"


### PR DESCRIPTION
Based on the https://stackoverflow.com/questions/1899436/pylint-unable-to-import-error-how-to-set-pythonpath this is fixing the Unable to import error.