### PR TITLE
WIP: Yaml-configured BeamlineObject

### DIFF
--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -15,7 +15,9 @@ class ConfiguredObject(object):
     # NB the double underscore is deliberate - attribute must be hidden from subclasses
     __object_role_categories = OrderedDict()
 
-    def __init__(self):
+    def __init__(self, name):
+
+        self.name = name
 
         self._objects = OrderedDict((role, None) for role in self.role_to_category)
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -32,7 +32,7 @@ __license__ = "LGPLv3+"
 __author__ = "Rasmus H Fogh"
 
 from collections import OrderedDict
-from BaseHardwareObjects import ConfiguredObject
+from HardwareRepository.BaseHardwareObjects import ConfiguredObject
 
 
 class Beamline(ConfiguredObject):

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -27,7 +27,7 @@ All HardwareObjects
 from __future__ import division, absolute_import
 from __future__ import print_function, unicode_literals
 
-__copyright__ = """ Copyright © 2019 by Global Phasing Ltd. """
+__copyright__ = """ Copyright © 2019 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 __author__ = "Rasmus H Fogh"
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -1,0 +1,467 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Beamline class serving as singleton container for links to top-level HardwareObjects
+
+All HardwareObjects
+"""
+
+from __future__ import division, absolute_import
+from __future__ import print_function, unicode_literals
+
+__copyright__ = """ Copyright © 2019 by Global Phasing Ltd. """
+__license__ = "LGPLv3+"
+__author__ = "Rasmus H Fogh"
+
+from collections import OrderedDict
+from BaseHardwareObjects import ConfiguredObject
+
+
+class Beamline(ConfiguredObject):
+    """Beamline class serving as singleton container for links to HardwareObjects"""
+
+    # Roles of defined objects and the category they belong to
+    # NB the double underscore is deliberate - attribute must be hidden from subclasses
+    __object_role_categories = OrderedDict()
+
+    @property
+    def machine_info(self):
+        """Machine information Hardware object
+
+        Returns:
+            Optional[AbstractMachineInfo]:
+        """
+        return self._objects.get("machine_info")
+
+    __object_role_categories["machine_info"] = "hardware"
+
+    @property
+    def transmission(self):
+        """Transmission Hardware object
+
+        Returns:
+            Optional[AbstractTransmission]:
+        """
+        return self._objects.get("transmission")
+
+    __object_role_categories["transmission"] = "hardware"
+
+    @property
+    def energy(self):
+        """Energy Hardware object
+
+        Returns:
+            Optional[AbstractEnergy]:
+        """
+        return self._objects.get("energy")
+
+    __object_role_categories["energy"] = "hardware"
+
+    @property
+    def flux(self):
+        """Flux Hardware object
+
+        Returns:
+            Optional[AbstractActuator]:
+        """
+        return self._objects.get("flux")
+
+    __object_role_categories["fkux"] = "hardware"
+
+    @property
+    def beam(self):
+        """Beam Hardware object
+
+        Returns:
+            Optional[AbstractBeam]:
+        """
+        return self._objects.get("beam")
+
+    __object_role_categories["beam"] = "hardware"
+
+    @property
+    def hutch_interlock(self):
+        """Hutch Interlock Hardware object
+
+        Returns:
+            Optional[AbstractInterlock]:
+        """
+        return self._objects.get("hutch_interlock")
+
+    __object_role_categories["hutch_interlock"] = "hardware"
+
+    @property
+    def safety_shutter(self):
+        """Safety Shutter Hardware object
+
+        Returns:
+            Optional[AbstractShutter]:
+        """
+        return self._objects.get("safety_shutter")
+
+    __object_role_categories["safety_shutter"] = "hardware"
+
+    @property
+    def fast_shutter(self):
+        """Fast Shutter Hardware object
+
+        Returns:
+            Optional[AbstractShutter]:
+        """
+        return self._objects.get("fast_shutter")
+
+    __object_role_categories["fast_shutter"] = "hardware"
+
+    @property
+    def diffractometer(self):
+        """Diffractometer Hardware object
+
+        Returns:
+            Optional[AbstractDiffractometer]:
+        """
+        return self._objects.get("diffractometer")
+
+    __object_role_categories["diffractometer"] = "hardware"
+
+    @property
+    def detector(self):
+        """Detector Hardware object
+
+        Returns:
+            Optional[AbstractDetector]:
+        """
+        return self._objects.get("detector")
+
+    __object_role_categories["detector"] = "hardware"
+
+    @property
+    def resolution(self):
+        """Resolution Hardware object
+
+        Returns:
+            Optional[AbstractActuator]:
+        """
+        return self._objects.get("resolution")
+
+    __object_role_categories["resolution"] = "hardware"
+
+    @property
+    def sample_changer(self):
+        """Sample Changer Hardware object
+        can be a sample changer, plate_manipulator, jets, chips
+
+        Returns:
+            Optional[AbstractSampleChanger]:
+        """
+        return self._objects.get("sample_changer")
+
+    __object_role_categories["sample_changer"] = "hardware"
+
+    @property
+    def session(self):
+        """Session Hardware object, holding information on current session and user.
+
+        Returns:
+            Optional[Session]:
+        """
+        return self._objects.get("session")
+
+    __object_role_categories["session"] = "hardware"
+
+    @property
+    def lims(self):
+        """LIMS client object.
+
+        Returns:
+            Optional[ISPyBClient]:
+        """
+        return self._objects.get("lims")
+
+    __object_role_categories["lims"] = "hardware"
+
+    @property
+    def graphics(self):
+        """Graphics/OAV object. Includes defined shapes.
+
+        Returns:
+            Optional[AbstractGraphics]:
+        """
+        return self._objects.get("graphics")
+
+    __object_role_categories["graphics"] = "hardware"
+
+    @property
+    def queue_manager(self):
+        """Queue manager object.
+
+        Returns:
+            Optional[QueueManager]:
+        """
+        return self._objects.get("queue_manager")
+
+    __object_role_categories["queue_manager"] = "hardware"
+
+    @property
+    def queue_model(self):
+        """Queue model object.
+
+        Returns:
+            Optional[QueueModel]:
+        """
+        return self._objects.get("queue_model")
+
+    __object_role_categories["queue_model"] = "hardware"
+
+    # Procedures
+
+    @property
+    def collect(self):
+        """Data collection procedure.
+
+        Returns:
+            Optional[AbstractCollect]:
+        """
+        return self._objects.get("collect")
+
+    __object_role_categories["collect"] = "procedure"
+
+    @property
+    def xrf_spectrum(self):
+        """X-ray fluorescence spectrum procedure.
+
+        Returns:
+            Optional[AbstractProcedure]
+        """
+        return self._objects.get("xrf_spectrum")
+
+    __object_role_categories["xrf_spectrum"] = "procedure"
+
+    @property
+    def energy_scan(self):
+        """Energy scan procedure.
+
+        Returns:
+            Optional[AbstractProcedure]:
+        """
+        return self._objects.get("energy_scan")
+
+    __object_role_categories["energy_scan"] = "procedure"
+
+    @property
+    def imaging(self):
+        """Imaging procedure.
+
+        Returns:
+            Optional[AbstractProcedure]:
+        """
+        return self._objects.get("imaging")
+
+    __object_role_categories["imaging"] = "procedure"
+
+    @property
+    def gphl_workflow(self):
+        """Global phasing data collection workflow procedure.
+
+        Returns:
+            Optional[GpglWorkflow]:
+        """
+        return self._objects.get("gphl_workflow")
+
+    __object_role_categories["gphl_workflow"] = "procedure"
+
+    # This one is 'hardware', but it is put with its companion
+    @property
+    def gphl_connection(self):
+        """Global PHasing workflow remote connection
+
+        Returns:
+            Optional[GphlWorkflowConnection]:
+        """
+        return self._objects.get("gphl_connection")
+
+    __object_role_categories["gphl_connection"] = "hardware"
+
+    # centring
+
+    # NB Could centring be treated as procedures instesad?
+
+    @property
+    def n_click_centring(self):
+        """Manual (n-click) centring procedure.
+
+        Returns:
+            Optional[AbstractCentring]:
+        """
+        return self._objects.get("n_click_centring")
+
+    __object_role_categories["n_click_centring"] = "centring"
+
+    @property
+    def move_to_beam(self):
+        """Manual in-plane, double-click (move-to-beam) centring procedure.
+
+        Returns:
+            Optional[AbstractCentring]:
+        """
+        return self._objects.get("move_to_beam")
+
+    __object_role_categories["move_to_beam"] = "centring"
+
+    @property
+    def optical_centring(self):
+        """Automatic optical centring procedure.
+
+        Returns:
+            Optional[AbstractCentring]:
+        """
+        return self._objects.get("optical_centring")
+
+    __object_role_categories["optical_centring"] = "centring"
+
+    @property
+    def x_ray_centring(self):
+        """Automatic X-ray centring procedure.
+
+        Returns:
+            Optional[AbstractCentring]:
+        """
+        return self._objects.get("x_ray_centring")
+
+    __object_role_categories["x_ray_centring"] = "centring"
+
+    # Analysis (combines processing and data analysis)
+
+    @property
+    def online_processing(self):
+        """Synchronous (on-line) data processing procedure.
+
+        Returns:
+            Optional[AbstractProcessing]:
+        """
+        return self._objects.get("online_processing")
+
+    __object_role_categories["online_processing"] = "analysis"
+
+    @property
+    def offline_processing(self):
+        """Asynchronous (queue sumbission) data processing procedure.
+
+        Returns:
+            Optional[AbstractProcessing]:
+        """
+        return self._objects.get("offline_processing")
+
+    __object_role_categories["offline_processing"] = "analysis"
+
+    @property
+    def edna_characterisation(self):
+        """EDNA charadterisatoin and analysis procedure.
+
+        NB the current code looks rather EDNA-specific
+        to be called 'AbsatractCharacterisation'.
+        Potentially we could generalise it, and maybe make it into a procedure???
+
+        Returns:
+            Optional[EdnaCharacterisation]:
+        """
+        return self._objects.get("edna_characterisation")
+
+    __object_role_categories["edna_characterisation"] = "analysis"
+
+
+class BeamlineSubclass(Beamline):
+    """Example of Beamline subclass, for local enhancements"""
+
+    # Roles of defined objects and the category they belong to
+    # NB the double underscore is deliberate - attribute must be hidden from subclasses
+    __object_role_categories = OrderedDict()
+
+    def __init__(self, mode="production"):
+        """Subclass init
+
+        Adds slots for non-object configuration parameters
+
+        """
+        super(self, BeamlineSubclass).__init__(self)
+
+        self.mode = mode
+
+        # Add non-object attriiutes to configure
+
+        # List/tuple of advanced methods. Value set in config file
+        self.advanced_methods = None
+
+        # Boolean - is wavelength tunable? Value set in config file
+        self.tunable_wavelength = None
+
+        # Boolean - disable number-of-passes input box. Value set in config file
+        self.disable_num_passes = None
+
+    # NB This property is the only addition necessary to make the subclass finction
+    @property
+    def role_to_category(self):
+        """Mapping from role to category
+
+        Returns:
+            OrderedDict[text_str, text_str]
+        """
+        # Copy roles from superclass and add those form this class
+        result = super(self, BeamlineSubclass).role_to_category
+        result.update(self.__object_role_categories)
+        return result
+
+    # Additional properties
+
+    @property
+    def beam_definer(self):
+        """Beam-definer Hardware object
+
+        Returns:
+            Optional[AbstractMotor]:
+        """
+        return self._objects.get("beam_definer")
+
+    __object_role_categories["beam_definer"] = "hardware"
+
+    @property
+    def beam_realign(self):
+        """Beam-realign procedure object
+
+        Returns:
+            Optional[AbstractProcedure]:
+        """
+        return self._objects.get("beam_realign")
+
+    __object_role_categories["beam_realign"] = "procedure"
+
+    # NB Objects need not be HardwareObjects
+    # We still categorise them as'hardware' if they are not procedures, though
+    # The attribute values will be given in the config.yml file
+    @property
+    def default_characterisation_parameters(self):
+        """Default characterisation parameters object
+
+        Returns:
+            Optional[queue_model_objects.CharacterisationParameters]:
+        """
+        return self._objects.get("default_characterisation_parameters")
+
+    __object_role_categories["default_characterisation_parameters"] = "hardware"

--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -59,12 +59,12 @@ def get_beamline():
     """
     global _beamline
     if _beamline is None:
-        _beamline = load_from_yaml(BEAMLINE_CONFIG_FILE)
+        _beamline = load_from_yaml(BEAMLINE_CONFIG_FILE, role='beamline')
     else:
         return _beamline
 
 
-def load_from_yaml(configuration_file):
+def load_from_yaml(configuration_file, role):
     """Loads yaml configuration file,
     and recursively loads contained objects from their configuration files
 
@@ -106,7 +106,7 @@ def load_from_yaml(configuration_file):
     cls = __import__(ll0[-1], fromlist=ll0[:-1], level=0)
 
     # instantiate object
-    result = cls(**initialise_class)
+    result = cls(name=role, **initialise_class)
 
     # Initialise object
     result.init()
@@ -115,7 +115,7 @@ def load_from_yaml(configuration_file):
     _objects = configuration.pop("_objects", {})
     for role, config_file in _objects.items():
         if os.path.splitext(config_file)[1] == ".yml":
-            hwobj = load_from_yaml(config_file)
+            hwobj = load_from_yaml(config_file, role=role)
             hwobj.init()
         elif os.path.splitext(config_file)[1] == ".xml":
             hwobj = _instance.loadHardwareObject(config_file)

--- a/HardwareRepository.py
+++ b/HardwareRepository.py
@@ -13,7 +13,6 @@ import weakref
 import sys
 import os
 import time
-import yaml
 import gevent.monkey
 from datetime import datetime
 
@@ -29,6 +28,14 @@ from . import BaseHardwareObjects
 from . import HardwareObjectFileParser
 from HardwareRepository.dispatcher import dispatcher
 from HardwareRepository.ConvertUtils import string_types
+
+from ruamel.yaml import YAML
+# If you want to write out copies of the file, use typ="rt" instead
+# pure=True uses yaml version 1.2, with fewere gotchas for strange type conversions
+yaml  = YAML(typ="safe", pure=True)
+# The following are not needed for load, but define the default style.
+yaml.default_flow_style = False
+yaml.indent(mapping=4, sequence=4, offset=2)
 
 __author__ = "Matias Guijarro"
 __version__ = 1.3
@@ -80,19 +87,18 @@ def load_from_yaml(configuration_file):
 
     # Load the configuration file
     with open(configuration_path, "r") as fp0:
-        configuration = yaml.safe_load(fp0)
-        yaml.dump()
+        configuration = yaml.load(fp0)
 
     # Get actual class
-    initialise_class = configuration.pop("initialise_class", None)
+    initialise_class = configuration.pop("_initialise_class", None)
     if not initialise_class:
         raise ValueError(
-            "Configuration file %s lacks 'initialise_class' tag" % configuration_path
+            "Configuration file %s lacks '_initialise_class' tag" % configuration_path
         )
     class_import = initialise_class.pop("class", None)
     if not class_import:
         raise ValueError(
-            "Configuration file %s 'initialise_class' lacks 'class' tag"
+            "Configuration file %s '_initialise_class' lacks 'class' tag"
             % configuration_path
         )
     ll0 = class_import.split(".")

--- a/configuration/xml-qt/beamline_config.yml
+++ b/configuration/xml-qt/beamline_config.yml
@@ -1,6 +1,5 @@
----
 # The class to initialise, and init parameters
-initialise_class:
+_initialise_class:
     class: HardwareRepository.HardwareObjects.Beamline.BeamlineSubclass
     # Further key-value pairs here will be passed to the class init
     mode: devel
@@ -57,7 +56,9 @@ _objects:
     # NB this one does not yet exist, but should be written:
     default_characterisation_parameters: default_characterisation_parameters.xml
 # Non-object attributes:
-advanced_methods: ["MeshScan", "XrayCentering"]
+advanced_methods:
+  - MeshScan
+  - XrayCentering
 tunable_wavelength: true
 disable_num_passes: false
 

--- a/configuration/xml-qt/beamline_config.yml
+++ b/configuration/xml-qt/beamline_config.yml
@@ -1,0 +1,63 @@
+---
+# The class to initialise, and init parameters
+initialise_class:
+    class: HardwareRepository.HardwareObjects.Beamline.BeamlineSubclass
+    # Further key-value pairs here will be passed to the class init
+    mode: devel
+
+# objects
+#
+# Eventually all objects should use the yaml config system like Beamline,
+# but for now we can leave them as xml
+#
+# NBNB some objects that do not currently have their own config files
+# would need those added (e.g. the centring methods)
+#
+_objects:
+    # The values are the file paths to the configuration file for the
+    # object, relative to the configuration file path(s)
+    #
+    # Hardware:
+    machine_info: mach-info.xml
+    transmission: attenuators.xml
+    energy: energy.xml
+    flux: flux.xml
+    beam: beam-info.xml
+    hutch_interlock: door-interlock.xml
+    safety_shutter: safshut.xml
+    fast_shutter: fast-shut.xml
+    diffractometer: mini-diff.xml
+    detector: eh1/detector.xml
+    resolution: eh1/resolution.xml
+    sample_changer: sc-generic.xml
+    session: session.xml
+    lims: dbconnection.xml
+    graphics: graphics.xml
+    queue_manager: queue.xml
+    queue_model: queue_model.xml
+    # Procedures:
+    collect: mxcollect.xml
+    xrf_spectrum: xrf-spectrum.xml
+    energy_scan: energyscan.xml
+    imaging: xray-imaging.xml
+    gphl_workflow: gphl-workflow.yml
+    gphl_connection: gphl-setup.yml
+    # Centring:
+    n_click_centring: three-click-centring.xml
+    move_to_beam: move-to-beam.xml
+    # optical_centring: # Skipped - optional
+    # x_ray_centring: # Skipped - optional
+    # Analysis:
+    online_processing: auto-processing.xml
+    offline_processing: parallel-processing.xml
+    edna_characterisation: data-analysis.xml
+    # Subclass-specific objects:
+    beam_definer: eh1/beamFocusing.xml
+    # beam_realign: # Skipped - optional
+    # NB this one does not yet exist, but should be written:
+    default_characterisation_parameters: default_characterisation_parameters.xml
+# Non-object attributes:
+advanced_methods: ["MeshScan", "XrayCentering"]
+tunable_wavelength: true
+disable_num_passes: false
+


### PR DESCRIPTION
This is a new proposal for the beamline object, with yaml configuration. 

There is still a fair bit to do, but before I add functionality, try to extend this to e.g. the diffractometer, or modify the code to fit the new system, we should agree if this is indeed the way to go. 

Comments
=========

  -  The framework will support configuration of any contained object, so I propose it could eventually become a replacement for HardwareObjectNode. I have therefore put it in HardwareRepository and BaseHardwareObjects. For a start (transition phase?) it should support both yaml-configured objects and xml-configured HardwareObjects as contained objects. 

  - All contained objects must be defined as properties, with a single role name per object. They are optional, so you can simply omit them from the configuration file. This is not limited to HardwareObjects, you could configure e.g. AcquisitionParameter objects.

  - The BeamlineObject (and any other object that uses the framework) can be subclassed - you just need to add any additional properties and update a single short function in the subclass

  - Each object belongs to one (and only one) category, and you can get objects by category. That allows you to define and get e.g. all procedures or all centring functions. 

  - You can put lists, maps, or scalars in as non-object properties. These do not have to be defined as properties, but for safety the corresponding attribute has to be set in the class.\_\_init\_\_

TODO
====

  - DONE Check the ruamel.yaml module, which looks like a better replacement for standard yaml (which has a lot of gotchas) (ACTION @rhfogh )

  - DONE Check the yaml formatting we want and the dump options this corresponds to, and rewrite the example to match. (ACTION @rhfogh)

  - Add  output for loaded objects (with load time), failed loads, and non-configured objects. (ACTION @rhfogh)
