### PR TITLE
Removed unit in method name

### DIFF
--- a/HardwareObjects/EMBL/EMBLAperture.py
+++ b/HardwareObjects/EMBL/EMBLAperture.py
@@ -86,7 +86,7 @@ class EMBLAperture(AbstractAperture):
             self._diameter_size_list[self._current_diameter_index] / 1000.0,
         )
 
-    def get_diameter_size_mm(self):
+    def get_diameter_size(self):
         """Returns: diameter size in mm"""
         return self._diameter_size_list[self._current_diameter_index] / 1000.0
 

--- a/HardwareObjects/EMBL/EMBLFlux.py
+++ b/HardwareObjects/EMBL/EMBLFlux.py
@@ -354,7 +354,7 @@ class EMBLFlux(AbstractFlux):
             self.fast_shutter_hwobj.openShutter(wait=True)
 
             for index, diameter_size in enumerate(
-                self.aperture_hwobj.get_diameter_size_mm_list()
+                self.aperture_hwobj.get_diameter_size_list()
             ):
                 # 5. open the fast shutter -----------------------------------------
                 self.emit(

--- a/HardwareObjects/MAXIV/BIOMAXAperture.py
+++ b/HardwareObjects/MAXIV/BIOMAXAperture.py
@@ -18,7 +18,7 @@ class BIOMAXAperture(MicrodiffAperture):
         if self.aperture_position is not None:
             self.connect(self.aperture_position, "update", self.position_changed)
 
-        self.get_diameter_size_mm_list = self.getPredefinedPositionsList
+        self.get_diameter_size_list = self.getPredefinedPositionsList
         self.set_position = self.moveToPosition
 
     def moveToPosition(self, positionName):

--- a/HardwareObjects/MicrodiffAperture.py
+++ b/HardwareObjects/MicrodiffAperture.py
@@ -72,7 +72,7 @@ class MicrodiffAperture(MD2Motor):
         )
         self.emit("apertureChanged", (self.getApertureSize(),))
 
-    def get_diameter_size_mm(self, pos=None):
+    def get_diameter_size(self, pos=None):
         if self.getPosition() is not None:
             pos = pos or self.getPosition()
         else:
@@ -87,11 +87,11 @@ class MicrodiffAperture(MD2Motor):
 
     def getCurrentPositionName(self, pos=None):
         warn(
-          "getCurrentPositionName is deprecated. Use get_diameter_size_mm() instead",
+          "getCurrentPositionName is deprecated. Use get_diameter_size() instead",
           DeprecationWarning,
         )
 
-        return self.get_diameter_size_mm(pos)
+        return self.get_diameter_size(pos)
 
 
     def moveToPosition(self, positionName):

--- a/HardwareObjects/UnitTest.py
+++ b/HardwareObjects/UnitTest.py
@@ -54,14 +54,14 @@ class TestMethods(unittest.TestCase):
 
         logging.getLogger("HWR").debug("UnitTest: Testing aperture hwobj")
         self.assertIn(
-            type(BL_SETUP.beam_info_hwobj.aperture_hwobj.get_diameter_size_mm()),
+            type(BL_SETUP.beam_info_hwobj.aperture_hwobj.get_diameter_size()),
             (float, int),
-            "Aperture | get_diameter_size_mm() returns float",
+            "Aperture | get_diameter_size() returns float",
         )
         self.assertIn(
-            type(BL_SETUP.beam_info_hwobj.aperture_hwobj.get_diameter_size_mm_list()),
+            type(BL_SETUP.beam_info_hwobj.aperture_hwobj.get_diameter_size_list()),
             (list, tuple),
-            "Aperture | get_diameter_size_mm_list() returns list or tuple",
+            "Aperture | get_diameter_size_list() returns list or tuple",
         )
         self.assertIn(
             type(BL_SETUP.beam_info_hwobj.aperture_hwobj.get_position_list()),

--- a/HardwareObjects/abstract/AbstractAperture.py
+++ b/HardwareObjects/abstract/AbstractAperture.py
@@ -48,7 +48,7 @@ class AbstractAperture(HardwareObject):
         except BaseException:
             logging.getLogger("HWR").error("Aperture: no position list defined")
 
-    def get_diameter_size_mm_list(self):
+    def get_diameter_size_list(self):
         """
         Returns:
             list: list of diameter sizes in microns
@@ -91,14 +91,14 @@ class AbstractAperture(HardwareObject):
                 "Aperture: Diameter index %d is not valid" % diameter_index
             )
 
-    def get_diameter_size_mm(self):
+    def get_diameter_size(self):
         """
         Returns:
             float: current diameter size in mm
         """
         return self._diameter_size_list[self._current_diameter_index]
 
-    def set_diameter_size_mm(self, diameter_size):
+    def set_diameter_size(self, diameter_size):
         """
         Args:
             diameter_size (int): selected diameter index

--- a/HardwareObjects/mockup/BeamInfoMockup.py
+++ b/HardwareObjects/mockup/BeamInfoMockup.py
@@ -41,7 +41,7 @@ class BeamInfoMockup(Equipment):
                 self.aperture_diameter_changed,
             )
 
-            ad = self.aperture_hwobj.get_diameter_size_mm() / 1000.0
+            ad = self.aperture_hwobj.get_diameter_size() / 1000.0
             self.beam_size_aperture = [ad, ad]
 
         self.slits_hwobj = self.getObjectByRole("slits")


### PR DESCRIPTION
Dear all,

Noticed that one commit was missing from the previous PR #407, sorry,

So we finally agreed on removing the unit from the method name but that the
methods would return the same unit, on all sites, defined by AbstractAperture.
Either mm or microns which is a decision that remains be taken.

Regards,
Marcus