### PR TITLE
ApertureMockup fix

### DIFF
--- a/HardwareObjects/mockup/ApertureMockup.py
+++ b/HardwareObjects/mockup/ApertureMockup.py
@@ -89,3 +89,10 @@ class ApertureMockup(AbstractAperture):
             list: sizes of available apertures in microns
         """
         return self._diameter_size_list
+    
+    def get_position_list(self):
+        """
+        Returns:
+            list: strings designating named positions (e.g. "BEAM", "OFF", "PARK" ...)
+        """
+        return self._position_list

--- a/HardwareObjects/mockup/ApertureMockup.py
+++ b/HardwareObjects/mockup/ApertureMockup.py
@@ -82,3 +82,10 @@ class ApertureMockup(AbstractAperture):
             bool: True if aperture is in the beam, otherwise returns false
         """
         return self._current_position_name != "BEAM"
+
+    def get_diameter_list(self):
+        """
+        Returns:
+            list: sizes of available apertures in microns
+        """
+        return [5, 10, 20, 50, 100, 300]

--- a/HardwareObjects/mockup/ApertureMockup.py
+++ b/HardwareObjects/mockup/ApertureMockup.py
@@ -88,4 +88,4 @@ class ApertureMockup(AbstractAperture):
         Returns:
             list: sizes of available apertures in microns
         """
-        return [5, 10, 20, 50, 100, 300]
+        return self._diameter_size_list


### PR DESCRIPTION
This adds two methods to ApertureMockup.py: get_diameter_list() and get_position_list(). Both methods are expected by ApertureBrick.py. This fixes error when starting example gui with aperture mockup hardware object.