### PR TITLE
Add refractive model alignment to PX2Diffractometer.py

### DIFF
--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -124,7 +124,8 @@ class PX2Diffractometer(GenericDiffractometer):
         self.cmd_start_auto_focus = None
         self.cmd_get_omega_scan_limits = None
         self.cmd_save_centring_positions = None
-
+        self.centring_time = None
+        
         # Internal values -----------------------------------------------------
         self.use_sc = False
         self.omega_reference_pos = [0, 0]
@@ -466,7 +467,6 @@ class PX2Diffractometer(GenericDiffractometer):
         else:
             self.emit_progress_message("Moving sample to centred position...")
             self.emit_centring_moving()
-            s_move = time.time()
             try:
                 self.move_to_motors_positions(motor_pos)
             except BaseException:

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -125,7 +125,6 @@ class PX2Diffractometer(GenericDiffractometer):
         self.cmd_get_omega_scan_limits = None
         self.cmd_save_centring_positions = None
         self.centring_time = None
-        
         # Internal values -----------------------------------------------------
         self.use_sc = False
         self.omega_reference_pos = [0, 0]

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -19,9 +19,13 @@
 
 import os
 import time
-import gevent
 import logging
 import traceback
+import gevent
+import pickle
+
+import numpy as np
+from scipy.optimize import minimize
 
 from math import sqrt
 from goniometer import goniometer
@@ -32,9 +36,6 @@ from film import film
 import beam_align
 import scan_and_align
 import optical_alignment
-import pickle
-import numpy as np
-from scipy.optimize import minimize
 import copy
 from anneal import anneal as anneal_procedure
 import datetime

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -709,21 +709,6 @@ class PX2Diffractometer(GenericDiffractometer):
             c *= 1e-3
             r *= 1.0e-3
             v = {"c": c, "r": r, "alpha": alpha}
-            # initial_parameters = lmfit.Parameters()
-            # initial_parameters.add_many(('c', 0., True, -5e3, +5e3, None, None),
-            # ('r', 0., True, 0., 4e3, None, None),
-            # ('alpha', -np.pi/3, True, -2*np.pi, 2*np.pi, None, None))
-
-            # fit_y = lmfit.minimize(self.circle_model_residual2, initial_parameters, method='nelder', args=(angles, vertical_discplacements)) #, kws={'data': vertical_discplacements})
-            # self.log.info(fit_report(fit_y))
-            # optimal_params = fit_y.params
-            # v = optimal_params.valuesdict()
-            # c = v['c']
-            # r = v['r']
-            # alpha = v['alpha']
-
-            # c *= 1e-3
-            # r *=1.e-3
 
         else:
             initial_parameters = lmfit.Parameters()
@@ -742,7 +727,7 @@ class PX2Diffractometer(GenericDiffractometer):
                 initial_parameters,
                 method="nelder",
                 args=(angles, vertical_discplacements),
-            )  # , kws={'data': vertical_discplacements})
+            )
             self.log.info(fit_report(fit_y))
             optimal_params = fit_y.params
             v = optimal_params.valuesdict()
@@ -758,7 +743,6 @@ class PX2Diffractometer(GenericDiffractometer):
             r *= 1.0e-3
             front *= 1.0e-3
             back *= 1.0e-3
-            # c, r, alpha, front, back, n, beta = fit_lmfit(angles, y)
 
         horizontal_center = np.mean(horizontal_displacements)
 
@@ -798,8 +782,6 @@ class PX2Diffractometer(GenericDiffractometer):
             "duration": duration,
             "vertical_optimal_parameters": v,
         }
-
-        # self.goniometer.set_position(result_position)
 
         template = os.path.join(directory, name_pattern)
 

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -505,7 +505,7 @@ class PX2Diffractometer(GenericDiffractometer):
         # position[motor] = motor_positions[motor]
 
         # self.log.info('position %s' % position)
-        self.goniometer.set_position(position)
+        self.goniometer.set_position(position, timeout=timeout)
 
         # self.log.info('move_motors took %.3f seconds' % (time.time()-start))
 

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -23,18 +23,18 @@ import logging
 import traceback
 import pickle
 import copy
+import datetime
+import h5py
+
 import numpy as np
 from scipy.optimize import minimize
 from math import sqrt
-import datetime
-import h5py
 
 import gevent
 
 from goniometer import goniometer
 from detector import detector
 from camera import camera
-from film import film
 
 import beam_align
 import scan_and_align

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -455,7 +455,6 @@ class PX2Diffractometer(GenericDiffractometer):
         """
         Descript. :
         """
-        start = time.time()
         try:
             motor_pos = centring_procedure.get()
             # if isinstance(motor_pos, gevent.GreenletExit):

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -22,12 +22,15 @@ import time
 import logging
 import traceback
 import pickle
-import gevent
-
+import copy
 import numpy as np
 from scipy.optimize import minimize
-
 from math import sqrt
+import datetime
+import h5py
+
+import gevent
+
 from goniometer import goniometer
 from detector import detector
 from camera import camera
@@ -36,10 +39,8 @@ from film import film
 import beam_align
 import scan_and_align
 import optical_alignment
-import copy
+
 from anneal import anneal as anneal_procedure
-import datetime
-import h5py
 from queue_model_enumerables_v1 import CENTRING_METHOD
 
 try:

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -21,8 +21,8 @@ import os
 import time
 import logging
 import traceback
-import gevent
 import pickle
+import gevent
 
 import numpy as np
 from scipy.optimize import minimize

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -17,10 +17,10 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import time
 import gevent
 import logging
-import os
 import traceback
 
 from math import sqrt

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -487,27 +487,15 @@ class PX2Diffractometer(GenericDiffractometer):
         """
         Moves diffractometer motors to the requested positions
 
-        :param motors_dict: dictionary with motor names or hwobj
+        :param motors_dict:  with motor names or hwobj
                             and target values.
         :type motors_dict: dict
         """
-        start = time.time()
-        # self.log.info('in move_motors')
-        # self.log.info('motor_positions %s' % motor_positions)
 
         position = self.translate_from_mxcube_to_md2(motor_positions)
 
-        # position = {}
-        # for motor in motor_positions:
-        # if hasattr(motor, 'motor_name'):
-        # position[motor.motor_name] = motor_positions[motor]
-        # elif motor in self.motor_name_mapping:
-        # position[motor] = motor_positions[motor]
-
-        # self.log.info('position %s' % position)
         self.goniometer.set_position(position, timeout=timeout)
 
-        # self.log.info('move_motors took %.3f seconds' % (time.time()-start))
 
     def get_centred_point_from_coord(self, x, y, return_by_names=None):
         """

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -20,8 +20,35 @@
 import time
 import gevent
 import logging
+import os
+import traceback
 
 from math import sqrt
+from goniometer import goniometer
+from detector import detector
+from camera import camera
+from film import film
+
+import beam_align
+import scan_and_align
+import optical_alignment
+import pickle
+import numpy as np
+from scipy.optimize import minimize
+import copy
+from anneal import anneal as anneal_procedure
+import datetime
+import h5py
+from queue_model_enumerables_v1 import CENTRING_METHOD
+
+try:
+    import lmfit
+    from lmfit import fit_report
+except ImportError:
+    logging.warning(
+        "Could not lmfit minimization library, "
+        + "refractive model centring will not work."
+    )
 
 try:
     import lucid2 as lucid
@@ -30,14 +57,12 @@ except ImportError:
         import lucid
     except ImportError:
         logging.warning(
-            "Could not find autocentring library, " + "automatic centring is disabled"
+            "Could not find autocentring library, automatic centring is disabled"
         )
 
-from HardwareRepository.HardwareObjects.GenericDiffractometer import (
-    GenericDiffractometer
-)
-from HardwareRepository.TaskUtils import task
+from GenericDiffractometer import GenericDiffractometer
 
+from HardwareRepository.TaskUtils import task
 
 __credits__ = ["SOLEIL"]
 __version__ = "2.3."
@@ -50,6 +75,19 @@ class PX2Diffractometer(GenericDiffractometer):
     """
 
     AUTOMATIC_CENTRING_IMAGES = 6
+
+    motor_name_mapping = [
+        ("AlignmentX", "phix"),
+        ("AlignmentY", "phiy"),
+        ("AlignmentZ", "phiz"),
+        ("CentringX", "sampx"),
+        ("CentringY", "sampy"),
+        ("Omega", "phi"),
+        ("Kappa", "kappa"),
+        ("Phi", "kappa_phi"),
+        ("beam_x", "beam_x"),
+        ("beam_y", "beam_y"),
+    ]
 
     def __init__(self, *args):
         """
@@ -64,6 +102,10 @@ class PX2Diffractometer(GenericDiffractometer):
         self.centring_hwobj = None
         self.minikappa_correction_hwobj = None
         self.detector_distance_motor_hwobj = None
+        self.nclicks = None
+        self.step = None
+        self.centring_method = None
+        self.collecting = False
 
         # Channels and commands -----------------------------------------------
         self.chan_calib_x = None
@@ -85,6 +127,19 @@ class PX2Diffractometer(GenericDiffractometer):
         self.use_sc = False
         self.omega_reference_pos = [0, 0]
         self.reference_pos = [680, 512]
+
+        self.goniometer = goniometer()
+        self.camera = camera()
+        self.detector = detector()
+
+        self.md2_to_mxcube = dict(
+            [(key, value) for key, value in self.motor_name_mapping]
+        )
+        self.mxcube_to_md2 = dict(
+            [(value, key) for key, value in self.motor_name_mapping]
+        )
+
+        self.log = logging.getLogger("HWR")
 
     def init(self):
         """
@@ -173,11 +228,14 @@ class PX2Diffractometer(GenericDiffractometer):
         self.omega_reference_motor = self.getObjectByRole(
             self.omega_reference_par["motor_name"]
         )
+
         self.connect(
             self.omega_reference_motor,
             "positionChanged",
             self.omega_reference_motor_moved,
         )
+
+        self.omega_reference_motor_moved(self.omega_reference_motor.get_position())
 
         # self.use_sc = self.getProperty("use_sample_changer")
 
@@ -192,12 +250,14 @@ class PX2Diffractometer(GenericDiffractometer):
 
     def state_changed(self, state):
         # logging.getLogger("HWR").debug("State changed: %s" % str(state))
-        self.current_state = state
-        self.emit("minidiffStateChanged", (self.current_state))
+        if self.current_state != state:
+            self.current_state = state
+            self.emit("minidiffStateChanged", (self.current_state))
 
     def status_changed(self, status):
-        self.current_status = status
-        self.emit("minidiffStatusChanged", (self.current_status))
+        if self.current_status != status:
+            self.current_status = status
+            self.emit("minidiffStatusChanged", (self.current_status))
 
     def zoom_position_changed(self, value):
         self.update_pixels_per_mm()
@@ -345,21 +405,23 @@ class PX2Diffractometer(GenericDiffractometer):
             "Diffractometer: Setting %s phase. Please wait..." % phase
         )
 
-        if self.in_plate_mode() and (
-            phase
-            in (GenericDiffractometer.PHASE_TRANSFER, GenericDiffractometer.PHASE_BEAM)
-            or self.current_phase
-            in (GenericDiffractometer.PHASE_TRANSFER, GenericDiffractometer.PHASE_BEAM)
+        if phase in (
+            GenericDiffractometer.PHASE_TRANSFER,
+            GenericDiffractometer.PHASE_BEAM,
+        ) or self.current_phase in (
+            GenericDiffractometer.PHASE_TRANSFER,
+            GenericDiffractometer.PHASE_BEAM,
         ):
             detector_distance = self.detector_distance_motor_hwobj.getPosition()
             logging.getLogger("HWR").debug(
                 "Diffractometer current phase: %s " % self.current_phase
-                + "selected phase: %s" % phase
+                + "selected phase: %s " % phase
                 + "detector distance: %d mm" % detector_distance
             )
             if detector_distance < 350:
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                self.detector_distance_motor_hwobj.move(350, timeout=20)
+                self.detector_distance_motor_hwobj.move(350)
+                self.detector.insert_protective_cover()
 
         if timeout is not None:
             self.cmd_start_set_phase(phase)
@@ -386,25 +448,136 @@ class PX2Diffractometer(GenericDiffractometer):
         else:
             self.cmd_start_auto_focus()
 
-    def emit_diffractometer_moved(self, *args):
+    def centring_done(self, centring_procedure):
         """
         Descript. :
         """
-        self.emit("diffractometerMoved", ())
+        start = time.time()
+        try:
+            motor_pos = centring_procedure.get()
+            # if isinstance(motor_pos, gevent.GreenletExit):
+            # raise motor_pos
+            # self.log.info('motor_pos from centring_procedure %s' % motor_pos)
+        except BaseException:
+            logging.exception("Could not complete centring")
+            self.emit_centring_failed()
+        else:
+            self.emit_progress_message("Moving sample to centred position...")
+            self.emit_centring_moving()
+            s_move = time.time()
+            try:
+                self.move_to_motors_positions(motor_pos)
+            except BaseException:
+                logging.exception("Could not move to centred position")
+                self.emit_centring_failed()
 
-    def invalidate_centring(self):
+            if (
+                self.current_centring_method
+                == GenericDiffractometer.CENTRING_METHOD_AUTO
+            ):
+                self.emit("newAutomaticCentringPoint", motor_pos)
+
+            self.ready_event.set()
+            self.centring_time = time.time()
+            self.emit_centring_successful()
+
+    def move_motors(self, motor_positions, timeout=15):
         """
-        Descript. :
+        Moves diffractometer motors to the requested positions
+
+        :param motors_dict: dictionary with motor names or hwobj
+                            and target values.
+        :type motors_dict: dict
         """
-        if self.current_centring_procedure is None and self.centring_status["valid"]:
-            self.centring_status = {"valid": False}
-            self.emit_progress_message("")
-            self.emit("centringInvalid", ())
+        start = time.time()
+        # self.log.info('in move_motors')
+        # self.log.info('motor_positions %s' % motor_positions)
+
+        position = self.translate_from_mxcube_to_md2(motor_positions)
+
+        # position = {}
+        # for motor in motor_positions:
+        # if hasattr(motor, 'motor_name'):
+        # position[motor.motor_name] = motor_positions[motor]
+        # elif motor in self.motor_name_mapping:
+        # position[motor] = motor_positions[motor]
+
+        # self.log.info('position %s' % position)
+        self.goniometer.set_position(position)
+
+        # self.log.info('move_motors took %.3f seconds' % (time.time()-start))
 
     def get_centred_point_from_coord(self, x, y, return_by_names=None):
         """
         Descript. :
         """
+
+        self.log.info("get_centred_point_from_coord: x, y: %s %s" % (x, y))
+        self.log.info(
+            "get_centred_point_from_coord: self.pixels_per_mm_x, self.pixels_per_mm_ y: %s %s"
+            % (self.pixels_per_mm_x, self.pixels_per_mm_y)
+        )
+        self.log.info(
+            "get_centred_point_from_coord: self.beam_position: %s"
+            % str(self.beam_position)
+        )
+
+        current_position = self.goniometer.get_aligned_position()
+
+        omega_reference = self.omega_reference_par["position"]
+
+        alignmentz_shift = current_position["AlignmentZ"] - omega_reference
+
+        vertical_shift = y - self.beam_position[1]
+
+        horizontal_shift = x - self.beam_position[0]
+
+        vertical_shift /= self.pixels_per_mm_y
+        horizontal_shift /= self.pixels_per_mm_x
+
+        self.log.info(
+            "get_centred_point_from_coord: original_vertical_shift: %s "
+            % vertical_shift
+        )
+
+        vertical_shift += alignmentz_shift
+
+        centringx_shift, centringy_shift = self.goniometer.get_x_and_y(
+            0, vertical_shift, current_position["Omega"]
+        )
+
+        centred_point = copy.deepcopy(current_position)
+
+        self.log.info(
+            "get_centred_point_from_coord: alignmentz_shift: %s " % alignmentz_shift
+        )
+        self.log.info(
+            "get_centred_point_from_coord: horizontal_shift: %s " % horizontal_shift
+        )
+
+        self.log.info(
+            "get_centred_point_from_coord: vertical_shift: %s " % vertical_shift
+        )
+        self.log.info(
+            "get_centred_point_from_coord: centringx_shift: %s " % centringx_shift
+        )
+        self.log.info(
+            "get_centred_point_from_coord: centringy_shift: %s " % centringy_shift
+        )
+
+        centred_point["AlignmentZ"] -= alignmentz_shift
+        centred_point["AlignmentY"] -= horizontal_shift
+
+        centred_point["CentringX"] += centringx_shift
+        centred_point["CentringY"] += centringy_shift
+
+        # centred_point['Omega'] += 90.
+        pos = self.translate_from_md2_to_mxcube(centred_point)
+
+        self.log.info("get_centred_point_from_coord: centred_point: %s " % str(pos))
+
+        return pos
+
         self.centring_hwobj.initCentringProcedure()
         self.centring_hwobj.appendCentringDataPoint(
             {
@@ -414,6 +587,7 @@ class PX2Diffractometer(GenericDiffractometer):
         )
         self.omega_reference_add_constraint()
         pos = self.centring_hwobj.centeredPosition()
+        self.log.info("get_centred_point_from_coord: pos %s" % str(pos))
         if return_by_names:
             pos = self.convert_from_obj_to_name(pos)
         return pos
@@ -422,64 +596,346 @@ class PX2Diffractometer(GenericDiffractometer):
         """Creates a new centring point based on all motors positions
         """
         if self.current_phase != "BeamLocation":
-            GenericDiffractometer.move_to_beam(self, x, y, omega)
+            GenericDiffractometer.move_to_beam(
+                self, x, y, omega=self.goniometer.get_omega_position()
+            )
         else:
             logging.getLogger("HWR").debug(
                 "Diffractometer: Move to screen"
                 + " position disabled in BeamLocation phase."
             )
 
-    def manual_centring(self):
+    def manual_centring(
+        self,
+        n_clicks=3,
+        alignmenty_direction=-1.0,
+        alignmentz_direction=1.0,
+        centringx_direction=-1.0,
+        centringy_direction=1.0,
+        refractive_model=False,
+    ):
         """
         Descript. :
         """
-        logging.getLogger("HWR").info("in manual_centring")
+        logging.getLogger("user_level_log").info("starting manual centring")
+        _start = time.time()
+        result_position = {}
+        self.goniometer.insert_backlight()
+        self.goniometer.extract_frontlight()
 
-        self.centring_hwobj.initCentringProcedure()
-        # self.head_type = self.chan_head_type.getValue()
-        for k, click in enumerate(range(3)):
+        reference_position = self.goniometer.get_aligned_position()
+
+        vertical_clicks = []
+        horizontal_clicks = []
+        vertical_discplacements = []
+        horizontal_displacements = []
+        omegas = []
+        images = []
+        auxiliary_images = []
+        calibrations = []
+
+        if isinstance(self.nclicks, int) and self.nclicks >= 3:
+            n_clicks = self.nclicks
+
+        logging.getLogger("user_level_log").info(
+            "expected number of clicks %d" % (n_clicks)
+        )
+
+        if self.step is not None:
+            step = self.step
+        else:
+            step = 360.0 / (n_clicks)
+
+        logging.getLogger("user_level_log").info("default centring step %.2f" % (step))
+
+        start_clicks = time.time()
+
+        for k in range(n_clicks):
             self.user_clicked_event = gevent.event.AsyncResult()
             x, y = self.user_clicked_event.get()
-            logging.getLogger("HWR").info("click %d %f %f" % (k + 1, x, y))
-            self.centring_hwobj.appendCentringDataPoint(
-                {
-                    "X": (x - self.beam_position[0]) / self.pixels_per_mm_x,
-                    "Y": (y - self.beam_position[1]) / self.pixels_per_mm_y,
-                }
-            )
-            if click <= 2:
-                self.motor_hwobj_dict["phi"].moveRelative(90)
-        self.omega_reference_add_constraint()
-        return self.centring_hwobj.centeredPosition(return_by_name=False)
+            image = self.camera_hwobj.get_last_image()
+            calibration = self.camera.get_calibration()
+            omega = self.goniometer.get_omega_position()
 
-    def automatic_centring(self):
-        """Automatic centring procedure. Rotates n times and executes
-           centring algorithm. Optimal scan position is detected.
+            vertical_clicks.append(y)
+            horizontal_clicks.append(x)
+            omegas.append(omega)
+            images.append(image)
+            calibrations.append([calibration])
+
+            x -= self.beam_position[0]
+            x /= self.pixels_per_mm_x
+            y -= self.beam_position[1]
+            y /= self.pixels_per_mm_y
+            vertical_discplacements.append(y)
+            horizontal_displacements.append(x)
+
+            logging.getLogger("HWR").info("click %d %f %f %f" % (k + 1, omega, x, y))
+
+            if k <= n_clicks:
+                self.goniometer.set_position({"Omega": omega + step})
+
+        end_clicks = time.time()
+
+        name_pattern = "%s_%s" % (os.getuid(), time.asctime().replace(" ", "_"))
+        directory = "%s/manual_optical_alignment" % os.getenv("HOME")
+
+        save_history_command = "history_saver.py -s %.2f -e %.2f -d %s -n %s &" % (
+            start_clicks,
+            end_clicks,
+            directory,
+            name_pattern,
+        )
+
+        self.log.info("save_history_command: %s" % save_history_command)
+        os.system(save_history_command)
+
+        vertical_discplacements = np.array(vertical_discplacements) * 1.0e3
+
+        angles = np.radians(omegas)
+
+        if self.centring_method != CENTRING_METHOD.REFRACTIVE:
+            initial_parameters = [4.0, 25.0, 0.05]
+            fit_y = minimize(
+                self.circle_model_residual,
+                initial_parameters,
+                method="nelder-mead",
+                args=(angles, vertical_discplacements),
+            )
+
+            c, r, alpha = fit_y.x
+            c *= 1e-3
+            r *= 1.0e-3
+            v = {"c": c, "r": r, "alpha": alpha}
+            # initial_parameters = lmfit.Parameters()
+            # initial_parameters.add_many(('c', 0., True, -5e3, +5e3, None, None),
+            # ('r', 0., True, 0., 4e3, None, None),
+            # ('alpha', -np.pi/3, True, -2*np.pi, 2*np.pi, None, None))
+
+            # fit_y = lmfit.minimize(self.circle_model_residual2, initial_parameters, method='nelder', args=(angles, vertical_discplacements)) #, kws={'data': vertical_discplacements})
+            # self.log.info(fit_report(fit_y))
+            # optimal_params = fit_y.params
+            # v = optimal_params.valuesdict()
+            # c = v['c']
+            # r = v['r']
+            # alpha = v['alpha']
+
+            # c *= 1e-3
+            # r *=1.e-3
+
+        else:
+            initial_parameters = lmfit.Parameters()
+            initial_parameters.add_many(
+                ("c", 0.0, True, -5e3, +5e3, None, None),
+                ("r", 0.0, True, 0.0, 4e3, None, None),
+                ("alpha", -np.pi / 3, True, -2 * np.pi, 2 * np.pi, None, None),
+                ("front", 0.01, True, 0.0, 1.0, None, None),
+                ("back", 0.005, True, 0.0, 1.0, None, None),
+                ("n", 1.31, True, 1.29, 1.33, None, None),
+                ("beta", 0.0, True, -2 * np.pi, +2 * np.pi, None, None),
+            )
+
+            fit_y = lmfit.minimize(
+                self.refractive_model_residual,
+                initial_parameters,
+                method="nelder",
+                args=(angles, vertical_discplacements),
+            )  # , kws={'data': vertical_discplacements})
+            self.log.info(fit_report(fit_y))
+            optimal_params = fit_y.params
+            v = optimal_params.valuesdict()
+            c = v["c"]
+            r = v["r"]
+            alpha = v["alpha"]
+            front = v["front"]
+            back = v["back"]
+            n = v["n"]
+            beta = v["beta"]
+
+            c *= 1.0e-3
+            r *= 1.0e-3
+            front *= 1.0e-3
+            back *= 1.0e-3
+            # c, r, alpha, front, back, n, beta = fit_lmfit(angles, y)
+
+        horizontal_center = np.mean(horizontal_displacements)
+
+        d_sampx = centringx_direction * r * np.sin(alpha)
+        d_sampy = centringy_direction * r * np.cos(alpha)
+        d_y = alignmenty_direction * horizontal_center
+        d_z = alignmentz_direction * c
+
+        move_vector_dictionary = {
+            "AlignmentZ": d_z,
+            "AlignmentY": d_y,
+            "CentringX": d_sampx,
+            "CentringY": d_sampy,
+        }
+
+        for motor in reference_position:
+            result_position[motor] = reference_position[motor]
+            if motor in move_vector_dictionary:
+                result_position[motor] += move_vector_dictionary[motor]
+
+        _end = time.time()
+        duration = _end - _start
+        self.log.info(
+            "input and analysis in manual_centring took %.3f seconds" % duration
+        )
+
+        results = {
+            "vertical_clicks": vertical_clicks,
+            "horizontal_clicks": horizontal_clicks,
+            "vertical_discplacements": vertical_discplacements,
+            "horizontal_displacements": horizontal_displacements,
+            "omegas": omegas,
+            "angles": angles,
+            "calibrations": calibrations,
+            "reference_position": reference_position,
+            "result_position": result_position,
+            "duration": duration,
+            "vertical_optimal_parameters": v,
+        }
+
+        # self.goniometer.set_position(result_position)
+
+        template = os.path.join(directory, name_pattern)
+
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
+
+        images_filename = "%s_images.h5" % template
+        images_file = h5py.File(images_filename, "w")
+        images_file.create_dataset(
+            "images", data=np.array(images), compression="lzf", dtype=np.uint8
+        )
+        images_file.close()
+
+        clicks_filename = "%s_clicks.pickle" % template
+        f = open(clicks_filename, "w")
+        pickle.dump(results, f)
+        f.close()
+
+        self.log.info(
+            "manual_centring finished in %.3f seconds" % (time.time() - _start)
+        )
+
+        translated_position = self.translate_from_md2_to_mxcube(result_position)
+        return translated_position
+
+    def translate_from_md2_to_mxcube(self, position):
+        translated_position = {}
+
+        for key in position:
+            translated_position[self.md2_to_mxcube[key]] = position[key]
+
+        return translated_position
+
+    def convert_from_obj_to_name(self, motor_pos):
         """
-        self.wait_device_ready(20)
-        surface_score_list = []
-        self.zoom_motor_hwobj.moveToPosition("Zoom 1")
-        self.centring_hwobj.initCentringProcedure()
-        for image in range(PX2Diffractometer.AUTOMATIC_CENTRING_IMAGES):
-            x, y, score = self.find_loop()
-            if x > 0 and y > 0:
-                self.centring_hwobj.appendCentringDataPoint(
-                    {
-                        "X": (x - self.beam_position[0]) / self.pixels_per_mm_x,
-                        "Y": (y - self.beam_position[1]) / self.pixels_per_mm_y,
-                    }
-                )
-            surface_score_list.append(score)
-            self.motor_hwobj_dict["phi"].moveRelative(
-                360.0 / PX2Diffractometer.AUTOMATIC_CENTRING_IMAGES
-            )
-            gevent.sleep(0.01)
-            self.wait_device_ready(10)
-        self.omega_reference_add_constraint()
-        centred_pos_dir = self.centring_hwobj.centeredPosition(return_by_name=False)
-        # self.emit("newAutomaticCentringPoint", centred_pos_dir)
+        """
+        # self.log.info('convert_from_obj_to_name motor_pos %s' % str(motor_pos))
+        # self.log.info('convert_from_obj_to_name cml %s ' % str(self.centring_motors_list))
+        # self.log.info('convert_from_obj_to_name motor_names %s' % str([motor.motor_name for motor in motor_pos]))
 
-        return centred_pos_dir
+        aligned_position = self.goniometer.get_aligned_position()
+
+        motors = self.translate_from_mxcube_to_md2(motor_pos)
+
+        for key in aligned_position:
+            if key not in motors:
+                motors[key] = aligned_position[key]
+
+        motors = self.translate_from_md2_to_mxcube(motors)
+        # motors = {}
+        # for motor_role in self.centring_motors_list:
+        # self.log.info('motor_role %s' % motor_role)
+        # motor_obj = self.getObjectByRole(motor_role)
+        # try:
+        # motors[motor_role] = motor_pos[motor_obj]
+        # except KeyError:
+
+        # self.log.exception('convert_from_obj_to_name %s' % traceback.format_exc())
+        # if motor_obj:
+        # motors[motor_role] = motor_obj.getPosition()
+
+        motors["beam_x"] = (
+            self.beam_position[0] - self.zoom_centre["x"]
+        ) / self.pixels_per_mm_y
+        motors["beam_y"] = (
+            self.beam_position[1] - self.zoom_centre["y"]
+        ) / self.pixels_per_mm_x
+        self.log.info("convert_from_obj_to_name motors %s" % str(motors))
+        return motors
+
+    def translate_from_mxcube_to_md2(self, position):
+        translated_position = {}
+
+        for key in position:
+            if isinstance(key, str):
+                translated_position[self.mxcube_to_md2[key]] = position[key]
+            else:
+                translated_position[key.motor_name] = position[key]
+        return translated_position
+
+    def circle_model(self, angles, c, r, alpha):
+        return c + r * np.cos(angles - alpha)
+
+    def circle_model_residual(self, parameters, angles, data):
+        c, r, alpha = parameters
+        model = self.circle_model(angles, c, r, alpha)
+        # return 1./(2*len(model)) * np.sum(np.sum(np.abs(data - model)**2))
+        return self.cost(data, model, normalize=True)
+
+    def circle_model_residual2(self, parameters, angles, data):
+        v = parameters.valuesdict()
+        c = v["c"]
+        r = v["r"]
+        alpha = v["alpha"]
+        model = self.circle_model(angles, c, r, alpha)
+
+        return self.cost_array(data, model)
+
+    def refractive_model(self, t, c, r, alpha, front, back, n, beta):
+        return self.circle_model(t, c, r, alpha) - self.shift(t, front, back, n, beta)
+
+    def refractive_model_residual(self, parameters, angles, data):
+        v = parameters.valuesdict()
+        c = v["c"]
+        r = v["r"]
+        alpha = v["alpha"]
+        front = v["front"]
+        back = v["back"]
+        n = v["n"]
+        beta = v["beta"]
+        model = self.refractive_model(angles, c, r, alpha, front, back, n, beta)
+
+        return self.cost_array(data, model)
+
+    def cost(self, data, model, factor=1.0, normalize=False):
+        if normalize == True:
+            factor = 1.0 / (2 * len(model))
+        return factor * np.sum(np.sum(np.abs(data - model) ** 2))
+
+    def cost_array(self, data, model):
+        return np.abs(data - model) ** 2
+
+    def i(self, t, n):
+        return np.arcsin(np.sin(t) / n)
+
+    def planparallel_shift(self, depth, t, n, sense=1):
+        i = self.i(t, n)
+        return -depth * np.sin(sense * t - i) / np.cos(i)
+
+    def shift(self, t, f, b, n, beta):
+        t = t - beta
+        dt = np.degrees(t)
+        s = np.zeros(dt.shape)
+        t_base = t % (2 * np.pi)
+        mask = np.where(((t_base < 3 * np.pi / 2) & (t_base >= np.pi / 2)), 1, 0)
+        s[mask == 0] = self.planparallel_shift(f, t_base[mask == 0], n, sense=1)
+        s[mask == 1] = self.planparallel_shift(b, t_base[mask == 1], n, sense=-1)
+        return s
 
     def motor_positions_to_screen(self, centred_positions_dict):
         """
@@ -487,35 +943,86 @@ class PX2Diffractometer(GenericDiffractometer):
         """
         c = centred_positions_dict
 
+        # self.log.info('motor_positions_to_screen c %s ' % str(c))
+
         # kappa = self.current_motor_positions["kappa"]
         # phi = self.current_motor_positions["kappa_phi"]
+        self.log.info("centred_positions_dict %s" % str(centred_positions_dict))
+        try:
+            for key in c:
+                if c[key] is None:
+                    try:
+                        c[key] = self.motor_hwobj_dict[key].getPosition()
+                    except BaseException:
+                        # self.log.info('motor_positions_to_screen exception key %s' % key)
+                        self.log.info(traceback.format_exc())
 
-        kappa = self.motor_hwobj_dict["kappa"].getPosition()
-        phi = self.motor_hwobj_dict["kappa_phi"].getPosition()
-        # IK TODO remove this director call
+            if "kappa" in c and c["kappa"] is None:
+                kappa = self.motor_hwobj_dict["kappa"].getPosition()
+                c["kappa"] = kappa
+            else:
+                c["kappa"] = self.goniometer.get_kappa_position()
 
-        if (c["kappa"], c["kappa_phi"]) != (
-            kappa,
-            phi,
-        ) and self.minikappa_correction_hwobj is not None:
-            # c['sampx'], c['sampy'], c['phiy']
-            c["sampx"], c["sampy"], c["phiy"] = self.minikappa_correction_hwobj.shift(
-                c["kappa"],
-                c["kappa_phi"],
-                [c["sampx"], c["sampy"], c["phiy"]],
-                kappa,
-                phi,
-            )
-        xy = self.centring_hwobj.centringToScreen(c)
-        if xy:
-            x = (xy["X"] + c["beam_x"]) * self.pixels_per_mm_x + self.zoom_centre["x"]
-            y = (xy["Y"] + c["beam_y"]) * self.pixels_per_mm_y + self.zoom_centre["y"]
-            return x, y
+            if "kappa_phi" in c and c["kappa_phi"] is None:
+                phi = self.motor_hwobj_dict["kappa_phi"].getPosition()
+                c["kappa_phi"] = phi
+            else:
+                c["kappa_phi"] = self.goniometer.get_phi_position()
+
+            if "beam_x" in c and c["beam_x"] in [0.0, None]:
+                c["beam_x"] = 0.0  # self.beam_position[0]
+            else:
+                c["beam_x"] = 0.0  # self.beam_position[0]
+
+            if "beam_y" not in c and c["beam_y"] in [0.0, None]:
+                c["beam_y"] = 0.0  # self.beam_position[1]
+            else:
+                c["beam_y"] = 0.0  # self.beam_position[1]
+
+            # self.log.info('motor_positions_to_screen c2 %s ' % str(c))
+
+            if (c["kappa"], c["kappa_phi"]) != (
+                self.goniometer.get_kappa_position(),
+                self.goniometer.get_phi_position(),
+            ) and self.minikappa_correction_hwobj is not None:
+                self.log.info("calculating minikappa correction")
+                c["sampx"], c["sampy"], c[
+                    "phiy"
+                ] = self.minikappa_correction_hwobj.shift(
+                    c["kappa"],
+                    c["kappa_phi"],
+                    [c["sampx"], c["sampy"], c["phiy"]],
+                    c["kappa"],
+                    c["kappa_phi"],
+                )
+
+            xy = self.centring_hwobj.centringToScreen(c)
+            # self.log.info('xy %s' % xy)
+
+            if xy:
+                x = (xy["X"] + c["beam_x"]) * self.pixels_per_mm_x + self.zoom_centre[
+                    "x"
+                ]
+                y = (xy["Y"] + c["beam_y"]) * self.pixels_per_mm_y + self.zoom_centre[
+                    "y"
+                ]
+                return x, y
+        except BaseException:
+            return 0, 0
 
     def move_to_centred_position(self, centred_position):
         """
         Descript. :
         """
+        # self.log.info('in move_to_centred_position')
+        # self.log.info('centred_position %s' % centred_position)
+
+        if centred_position.beam_x is None:
+            centred_position.beam_x = 0.0
+
+        if centred_position.beam_y is None:
+            centred_position.beam_y = 0.0
+
         if self.current_phase != "BeamLocation":
             try:
                 x, y = centred_position.beam_x, centred_position.beam_y
@@ -547,6 +1054,15 @@ class PX2Diffractometer(GenericDiffractometer):
             logging.getLogger("HWR").debug(
                 "Move to centred position disabled in BeamLocation phase."
             )
+
+    def move_to_motors_positions(self, motors_positions, wait=False):
+        """
+        """
+        self.emit_progress_message("Moving to motors positions...")
+        self.move_to_motors_positions_procedure = gevent.spawn(
+            self.move_motors, motors_positions
+        )
+        self.move_to_motors_positions_procedure.link(self.move_motors_done)
 
     def move_kappa_and_phi(self, kappa=None, kappa_phi=None, wait=False):
         """
@@ -591,32 +1107,6 @@ class PX2Diffractometer(GenericDiffractometer):
 
             self.move_motors(motor_pos_dict, timeout=30)
 
-    def convert_from_obj_to_name(self, motor_pos):
-        motors = {}
-        for motor_role in (
-            "phiy",
-            "phiz",
-            "sampx",
-            "sampy",
-            "zoom",
-            "phi",
-            "focus",
-            "kappa",
-            "kappa_phi",
-        ):
-            mot_obj = self.getObjectByRole(motor_role)
-            try:
-                motors[motor_role] = motor_pos[mot_obj]
-            except KeyError:
-                motors[motor_role] = mot_obj.getPosition()
-        motors["beam_x"] = (
-            self.beam_position[0] - self.zoom_centre["x"]
-        ) / self.pixels_per_mm_y
-        motors["beam_y"] = (
-            self.beam_position[1] - self.zoom_centre["y"]
-        ) / self.pixels_per_mm_x
-        return motors
-
     def visual_align(self, point_1, point_2):
         """
         Descript. :
@@ -634,7 +1124,8 @@ class PX2Diffractometer(GenericDiffractometer):
                 new_sampx,
                 new_sampy,
                 new_phiy,
-            ) = self.minikappa_correction_hwobj.alignVector(t1, t2, kappa, phi)
+            ) = self.goniometer.get_align_vector(t1, t2, kappa, phi)
+            # self.minikappa_correction_hwobj.alignVector(t1,t2,kappa,phi)
             self.move_to_motors_positions(
                 {
                     self.motor_hwobj_dict["kappa"]: new_kappa,
@@ -728,7 +1219,7 @@ class PX2Diffractometer(GenericDiffractometer):
         return self.motor_hwobj_dict["phi"].getMaxSpeed()
 
     def get_scan_limits(self, speed=None, num_images=None, exp_time=None):
-        """
+        """optical_alignment
         Gets scan limits. Necessary for example in the plate mode
         where osc range is limited
         """
@@ -743,7 +1234,7 @@ class PX2Diffractometer(GenericDiffractometer):
         x2 = 100
 
         c1 = self.cmd_get_omega_scan_limits(x1)[0] - w0
-        c2 = self.cmd_get_omega_scan_limits(x2)[0] - w0
+        c2 = self.cmd_get_omoptical_alignmentega_scan_limits(x2)[0] - w0
 
         a = -(c2 * x1 - c1 * x2) / (x1 * x2 * (x1 - x2))
         b = -(-c2 * pow(x1, 2) + c1 * pow(x2, 2)) / (x1 * x2 * (x1 - x2))
@@ -811,3 +1302,179 @@ class PX2Diffractometer(GenericDiffractometer):
 
     def save_centring_positions(self):
         self.cmd_save_centring_positions()
+
+    def beam_position_check(self):
+        logging.getLogger("user_level_log").info("Going to check the beam position")
+        self.bpc(wait=False)
+
+    @task
+    def bpc(self):
+        ba = beam_align.beam_align(
+            name_pattern="%s_%s" % (os.getuid(), time.asctime().replace(" ", "_")),
+            directory="%s/beam_align" % os.getenv("HOME"),
+        )
+        logging.getLogger("user_level_log").info(
+            "Align beam to the optical centre of the camera"
+        )
+        logging.getLogger("user_level_log").info(
+            "Moving scintillator to sample position, please wait ..."
+        )
+        ba.execute()
+
+        if ba.no_beam is False:
+            logging.getLogger("user_level_log").info(
+                "Initial mirror positions (vfm, hfm) [mrad]: %.4f %.4f"
+                % tuple(ba.initial_mirror_positions)
+            )
+            logging.getLogger("user_level_log").info(
+                "Initial pixel shift from center (vertical, horizontal): %.1f, %.1f"
+                % tuple(ba.initial_pixel_shift)
+            )
+            logging.getLogger("user_level_log").info(
+                "Beam position adjustment finished after %d iterations"
+                % ba.number_of_iterations
+            )
+            logging.getLogger("user_level_log").info(
+                "Final mirror positions (vfm, hfm) [mrad]: %.4f %.4f"
+                % tuple(ba.final_mirror_position)
+            )
+            logging.getLogger("user_level_log").info(
+                "Final pixel shift from center (vertical, horizontal): %.1f, %.1f"
+                % tuple(ba.final_pixel_shift)
+            )
+            logging.getLogger("user_level_log").info(
+                "Delta in motor positions [mrad]: %.4f, %.4f"
+                % tuple(ba.final_mirror_position - ba.initial_mirror_positions)
+            )
+        else:
+            logging.getLogger("user_level_log").info(ba.no_beam_message)
+
+    @task
+    def anneal(self, time=1.0):
+        anneal_procedure(time)
+
+    @task
+    def excenter(
+        self,
+        scan_length=0.1,
+        step=90.0,
+        start=0.0,
+        base_directory="/nfs/ruche/proxima2a-spool/2019_Run1/excenter",
+        name_pattern="excenter",
+    ):
+
+        directory = os.path.join(base_directory, datetime.datetime.today().isoformat())
+
+        angles = str(tuple(np.arange(start, 360.0, step)))
+
+        execute_line = 'excenter.py -d %s -n %s -l %.2f -a "%s" &' % (
+            directory,
+            name_pattern,
+            scan_length,
+            angles,
+        )
+
+        self.log.info("excenter angles %s" % angles)
+        self.log.info("excenter line %s" % execute_line)
+
+        os.system(execute_line)
+
+    def aperture_align(self):
+        logging.getLogger("user_level_log").info("Aligning the current aperture")
+        self.aa(wait=False)
+
+    @task
+    def aa(self):
+        logging.getLogger("user_level_log").info(
+            "Adjusting camera exposure time for visualisation on the scintillator"
+        )
+        a = scan_and_align.scan_and_align("aperture", display=False)
+        logging.getLogger("user_level_log").info("Scanning the aperture")
+        a.scan()
+        a.align(optimum="com")
+        a.save_scan()
+        logging.getLogger("user_level_log").info(
+            "Setting camera exposure time back to 0.050 seconds"
+        )
+        logging.getLogger("user_level_log").info("Aligning aperture finished")
+        a.predict()
+
+    def start_automatic_centring(
+        self, sample_info=None, loop_only=False, wait_result=None
+    ):
+        """
+        """
+        self.emit_progress_message("Automatic centring...")
+        self.current_centring_procedure = gevent.spawn(self.optical_alignment)
+        self.current_centring_procedure.link(self.centring_done)
+
+        if wait_result:
+            self.ready_event.wait()
+            self.ready_event.clear()
+
+        # self.optical_alignment(wait=False)
+
+    # @task
+    def optical_alignment(self):
+        start = time.time()
+        oa = optical_alignment.optical_alignment(
+            name_pattern="%s_%s" % (os.getuid(), time.asctime().replace(" ", "_")),
+            directory="%s/automated_optical_alignment" % os.getenv("HOME"),
+            analysis=True,
+            conclusion=True,
+            move_zoom=True,
+            film_step=120.0,
+        )
+
+        oa.execute()
+
+        self.log.info(
+            "optical sample alignment finished in %.3f seconds" % (time.time() - start)
+        )
+        # self.emit_centring_successful()
+        self.emit("centringSuccessful", self.current_centring_method, ())
+        result_position = oa.get_result_position()
+        translated_position = self.translate_from_md2_to_mxcube(result_position)
+        return translated_position
+
+    def set_nclicks(self, nclicks):
+        self.log.info(
+            "PX2Diffractometer: number of centring clicks changed: %s" % nclicks
+        )
+        try:
+            self.nclicks = int(nclicks)
+        except BaseException:
+            logging.getLogger("HWR").exception(traceback.format_exc())
+
+    def set_step(self, step):
+        self.log.info("PX2Diffractometer: centring step changed: %s" % step)
+        try:
+            self.step = float(step)
+        except BaseException:
+            logging.getLogger("HWR").exception(traceback.format_exc())
+
+    def set_centring_method(self, centring_method):
+        self.log.info(
+            "PX2Diffractometer: centring method changed: %s" % centring_method
+        )
+        try:
+            self.centring_method = centring_method
+        except BaseException:
+            logging.getLogger("HWR").exception(traceback.format_exc())
+
+    def is_ready(self):
+        """
+        Detects if device is ready
+        """
+        condition1 = self.current_state == DiffractometerState.tostring(
+            DiffractometerState.Ready
+        )
+
+        condition2 = self.collecting == False
+
+        # self.log.info('Diffractometer is_ready collecting %s' % self.collecting)
+
+        return condition1 and condition2
+
+    def set_collecting(self, collecting=True):
+        self.collecting = collecting


### PR DESCRIPTION
Updated PX2Diffractometer, now includes refractive optical alignment model.

The environment model is that of a transparent planparallel slab. To fit the image movement model we need three parameters to describe the circle on which the sample is really moving and four additional parameters to account for refractive shift of apparent sample position:: thickness of the slab, normal of the slab planes, index of refraction and position of the sample in the slab.

The fitting is done using Nelder-Mead algorithm as implemented in lmfit.minimize. The advantage of lmfit version is that it allows for specification of constraints on the fitted parameters. This is important to make the procedure work robustly in practice.

The minimum number of points (clicks) is 7 but I would recommend using more (>10) to make the fit more robust.