### PR TITLE
Beamline Object - Updates

### DIFF
--- a/HardwareObjects/ALBA/ALBACollect.py
+++ b/HardwareObjects/ALBA/ALBACollect.py
@@ -692,7 +692,7 @@ class ALBACollect(AbstractCollect):
         if not self.is_sampleview_phase():
             self.go_to_sampleview()
 
-        HWR.beamline.graphics.save_scene_snapshot(filename)
+        HWR.beamline.microscope.save_scene_snapshot(filename)
         logging.getLogger("HWR").debug(" - snapshot saved to %s" % filename)
 
     def set_energy(self, value):

--- a/HardwareObjects/BeamInfo.py
+++ b/HardwareObjects/BeamInfo.py
@@ -36,6 +36,7 @@ class BeamInfo(Equipment):
         Equipment.__init__(self, *args)
 
         self.aperture_hwobj = None
+        self.beam_definer = None
         self.slits_hwobj = None
 
         self.beam_size_slits = None
@@ -72,9 +73,9 @@ class BeamInfo(Equipment):
         else:
             logging.getLogger("HWR").debug("BeamInfo: Slits hwobj not defined")
 
-        if HWR.beamline.beam_definer is not None:
+        if self.beam_definer is not None:
             self.connect(
-                HWR.beamline.beam_definer,
+                self.beam_definer,
                 "definerPosChanged",
                 self.definer_pos_changed
             )
@@ -105,8 +106,8 @@ class BeamInfo(Equipment):
         """
         Descript. :
         """
-        if HWR.beamline.beam_definer is not None:
-            return HWR.beamline.beam_definer.get_divergence_hor()
+        if self.beam_definer is not None:
+            return self.beam_definer.get_divergence_hor()
         else:
             return self.default_beam_divergence[0]
 
@@ -114,8 +115,8 @@ class BeamInfo(Equipment):
         """
         Descript. :
         """
-        if HWR.beamline.beam_definer is not None:
-            return HWR.beamline.beam_definer.get_divergence_ver()
+        if self.beam_definer is not None:
+            return self.beam_definer.get_divergence_ver()
         else:
             return self.default_beam_divergence[1]
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -590,8 +590,10 @@ class Beamline(ConfiguredObject):
         osc_start = motor_positions.get("phi", params["osc_start"])
         acq_parameters.osc_start = round(float(osc_start), 2)
         kappa = motor_positions.get("kappa", 0.0)
+        kappa = kappa if kappa else 0.0
         acq_parameters.kappa = round(float(kappa), 2)
         kappa_phi = motor_positions.get("kappa_phi", 0.0)
+        kappa_phi = kappa_phi if kappa_phi else 0.0
         acq_parameters.kappa_phi = round(float(kappa_phi), 2)
 
         try:

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -197,6 +197,16 @@ class Beamline(ConfiguredObject):
     __content_roles.append("beam")
 
     @property
+    def beam_definer(self):
+        """Beam-definer Hardware object
+
+        Returns:
+            Optional[HardwareObject]:
+        """
+        return self._objects.get("beam_definer")
+    __content_roles.append("beam_definer")
+
+    @property
     def hutch_interlock(self):
         """Hutch Interlock Hardware object
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -299,6 +299,17 @@ class Beamline(ConfiguredObject):
     __content_roles.append("sample_changer")
 
     @property
+    def  sample_changer_maintenance(self):
+        """Sample Changer Maintnance Hardware object
+
+        Returns:
+            Optional[AbstractMaintnanceSampleChanger]:
+        """
+        return self._objects.get("sample_changer_maintenance")
+
+    __content_roles.append("sample_changer_maintenance")
+
+    @property
     def plate_manipulator(self):
         """Plate Manuipulator Hardware object
         NBNB TODO REMOVE THIS and treat as an alternative sample changer instead.

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -83,6 +83,12 @@ class Beamline(ConfiguredObject):
         # List[str] of advanced method names
         self.advanced_methods = []
 
+        # List[str] of available methods
+        self.available_methods = []
+
+        # int number of clicks used for click centring
+        self.click_centring_num_clicks = 3
+
         # bool Is wavelength tunable
         self.tunable_wavelength = False
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -327,6 +327,17 @@ class Beamline(ConfiguredObject):
     __content_roles.append("session")
 
     @property
+    def cryo(self):
+        """Cryostream Hardware object.
+
+        Returns:
+            Optional[Cryo]:
+        """
+        return self._objects.get("cryo")
+
+    __content_roles.append("cryo")
+
+    @property
     def lims(self):
         """LIMS client object.
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -329,7 +329,7 @@ class Beamline(ConfiguredObject):
         """Microscope object. Includes defined shapes.
 
         Returns:
-            Optional[AbstractMmicroscope]:
+            Optional[AbstractMicroscope]:
         """
         return self._objects.get("microscope")
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -359,7 +359,6 @@ class Beamline(ConfiguredObject):
 
     __content_roles.append("lims")
 
- 
     @property
     def microscope(self):
         """Microscope object. Includes defined shapes.
@@ -563,7 +562,6 @@ class Beamline(ConfiguredObject):
     # NB Objects need not be HardwareObjects
     # We still categorise them as'hardware' if they are not procedures, though
     # The attribute values will be given in the config.yml file
-
     def get_default_acquisition_parameters(self, acquisition_type="default"):
         """
         :returns: A AcquisitionParameters object with all default parameters for the

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -429,6 +429,28 @@ class Beamline(ConfiguredObject):
     __content_roles.append("imaging")
 
     @property
+    def xml_rpc_server(self):
+        """XMLRPCServer for RPC
+
+        Returns:
+            Optional[XMLRPCServer]:
+        """
+        return self._objects.get("xml_rpc_server")
+
+    __content_roles.append("xml_rpc_server")
+
+    @property
+    def workflow(self):
+        """Standarad EDNA workflow procedure.
+
+        Returns:
+            Optional[Workflow]:
+        """
+        return self._objects.get("workflow")
+
+    __content_roles.append("workflow")
+
+    @property
     def gphl_workflow(self):
         """Global phasing data collection workflow procedure.
 

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -307,16 +307,17 @@ class Beamline(ConfiguredObject):
 
     __content_roles.append("lims")
 
+ 
     @property
-    def graphics(self):
-        """Graphics/OAV object. Includes defined shapes.
+    def microscope(self):
+        """Microscope object. Includes defined shapes.
 
         Returns:
-            Optional[AbstractGraphics]:
+            Optional[AbstractMmicroscope]:
         """
-        return self._objects.get("graphics")
+        return self._objects.get("microscope")
 
-    __content_roles.append("graphics")
+    __content_roles.append("microscope")
 
     @property
     def queue_manager(self):

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -223,6 +223,30 @@ class Beamline(ConfiguredObject):
 
     __content_roles.append("fast_shutter")
 
+
+    @property
+    def beamstop(self):
+        """Beamstop Hardware object
+
+        Returns:
+            Optional[AbstractNState]:
+        """
+        return self._objects.get("beamstop")
+
+    __content_roles.append("beamstop")
+
+    @property
+    def capillary(self):
+        """Capillary Hardware object
+
+        Returns:
+            Optional[AbstractNState]:
+        """
+        return self._objects.get("capillary")
+
+    __content_roles.append("capillary")
+
+
     @property
     def diffractometer(self):
         """Diffractometer Hardware object

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -197,16 +197,6 @@ class Beamline(ConfiguredObject):
     __content_roles.append("beam")
 
     @property
-    def beam_definer(self):
-        """Beam-definer Hardware object
-
-        Returns:
-            Optional[HardwareObject]:
-        """
-        return self._objects.get("beam_definer")
-    __content_roles.append("beam_definer")
-
-    @property
     def hutch_interlock(self):
         """Hutch Interlock Hardware object
 
@@ -238,30 +228,6 @@ class Beamline(ConfiguredObject):
         return self._objects.get("fast_shutter")
 
     __content_roles.append("fast_shutter")
-
-
-    @property
-    def beamstop(self):
-        """Beamstop Hardware object
-
-        Returns:
-            Optional[AbstractNState]:
-        """
-        return self._objects.get("beamstop")
-
-    __content_roles.append("beamstop")
-
-    @property
-    def capillary(self):
-        """Capillary Hardware object
-
-        Returns:
-            Optional[AbstractNState]:
-        """
-        return self._objects.get("capillary")
-
-    __content_roles.append("capillary")
-
 
     @property
     def diffractometer(self):
@@ -309,7 +275,7 @@ class Beamline(ConfiguredObject):
     __content_roles.append("sample_changer")
 
     @property
-    def  sample_changer_maintenance(self):
+    def sample_changer_maintenance(self):
         """Sample Changer Maintnance Hardware object
 
         Returns:
@@ -346,17 +312,6 @@ class Beamline(ConfiguredObject):
         return self._objects.get("session")
 
     __content_roles.append("session")
-
-    @property
-    def cryo(self):
-        """Cryostream Hardware object.
-
-        Returns:
-            Optional[Cryo]:
-        """
-        return self._objects.get("cryo")
-
-    __content_roles.append("cryo")
 
     @property
     def lims(self):

--- a/HardwareObjects/DESY/NanoDiff.py
+++ b/HardwareObjects/DESY/NanoDiff.py
@@ -273,11 +273,11 @@ class NanoDiff(HardwareObject):
                 self.focus_motor_hwobj, "positionChanged", self.focus_motor_moved
             )
 
-        # if HWR.beamline.graphics.camera is None:
+        # if HWR.beamline.microscope.camera is None:
         #     logging.getLogger("HWR").error("NanoDiff: Camera is not defined")
         # else:
-        #     self.image_height = HWR.beamline.graphics.camera.getHeight()
-        #     self.image_width = HWR.beamline.graphics.camera.getWidth()
+        #     self.image_height = HWR.beamline.microscope.camera.getHeight()
+        #     self.image_width = HWR.beamline.microscope.camera.getWidth()
 
         try:
             self.zoom_centre = eval(self.getProperty("zoom_centre"))
@@ -633,9 +633,9 @@ class NanoDiff(HardwareObject):
         """
         Descript. :
         """
-        if HWR.beamline.graphics.camera is not None:
+        if HWR.beamline.microscope.camera is not None:
             if self.current_phase != "Unknown":
-                HWR.beamline.graphics.camera.refresh_video()
+                HWR.beamline.microscope.camera.refresh_video()
         if HWR.beamline.beam is not None:
             self.beam_position = HWR.beamline.beam.get_beam_position()
 
@@ -1356,6 +1356,6 @@ class NanoDiff(HardwareObject):
         snapshot_filename = os.path.join(
             tempfile.gettempdir(), "mxcube_sample_snapshot.png"
         )
-        HWR.beamline.graphics.camera.take_snapshot(snapshot_filename, bw=True)
+        HWR.beamline.microscope.camera.take_snapshot(snapshot_filename, bw=True)
         info, x, y = lucid.find_loop(snapshot_filename)
         return x, y

--- a/HardwareObjects/EMBL/EMBLBeamlineTest.py
+++ b/HardwareObjects/EMBL/EMBLBeamlineTest.py
@@ -121,7 +121,7 @@ class EMBLBeamlineTest(HardwareObject):
         self.bl_hwobj = self.getObjectByRole("beamline_setup")
         self.crl_hwobj = self.getObjectByRole("crl")
         self.connect(
-            HWR.beamline.graphics, "imageDoubleClicked", self.image_double_clicked
+            HWR.beamline.microscope, "imageDoubleClicked", self.image_double_clicked
         )
         self.connect(
             HWR.beamline.energy, "beamAlignmentRequested", self.center_beam_test
@@ -399,7 +399,7 @@ class EMBLBeamlineTest(HardwareObject):
             table_values += (
                 "<td><img src=%s style=width:700px;></td>" % beam_image_filename
             )
-            HWR.beamline.graphics.save_scene_snapshot(beam_image_filename)
+            HWR.beamline.microscope.save_scene_snapshot(beam_image_filename)
             progress_info = {"progress_total": len(aperture_list), "progress_msg": msg}
             self.emit("testProgress", (index, progress_info))
 
@@ -567,7 +567,7 @@ class EMBLBeamlineTest(HardwareObject):
                 slits_hwobj.set_vertical_gap(1.0)  # "Hor", 1.0)
                 slits_hwobj.set_horizontal_gap(1.0)  # "Ver", 1.0)
 
-            # HWR.beamline.graphics.save_scene_snapshot(beam_image_filename)
+            # HWR.beamline.microscope.save_scene_snapshot(beam_image_filename)
 
             # Actual centring procedure  ---------------
 
@@ -595,13 +595,13 @@ class EMBLBeamlineTest(HardwareObject):
             progress_info["progress_msg"] = msg
             log.info("Beam centering: %s" % msg)
             self.emit("testProgress", (6, progress_info))
-            HWR.beamline.graphics.move_beam_mark_auto()
+            HWR.beamline.microscope.move_beam_mark_auto()
 
         HWR.beamline.transmission.set_transmission(
             current_transmission
         )  # Transmission(current_transmission)
 
-        HWR.beamline.graphics.graphics_beam_item.set_detected_beam_position(
+        HWR.beamline.microscope.graphics_beam_item.set_detected_beam_position(
             None, None
         )
 
@@ -661,7 +661,7 @@ class EMBLBeamlineTest(HardwareObject):
                 with gevent.Timeout(10, False):
                     beam_pos_displacement = [None, None]
                     while None in beam_pos_displacement:
-                        beam_pos_displacement = HWR.beamline.graphics.get_beam_displacement(
+                        beam_pos_displacement = HWR.beamline.microscope.get_beam_displacement(
                             reference="beam"
                         )
                         gevent.sleep(0.1)
@@ -745,7 +745,7 @@ class EMBLBeamlineTest(HardwareObject):
                     with gevent.Timeout(10, False):
                         beam_pos_displacement = [None, None]
                         while None in beam_pos_displacement:
-                            beam_pos_displacement = HWR.beamline.graphics.get_beam_displacement(
+                            beam_pos_displacement = HWR.beamline.microscope.get_beam_displacement(
                                 reference="screen"
                             )
                             gevent.sleep(0.1)
@@ -831,7 +831,7 @@ class EMBLBeamlineTest(HardwareObject):
         beam_image_filename = os.path.join(
             self.test_directory, "auto_centring_before.png"
         )
-        HWR.beamline.graphics.save_scene_snapshot(beam_image_filename)
+        HWR.beamline.microscope.save_scene_snapshot(beam_image_filename)
         gevent.sleep(0.1)
         result["result_details"].append(
             "<img src=%s style=width:300px;><br>" % beam_image_filename
@@ -845,7 +845,7 @@ class EMBLBeamlineTest(HardwareObject):
         beam_image_filename = os.path.join(
             self.test_directory, "auto_centring_after.png"
         )
-        HWR.beamline.graphics.save_scene_snapshot(beam_image_filename)
+        HWR.beamline.microscope.save_scene_snapshot(beam_image_filename)
         result["result_details"].append(
             "<img src=%s style=width:300px;><br>" % beam_image_filename
         )

--- a/HardwareObjects/EMBL/EMBLCollect.py
+++ b/HardwareObjects/EMBL/EMBLCollect.py
@@ -368,7 +368,7 @@ class EMBLCollect(AbstractCollect):
     @task
     def _take_crystal_snapshot(self, snapshot_filename):
         """Saves crystal snapshot"""
-        HWR.beamline.graphics.save_scene_snapshot(snapshot_filename)
+        HWR.beamline.microscope.save_scene_snapshot(snapshot_filename)
 
     @task
     def _take_crystal_animation(self, animation_filename, duration_sec=1):
@@ -376,7 +376,7 @@ class EMBLCollect(AbstractCollect):
            Animation is saved as the fourth snapshot
         """
 
-        HWR.beamline.graphics.save_scene_animation(
+        HWR.beamline.microscope.save_scene_animation(
             animation_filename, duration_sec
         )
 

--- a/HardwareObjects/EMBL/EMBLDoorInterlock.py
+++ b/HardwareObjects/EMBL/EMBLDoorInterlock.py
@@ -165,7 +165,7 @@ class EMBLDoorInterlock(Device):
            as long as it is a one char
         """
         if HWR.beamline.diffractometer is not None:
-            detector_distance = HWR.beamline.detector.detector_distance
+            detector_distance = HWR.beamline.resolution.detector_distance
             if HWR.beamline.diffractometer.in_plate_mode():
                 if detector_distance  is not None:
                     if detector_distance .getPosition() < 780:

--- a/HardwareObjects/EMBL/EMBLDoorInterlock.py
+++ b/HardwareObjects/EMBL/EMBLDoorInterlock.py
@@ -165,7 +165,7 @@ class EMBLDoorInterlock(Device):
            as long as it is a one char
         """
         if HWR.beamline.diffractometer is not None:
-            detector_distance = HWR.beamline.resolution.detector_distance
+            detector_distance = HWR.beamline.detector.detector_distance
             if HWR.beamline.diffractometer.in_plate_mode():
                 if detector_distance  is not None:
                     if detector_distance .getPosition() < 780:

--- a/HardwareObjects/EMBL/EMBLDoorInterlock.py
+++ b/HardwareObjects/EMBL/EMBLDoorInterlock.py
@@ -165,7 +165,7 @@ class EMBLDoorInterlock(Device):
            as long as it is a one char
         """
         if HWR.beamline.diffractometer is not None:
-            detector_distance = HWR.beamline.detector.detector_distance
+            detector_distance = HWR.beamline.detector.distance
             if HWR.beamline.diffractometer.in_plate_mode():
                 if detector_distance  is not None:
                     if detector_distance .getPosition() < 780:

--- a/HardwareObjects/EMBL/EMBLFlux.py
+++ b/HardwareObjects/EMBL/EMBLFlux.py
@@ -277,7 +277,7 @@ class EMBLFlux(AbstractFlux):
 
         if HWR.beamline.session.beamline_name == "P14":
             if (
-                HWR.beamline.detector.detector_distance.get_position()
+                HWR.beamline.resolution.detector_distance.get_position()
                 > MIN_DETECTOR_DISTANCE
             ):
                 self.print_log(

--- a/HardwareObjects/EMBL/EMBLFlux.py
+++ b/HardwareObjects/EMBL/EMBLFlux.py
@@ -277,7 +277,7 @@ class EMBLFlux(AbstractFlux):
 
         if HWR.beamline.session.beamline_name == "P14":
             if (
-                HWR.beamline.resolution.detector_distance.get_position()
+                HWR.beamline.detector.detector_distance.get_position()
                 > MIN_DETECTOR_DISTANCE
             ):
                 self.print_log(

--- a/HardwareObjects/EMBL/EMBLFlux.py
+++ b/HardwareObjects/EMBL/EMBLFlux.py
@@ -277,7 +277,7 @@ class EMBLFlux(AbstractFlux):
 
         if HWR.beamline.session.beamline_name == "P14":
             if (
-                HWR.beamline.detector.detector_distance.get_position()
+                HWR.beamline.detector.distance.get_position()
                 > MIN_DETECTOR_DISTANCE
             ):
                 self.print_log(

--- a/HardwareObjects/EMBL/EMBLMiniDiff.py
+++ b/HardwareObjects/EMBL/EMBLMiniDiff.py
@@ -418,9 +418,9 @@ class EMBLMiniDiff(GenericDiffractometer):
             or self.current_phase
             in (GenericDiffractometer.PHASE_TRANSFER, GenericDiffractometer.PHASE_BEAM)
         ):
-            if (HWR.beamline.detector.detector_distance.get_position() < 350):
+            if (HWR.beamline.resolution.detector_distance.get_position() < 350):
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                HWR.beamline.detector.detector_distance.move(350, timeout=20)
+                HWR.beamline.resolution.detector_distance.move(350, timeout=20)
 
         if timeout is not None:
             _start = time.time()
@@ -826,7 +826,7 @@ class EMBLMiniDiff(GenericDiffractometer):
         Finds loop
         :return: int, int, int
         """
-        image_array = HWR.beamline.graphics.camera.get_snapshot(return_as_array=True)
+        image_array = HWR.beamline.microscope.get_snapshot(return_as_array=True)
         (info, x, y) = lucid.find_loop(image_array)
         surface_score = 10
         return x, y, surface_score

--- a/HardwareObjects/EMBL/EMBLMiniDiff.py
+++ b/HardwareObjects/EMBL/EMBLMiniDiff.py
@@ -418,9 +418,9 @@ class EMBLMiniDiff(GenericDiffractometer):
             or self.current_phase
             in (GenericDiffractometer.PHASE_TRANSFER, GenericDiffractometer.PHASE_BEAM)
         ):
-            if (HWR.beamline.detector.detector_distance.get_position() < 350):
+            if (HWR.beamline.detector.distance.get_position() < 350):
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                HWR.beamline.detector.detector_distance.move(350, timeout=20)
+                HWR.beamline.detector.distance.move(350, timeout=20)
 
         if timeout is not None:
             _start = time.time()

--- a/HardwareObjects/EMBL/EMBLMiniDiff.py
+++ b/HardwareObjects/EMBL/EMBLMiniDiff.py
@@ -418,9 +418,9 @@ class EMBLMiniDiff(GenericDiffractometer):
             or self.current_phase
             in (GenericDiffractometer.PHASE_TRANSFER, GenericDiffractometer.PHASE_BEAM)
         ):
-            if (HWR.beamline.resolution.detector_distance.get_position() < 350):
+            if (HWR.beamline.detector.detector_distance.get_position() < 350):
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                HWR.beamline.resolution.detector_distance.move(350, timeout=20)
+                HWR.beamline.detector.detector_distance.move(350, timeout=20)
 
         if timeout is not None:
             _start = time.time()

--- a/HardwareObjects/EMBL/EMBLXrayImaging.py
+++ b/HardwareObjects/EMBL/EMBLXrayImaging.py
@@ -127,7 +127,7 @@ class EMBLXrayImaging(QtGraphicsManager, AbstractCollect):
 
         QtGraphicsManager.init(self)
 
-        self.disconnect(HWR.beamline.graphics.camera, "imageReceived", self.camera_image_received)
+        self.disconnect(HWR.beamline.microscope.camera, "imageReceived", self.camera_image_received)
 
         self.disconnect(
             HWR.beamline.diffractometer,
@@ -513,7 +513,7 @@ class EMBLXrayImaging(QtGraphicsManager, AbstractCollect):
     @task
     def _take_crystal_snapshot(self, filename):
         """Saves crystal snapshot"""
-        HWR.beamline.graphics.save_scene_snapshot(filename)
+        HWR.beamline.microscope.save_scene_snapshot(filename)
 
     def data_collection_hook(self):
         pass

--- a/HardwareObjects/ESRF/ESRFBeamInfo.py
+++ b/HardwareObjects/ESRF/ESRFBeamInfo.py
@@ -37,8 +37,8 @@ class ESRFBeamInfo(BeamInfo.BeamInfo):
         else:
             # Cannot be done, as graphics HWOBJ is initialised after beam
             # self.beam_position = (
-            #     HWR.beamline.graphics.camera.getWidth() / 2,
-            #     HWR.beamline.graphics.camera.getHeight() / 2,
+            #     HWR.beamline.microscope.camera.getWidth() / 2,
+            #     HWR.beamline.microscope.camera.getHeight() / 2,
             # )
             logging.getLogger("HWR").warning(
                 "ESRFBeamInfo: "
@@ -50,8 +50,8 @@ class ESRFBeamInfo(BeamInfo.BeamInfo):
     def get_beam_position(self):
         if self.beam_position == (0, 0):
             self.beam_position = (
-                HWR.beamline.graphics.camera.getWidth() / 2,
-                HWR.beamline.graphics.camera.getHeight() / 2,
+                HWR.beamline.microscope.camera.getWidth() / 2,
+                HWR.beamline.microscope.camera.getHeight() / 2,
             )
         return self.beam_position
 

--- a/HardwareObjects/ESRF/ID231BeamInfo.py
+++ b/HardwareObjects/ESRF/ID231BeamInfo.py
@@ -53,7 +53,7 @@ class BeamInfo(Equipment):
             logging.getLogger("HWR").debug("BeamInfo: slits not defined correctly")
         try:
             self.connect(
-                HWR.beamline.beam_definer,
+                HWR.beamline.beam.beam_definer,
                 "definerPosChanged",
                 self.definer_pos_changed
             )

--- a/HardwareObjects/ESRF/ID232HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID232HutchTrigger.py
@@ -88,7 +88,7 @@ class ID232HutchTrigger(BaseHardwareObjects.HardwareObject):
         logging.info(
             "%s: %s hutch", self.name(), "entering" if entering_hutch else "leaving"
         )
-        dtox = HWR.beamline.detector.detector_distance
+        dtox = HWR.beamline.resolution.detector_distance
         udiff_ctrl = self.getObjectByRole("predefined")
         ctrl_obj = self.getObjectByRole("controller")
         if not entering_hutch:

--- a/HardwareObjects/ESRF/ID232HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID232HutchTrigger.py
@@ -88,7 +88,7 @@ class ID232HutchTrigger(BaseHardwareObjects.HardwareObject):
         logging.info(
             "%s: %s hutch", self.name(), "entering" if entering_hutch else "leaving"
         )
-        dtox = HWR.beamline.detector.detector_distance
+        dtox = HWR.beamline.detector.distance
         udiff_ctrl = self.getObjectByRole("predefined")
         ctrl_obj = self.getObjectByRole("controller")
         if not entering_hutch:

--- a/HardwareObjects/ESRF/ID232HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID232HutchTrigger.py
@@ -88,7 +88,7 @@ class ID232HutchTrigger(BaseHardwareObjects.HardwareObject):
         logging.info(
             "%s: %s hutch", self.name(), "entering" if entering_hutch else "leaving"
         )
-        dtox = HWR.beamline.resolution.detector_distance
+        dtox = HWR.beamline.detector.detector_distance
         udiff_ctrl = self.getObjectByRole("predefined")
         ctrl_obj = self.getObjectByRole("controller")
         if not entering_hutch:

--- a/HardwareObjects/ESRF/ID29HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID29HutchTrigger.py
@@ -65,7 +65,7 @@ class ID29HutchTrigger(BaseHardwareObjects.HardwareObject):
         logging.info(
             "%s: %s hutch", self.name(), "entering" if entering_hutch else "leaving"
         )
-        dtox = HWR.beamline.detector.detector_distance
+        dtox = HWR.beamline.detector.distance
         if not entering_hutch:
             if old["dtox"] is not None:
                 dtox.move(old["dtox"])

--- a/HardwareObjects/ESRF/ID29HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID29HutchTrigger.py
@@ -65,7 +65,7 @@ class ID29HutchTrigger(BaseHardwareObjects.HardwareObject):
         logging.info(
             "%s: %s hutch", self.name(), "entering" if entering_hutch else "leaving"
         )
-        dtox = HWR.beamline.detector.detector_distance
+        dtox = HWR.beamline.resolution.detector_distance
         if not entering_hutch:
             if old["dtox"] is not None:
                 dtox.move(old["dtox"])

--- a/HardwareObjects/ESRF/ID29HutchTrigger.py
+++ b/HardwareObjects/ESRF/ID29HutchTrigger.py
@@ -65,7 +65,7 @@ class ID29HutchTrigger(BaseHardwareObjects.HardwareObject):
         logging.info(
             "%s: %s hutch", self.name(), "entering" if entering_hutch else "leaving"
         )
-        dtox = HWR.beamline.resolution.detector_distance
+        dtox = HWR.beamline.detector.detector_distance
         if not entering_hutch:
             if old["dtox"] is not None:
                 dtox.move(old["dtox"])

--- a/HardwareObjects/ESRF/ID30BPhotonFlux.py
+++ b/HardwareObjects/ESRF/ID30BPhotonFlux.py
@@ -22,7 +22,11 @@ class ID30BPhotonFlux(Equipment):
             self.counter = getattr(self.controller, counter)
         else:
             self.counter = self.getObjectByRole("counter")
-        self.shutter.connect("shutterStateChanged", self.shutterStateChanged)
+
+        try:
+            self.shutter.connect("shutterStateChanged", self.shutterStateChanged)
+        except Exception:
+            logging.exception("Could not connect to shutterStateChanged")
 
         self.counts_reading_task = self._read_counts_task(wait=False)
 

--- a/HardwareObjects/ESRF/ID30BeamInfo.py
+++ b/HardwareObjects/ESRF/ID30BeamInfo.py
@@ -15,8 +15,8 @@ class ID30BeamInfo(BeamInfo.BeamInfo):
             float, self.getProperty("beam_size_slits").split()
         ))  # [0.1, 0.05]
         self.beam_position = (
-            HWR.beamline.graphics.camera.getWidth() / 2,
-            HWR.beamline.graphics.camera.getHeight() / 2
+            HWR.beamline.microscope.camera.getWidth() / 2,
+            HWR.beamline.microscope.camera.getHeight() / 2
         )
 
     def get_beam_position(self):

--- a/HardwareObjects/GenericDiffractometer.py
+++ b/HardwareObjects/GenericDiffractometer.py
@@ -228,9 +228,9 @@ class GenericDiffractometer(HardwareObject):
         self.user_confirms_centring = True
 
         # Hardware objects ----------------------------------------------------
-        # if HWR.beamline.graphics.camera is not None:
-        #     self.image_height = HWR.beamline.graphics.camera.getHeight()
-        #     self.image_width = HWR.beamline.graphics.camera.getWidth()
+        # if HWR.beamline.microscope.camera is not None:
+        #     self.image_height = HWR.beamline.microscope.camera.getHeight()
+        #     self.image_width = HWR.beamline.microscope.camera.getWidth()
         # else:
         #     logging.getLogger("HWR").debug(
         #         "Diffractometer: " + "Camera hwobj is not defined"
@@ -688,14 +688,14 @@ class GenericDiffractometer(HardwareObject):
     #     return self.current_positions_dict.get("phi")
 
     def get_snapshot(self):
-        if HWR.beamline.graphics.camera:
-            return HWR.beamline.graphics.camera.get_snapshot()
+        if HWR.beamline.microscope:
+            return HWR.beamline.microscope.take_snapshot()
 
     def save_snapshot(self, filename):
         """
         """
-        if HWR.beamline.graphics.camera:
-            return HWR.beamline.graphics.camera.save_snapshot(filename)
+        if HWR.beamline.microscope:
+            return HWR.beamline.microscope.save_snapshot(filename)
 
     def get_pixels_per_mm(self):
         """
@@ -810,7 +810,7 @@ class GenericDiffractometer(HardwareObject):
         while self.automatic_centring_try_count > 0:
             if self.use_sample_centring:
                 self.current_centring_procedure = sample_centring.start_auto(
-                    HWR.beamline.graphics.camera,
+                    HWR.beamline.microscope.camera,
                     {
                         "phi": self.centring_phi,
                         "phiy": self.centring_phiy,

--- a/HardwareObjects/GphlWorkflow.py
+++ b/HardwareObjects/GphlWorkflow.py
@@ -1434,7 +1434,7 @@ class GphlWorkflow(HardwareObject, object):
             # We are moving to having recentered positions -
             # Set or prompt for fine zoom
             self._use_fine_zoom = True
-            zoom_motor = HWR.beamline.graphics.zoom
+            zoom_motor = HWR.beamline.microscope.zoom
             if zoom_motor:
                 # Zoom to the last predefined position
                 # - that should be the largest magnification

--- a/HardwareObjects/ISPyBClient.py
+++ b/HardwareObjects/ISPyBClient.py
@@ -156,6 +156,7 @@ class ISPyBClient(HardwareObject):
         HardwareObject.__init__(self, name)
         self.ldapConnection = None
         self.beamline_name = "unknown"
+        self.lims_rest = None
         self._shipping = None
         self._collection = None
         self._tools_ws = None
@@ -177,6 +178,7 @@ class ISPyBClient(HardwareObject):
         """
         Init method declared by HardwareObject.
         """
+        self.lims_rest = self.getObjectByRole("lims_rest")
         self.authServerType = self.getProperty("authServerType") or "ldap"
         if self.authServerType == "ldap":
             # Initialize ldap

--- a/HardwareObjects/ISPyBRestClient.py
+++ b/HardwareObjects/ISPyBRestClient.py
@@ -34,7 +34,7 @@ class ISPyBRestClient(HardwareObject):
         self.__rest_token = None
         self.__rest_token_timestamp = None
         self.base_result_url = None
-            self.beamline_name = None
+        self.beamline_name = None
 
     def init(self):
 

--- a/HardwareObjects/MAXIV/BIOMAXBeamInfo.py
+++ b/HardwareObjects/MAXIV/BIOMAXBeamInfo.py
@@ -56,8 +56,8 @@ class BIOMAXBeamInfo(BeamInfo.BeamInfo):
             self.beam_position[0] = self.chan_beam_pos_x.getValue() * zoom
             self.beam_position[1] = self.chan_beam_pos_y.getValue() * zoom
         else:
-            self.beam_position[0] = HWR.beamline.graphics.camera.getWidth() / 2
-            self.beam_position[1] = HWR.beamline.graphics.camera.getHeight() / 2
+            self.beam_position[0] = HWR.beamline.microscope.camera.getWidth() / 2
+            self.beam_position[1] = HWR.beamline.microscope.camera.getHeight() / 2
 
         return self.beam_position
 

--- a/HardwareObjects/MAXIV/BIOMAXBeamlineActions.py
+++ b/HardwareObjects/MAXIV/BIOMAXBeamlineActions.py
@@ -77,9 +77,9 @@ class BIOMAXBeamlineActions(HardwareObject):
             logging.getLogger("HWR").info("Closing detector cover...")
             self.detector_cover_hwobj.closeShutter()
 
-        if HWR.beamline.resolution.detector_distance is not None:
+        if HWR.beamline.detector.detector_distance is not None:
             logging.getLogger("HWR").info("Moving detector to safe area...")
-            HWR.beamline.resolution.detector_distance.syncMove(800, timeout=50)
+            HWR.beamline.detector.detector_distance.syncMove(800, timeout=50)
 
         if HWR.beamline.sample_changer.isPowered():
             if HWR.beamline.sample_changer.getLoadedSample() is not None:
@@ -133,9 +133,9 @@ class BIOMAXBeamlineActions(HardwareObject):
                 while HWR.beamline.safety_shutter.getShutterState() == "opened":
                     gevent.sleep(0.1)
 
-        if HWR.beamline.resolution.detector_distance is not None:
+        if HWR.beamline.detector.detector_distance is not None:
             logging.getLogger("HWR").info("Moving detector to safe area...")
-            HWR.beamline.resolution.detector_distance.syncMove(800, timeout=50)
+            HWR.beamline.detector.detector_distance.syncMove(800, timeout=50)
 
     def init(self):
         self.sample_changer_maint_hwobj = self.getObjectByRole(

--- a/HardwareObjects/MAXIV/BIOMAXBeamlineActions.py
+++ b/HardwareObjects/MAXIV/BIOMAXBeamlineActions.py
@@ -77,9 +77,9 @@ class BIOMAXBeamlineActions(HardwareObject):
             logging.getLogger("HWR").info("Closing detector cover...")
             self.detector_cover_hwobj.closeShutter()
 
-        if HWR.beamline.detector.detector_distance is not None:
+        if HWR.beamline.resolution.detector_distance is not None:
             logging.getLogger("HWR").info("Moving detector to safe area...")
-            HWR.beamline.detector.detector_distance.syncMove(800, timeout=50)
+            HWR.beamline.resolution.detector_distance.syncMove(800, timeout=50)
 
         if HWR.beamline.sample_changer.isPowered():
             if HWR.beamline.sample_changer.getLoadedSample() is not None:
@@ -133,9 +133,9 @@ class BIOMAXBeamlineActions(HardwareObject):
                 while HWR.beamline.safety_shutter.getShutterState() == "opened":
                     gevent.sleep(0.1)
 
-        if HWR.beamline.detector.detector_distance is not None:
+        if HWR.beamline.resolution.detector_distance is not None:
             logging.getLogger("HWR").info("Moving detector to safe area...")
-            HWR.beamline.detector.detector_distance.syncMove(800, timeout=50)
+            HWR.beamline.resolution.detector_distance.syncMove(800, timeout=50)
 
     def init(self):
         self.sample_changer_maint_hwobj = self.getObjectByRole(

--- a/HardwareObjects/MAXIV/BIOMAXBeamlineActions.py
+++ b/HardwareObjects/MAXIV/BIOMAXBeamlineActions.py
@@ -77,9 +77,9 @@ class BIOMAXBeamlineActions(HardwareObject):
             logging.getLogger("HWR").info("Closing detector cover...")
             self.detector_cover_hwobj.closeShutter()
 
-        if HWR.beamline.detector.detector_distance is not None:
+        if HWR.beamline.detector.distance is not None:
             logging.getLogger("HWR").info("Moving detector to safe area...")
-            HWR.beamline.detector.detector_distance.syncMove(800, timeout=50)
+            HWR.beamline.detector.distance.syncMove(800, timeout=50)
 
         if HWR.beamline.sample_changer.isPowered():
             if HWR.beamline.sample_changer.getLoadedSample() is not None:
@@ -133,9 +133,9 @@ class BIOMAXBeamlineActions(HardwareObject):
                 while HWR.beamline.safety_shutter.getShutterState() == "opened":
                     gevent.sleep(0.1)
 
-        if HWR.beamline.detector.detector_distance is not None:
+        if HWR.beamline.detector.distance is not None:
             logging.getLogger("HWR").info("Moving detector to safe area...")
-            HWR.beamline.detector.detector_distance.syncMove(800, timeout=50)
+            HWR.beamline.detector.distance.syncMove(800, timeout=50)
 
     def init(self):
         self.sample_changer_maint_hwobj = self.getObjectByRole(

--- a/HardwareObjects/MAXIV/BIOMAXCollect.py
+++ b/HardwareObjects/MAXIV/BIOMAXCollect.py
@@ -1191,7 +1191,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         lower_limit, upper_limit = self.get_detector_distance_limits()
         logging.getLogger("HWR").info(
             "...................value %s, detector movement start..... %s"
-            % (value, HWR.beamline.resolution.detector_distance.getPosition())
+            % (value, HWR.beamline.detector.detector_distance.getPosition())
         )
         if upper_limit is not None and lower_limit is not None:
             if value >= upper_limit or value <= lower_limit:
@@ -1201,8 +1201,8 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
                 self.stop_collect()
             else:
                 try:
-                    if HWR.beamline.resolution.detector_distance is not None:
-                        HWR.beamline.resolution.detector_distance.syncMove(
+                    if HWR.beamline.detector.detector_distance is not None:
+                        HWR.beamline.detector.detector_distance.syncMove(
                             value, timeout=50
                         )  # 30s is not enough for the whole range
                 except BaseException:
@@ -1216,22 +1216,22 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
             )
         logging.getLogger("HWR").info(
             "....................value %s detector movement finished.....%s"
-            % (value, HWR.beamline.resolution.detector_distance.getPosition())
+            % (value, HWR.beamline.detector.detector_distance.getPosition())
         )
 
     def get_detector_distance(self):
         """
         Descript. :
         """
-        if HWR.beamline.resolution.detector_distance is not None:
-            return HWR.beamline.resolution.detector_distance.getPosition()
+        if HWR.beamline.detector.detector_distance is not None:
+            return HWR.beamline.detector.detector_distance.getPosition()
 
     def get_detector_distance_limits(self):
         """
         Descript. :
         """
-        if HWR.beamline.resolution.detector_distance is not None:
-            return HWR.beamline.resolution.detector_distance.getLimits()
+        if HWR.beamline.detector.detector_distance is not None:
+            return HWR.beamline.detector.detector_distance.getLimits()
 
     def prepare_detector(self):
 
@@ -1259,7 +1259,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         )  # self.get_beam_centre_pixel() # returns pixel
         config["BeamCenterX"] = beam_centre_x  # unit, should be pixel for master file
         config["BeamCenterY"] = beam_centre_y
-        config["DetectorDistance"] = HWR.beamline.resolution.detector_distance.getPosition() / 1000.0
+        config["DetectorDistance"] = HWR.beamline.detector.detector_distance.getPosition() / 1000.0
 
         config["CountTime"] = oscillation_parameters["exposure_time"]
 

--- a/HardwareObjects/MAXIV/BIOMAXCollect.py
+++ b/HardwareObjects/MAXIV/BIOMAXCollect.py
@@ -153,7 +153,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         """
         logging.getLogger("HWR").info("[COLLECT] Moving to center position")
         shape_id = self.get_current_shape_id()
-        shape = HWR.beamline.graphics.get_shape(shape_id).as_dict()
+        shape = HWR.beamline.microscope.shapes.get_shape(shape_id).as_dict()
 
         x = shape.get("screen_coord")[0]
         y = shape.get("screen_coord")[1]
@@ -550,7 +550,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
                 % self.get_mesh_total_nb_frames()
             )
             shape_id = self.get_current_shape_id()
-            shape = HWR.beamline.graphics.get_shape(shape_id).as_dict()
+            shape = HWR.beamline.microscope.shapes.get_shape(shape_id).as_dict()
             range_x = shape.get("num_cols") * shape.get("cell_width") / 1000.0
             range_y = shape.get("num_rows") * shape.get("cell_height") / 1000.0
             HWR.beamline.diffractometer.raster_scan(
@@ -574,7 +574,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         ]
         if self.current_dc_parameters.get("experiment_type") == "Mesh":
             shape_id = self.get_current_shape_id()
-            shape = HWR.beamline.graphics.get_shape(shape_id).as_dict()
+            shape = HWR.beamline.microscope.shapes.get_shape(shape_id).as_dict()
             num_cols = shape.get("num_cols")
             num_rows = shape.get("num_rows")
             num_images = num_cols * num_rows
@@ -1074,7 +1074,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         Descript. :
         """
         # take image from server
-        HWR.beamline.graphics.camera.takeSnapshot(filename)
+        HWR.beamline.microscope.take_snapshot(filename)
 
     def set_detector_roi(self, value):
         """
@@ -1191,7 +1191,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         lower_limit, upper_limit = self.get_detector_distance_limits()
         logging.getLogger("HWR").info(
             "...................value %s, detector movement start..... %s"
-            % (value, HWR.beamline.detector.detector_distance.getPosition())
+            % (value, HWR.beamline.resolution.detector_distance.getPosition())
         )
         if upper_limit is not None and lower_limit is not None:
             if value >= upper_limit or value <= lower_limit:
@@ -1201,8 +1201,8 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
                 self.stop_collect()
             else:
                 try:
-                    if HWR.beamline.detector.detector_distance is not None:
-                        HWR.beamline.detector.detector_distance.syncMove(
+                    if HWR.beamline.resolution.detector_distance is not None:
+                        HWR.beamline.resolution.detector_distance.syncMove(
                             value, timeout=50
                         )  # 30s is not enough for the whole range
                 except BaseException:
@@ -1216,22 +1216,22 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
             )
         logging.getLogger("HWR").info(
             "....................value %s detector movement finished.....%s"
-            % (value, HWR.beamline.detector.detector_distance.getPosition())
+            % (value, HWR.beamline.resolution.detector_distance.getPosition())
         )
 
     def get_detector_distance(self):
         """
         Descript. :
         """
-        if HWR.beamline.detector.detector_distance is not None:
-            return HWR.beamline.detector.detector_distance.getPosition()
+        if HWR.beamline.resolution.detector_distance is not None:
+            return HWR.beamline.resolution.detector_distance.getPosition()
 
     def get_detector_distance_limits(self):
         """
         Descript. :
         """
-        if HWR.beamline.detector.detector_distance is not None:
-            return HWR.beamline.detector.detector_distance.getLimits()
+        if HWR.beamline.resolution.detector_distance is not None:
+            return HWR.beamline.resolution.detector_distance.getLimits()
 
     def prepare_detector(self):
 
@@ -1259,7 +1259,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         )  # self.get_beam_centre_pixel() # returns pixel
         config["BeamCenterX"] = beam_centre_x  # unit, should be pixel for master file
         config["BeamCenterY"] = beam_centre_y
-        config["DetectorDistance"] = HWR.beamline.detector.detector_distance.getPosition() / 1000.0
+        config["DetectorDistance"] = HWR.beamline.resolution.detector_distance.getPosition() / 1000.0
 
         config["CountTime"] = oscillation_parameters["exposure_time"]
 

--- a/HardwareObjects/MAXIV/BIOMAXCollect.py
+++ b/HardwareObjects/MAXIV/BIOMAXCollect.py
@@ -1191,7 +1191,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         lower_limit, upper_limit = self.get_detector_distance_limits()
         logging.getLogger("HWR").info(
             "...................value %s, detector movement start..... %s"
-            % (value, HWR.beamline.detector.detector_distance.getPosition())
+            % (value, HWR.beamline.detector.distance.getPosition())
         )
         if upper_limit is not None and lower_limit is not None:
             if value >= upper_limit or value <= lower_limit:
@@ -1201,8 +1201,8 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
                 self.stop_collect()
             else:
                 try:
-                    if HWR.beamline.detector.detector_distance is not None:
-                        HWR.beamline.detector.detector_distance.syncMove(
+                    if HWR.beamline.detector.distance is not None:
+                        HWR.beamline.detector.distance.syncMove(
                             value, timeout=50
                         )  # 30s is not enough for the whole range
                 except BaseException:
@@ -1216,22 +1216,22 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
             )
         logging.getLogger("HWR").info(
             "....................value %s detector movement finished.....%s"
-            % (value, HWR.beamline.detector.detector_distance.getPosition())
+            % (value, HWR.beamline.detector.distance.getPosition())
         )
 
     def get_detector_distance(self):
         """
         Descript. :
         """
-        if HWR.beamline.detector.detector_distance is not None:
-            return HWR.beamline.detector.detector_distance.getPosition()
+        if HWR.beamline.detector.distance is not None:
+            return HWR.beamline.detector.distance.getPosition()
 
     def get_detector_distance_limits(self):
         """
         Descript. :
         """
-        if HWR.beamline.detector.detector_distance is not None:
-            return HWR.beamline.detector.detector_distance.getLimits()
+        if HWR.beamline.detector.distance is not None:
+            return HWR.beamline.detector.distance.getLimits()
 
     def prepare_detector(self):
 
@@ -1259,7 +1259,7 @@ class BIOMAXCollect(AbstractCollect, HardwareObject):
         )  # self.get_beam_centre_pixel() # returns pixel
         config["BeamCenterX"] = beam_centre_x  # unit, should be pixel for master file
         config["BeamCenterY"] = beam_centre_y
-        config["DetectorDistance"] = HWR.beamline.detector.detector_distance.getPosition() / 1000.0
+        config["DetectorDistance"] = HWR.beamline.detector.distance.getPosition() / 1000.0
 
         config["CountTime"] = oscillation_parameters["exposure_time"]
 

--- a/HardwareObjects/MAXIV/BIOMAXMD3.py
+++ b/HardwareObjects/MAXIV/BIOMAXMD3.py
@@ -62,8 +62,8 @@ class BIOMAXMD3(GenericDiffractometer):
         # to make it comaptible
         self.acceptCentring = self.accept_centring
         self.startCentringMethod = self.start_centring_method
-        # self.image_width = HWR.beamline.graphics.camera.getWidth()
-        # self.image_height = HWR.beamline.graphics.camera.getHeight()
+        # self.image_width = HWR.beamline.microscope.camera.getWidth()
+        # self.image_height = HWR.beamline.microscope.camera.getHeight()
 
         self.phi_motor_hwobj = self.motor_hwobj_dict["phi"]
         self.phiz_motor_hwobj = self.motor_hwobj_dict["phiz"]
@@ -104,7 +104,7 @@ class BIOMAXMD3(GenericDiffractometer):
 
         try:
             self.zoom_centre = eval(self.getProperty("zoom_centre"))
-            zoom = HWR.beamline.graphics.camera.get_image_zoom()
+            zoom = HWR.beamline.microscope.camera.get_image_zoom()
             if zoom is not None:
                 self.zoom_centre["x"] = self.zoom_centre["x"] * zoom
                 self.zoom_centre["y"] = self.zoom_centre["y"] * zoom
@@ -137,7 +137,7 @@ class BIOMAXMD3(GenericDiffractometer):
 
         :returns: list with two floats
         """
-        zoom = HWR.beamline.graphics.camera.get_image_zoom()
+        zoom = HWR.beamline.microscope.camera.get_image_zoom()
         # return (0.5/self.channel_dict["CoaxCamScaleX"].getValue(),
         # 0.5/self.channel_dict["CoaxCamScaleY"].getValue())
         return (
@@ -150,7 +150,7 @@ class BIOMAXMD3(GenericDiffractometer):
         """
         # self.pixels_per_mm_x = 0.5/self.channel_dict["CoaxCamScaleX"].getValue()
         # self.pixels_per_mm_y = 0.5/self.channel_dict["CoaxCamScaleY"].getValue()
-        zoom = HWR.beamline.graphics.camera.get_image_zoom()
+        zoom = HWR.beamline.microscope.camera.get_image_zoom()
         self.pixels_per_mm_x = zoom / self.channel_dict["CoaxCamScaleX"].getValue()
         self.pixels_per_mm_y = zoom / self.channel_dict["CoaxCamScaleY"].getValue()
 
@@ -238,7 +238,7 @@ class BIOMAXMD3(GenericDiffractometer):
                         if -1 in (x, y):
                             continue
                         if y >= 0:
-                            if x < HWR.beamline.graphics.camera.getWidth() / 2:
+                            if x < HWR.beamline.microscope.camera.getWidth() / 2:
                                 x = 0
                                 self.centring_hwobj.appendCentringDataPoint(
                                     {
@@ -250,7 +250,7 @@ class BIOMAXMD3(GenericDiffractometer):
                                 )
                                 break
                             else:
-                                x = HWR.beamline.graphics.camera.getWidth()
+                                x = HWR.beamline.microscope.camera.getWidth()
                                 self.centring_hwobj.appendCentringDataPoint(
                                     {
                                         "X": (x - self.beam_position[0])
@@ -285,7 +285,7 @@ class BIOMAXMD3(GenericDiffractometer):
         """
         Description:
         """
-        imgStr = HWR.beamline.graphics.camera.get_snapshot_img_str()
+        imgStr = HWR.beamline.microscope.camera.get_snapshot_img_str()
         image = Image.open(io.BytesIO(imgStr))
         try:
             img = np.array(image)
@@ -293,7 +293,7 @@ class BIOMAXMD3(GenericDiffractometer):
             info, y, x = lucid.find_loop(
                 np.array(img_rot, order="C"), IterationClosing=6
             )
-            x = HWR.beamline.graphics.camera.getWidth() - x
+            x = HWR.beamline.microscope.camera.getWidth() - x
         except BaseException:
             return -1, -1, 0
         if info == "Coord":

--- a/HardwareObjects/MAXIV/BIOMAXPatches.py
+++ b/HardwareObjects/MAXIV/BIOMAXPatches.py
@@ -30,10 +30,10 @@ class BIOMAXPatches(HardwareObject):
                     "Cannot load sample, sample changer cannot go to SOAK position: %s"
                     % str(ex)
                 )
-        self.curr_dtox_pos = HWR.beamline.resolution.detector_distance.getPosition()
+        self.curr_dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
         if (
-            HWR.beamline.resolution.detector_distance is not None
-            and HWR.beamline.resolution.detector_distance.getPosition() < self.safe_position
+            HWR.beamline.detector.detector_distance is not None
+            and HWR.beamline.detector.detector_distance.getPosition() < self.safe_position
         ):
             logging.getLogger("HWR").info(
                 "Moving detector to safe position before loading a sample."
@@ -42,9 +42,9 @@ class BIOMAXPatches(HardwareObject):
                 "Moving detector to safe position before loading a sample."
             )
 
-        self.wait_motor_ready(HWR.beamline.resolution.detector_distance)
+        self.wait_motor_ready(HWR.beamline.detector.detector_distance)
         try:
-            HWR.beamline.resolution.detector_distance.syncMove(self.safe_position, timeout=30)
+            HWR.beamline.detector.detector_distance.syncMove(self.safe_position, timeout=30)
         except Exception:
             logging.getLogger("HWR").warning("Cannot move detector")
         else:
@@ -105,7 +105,7 @@ class BIOMAXPatches(HardwareObject):
                 raise RuntimeError(
                     "Not moving detector to pre-mount position, sample changer not powered"
                 )
-            HWR.beamline.resolution.detector_distance.syncMove(self.curr_dtox_pos, timeout=30)
+            HWR.beamline.detector.detector_distance.syncMove(self.curr_dtox_pos, timeout=30)
         except Exception:
             logging.getLogger("HWR").warning("Cannot move detector")
 

--- a/HardwareObjects/MAXIV/BIOMAXPatches.py
+++ b/HardwareObjects/MAXIV/BIOMAXPatches.py
@@ -30,10 +30,10 @@ class BIOMAXPatches(HardwareObject):
                     "Cannot load sample, sample changer cannot go to SOAK position: %s"
                     % str(ex)
                 )
-        self.curr_dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
+        self.curr_dtox_pos = HWR.beamline.detector.distance.getPosition()
         if (
-            HWR.beamline.detector.detector_distance is not None
-            and HWR.beamline.detector.detector_distance.getPosition() < self.safe_position
+            HWR.beamline.detector.distance is not None
+            and HWR.beamline.detector.distance.getPosition() < self.safe_position
         ):
             logging.getLogger("HWR").info(
                 "Moving detector to safe position before loading a sample."
@@ -42,9 +42,9 @@ class BIOMAXPatches(HardwareObject):
                 "Moving detector to safe position before loading a sample."
             )
 
-        self.wait_motor_ready(HWR.beamline.detector.detector_distance)
+        self.wait_motor_ready(HWR.beamline.detector.distance)
         try:
-            HWR.beamline.detector.detector_distance.syncMove(self.safe_position, timeout=30)
+            HWR.beamline.detector.distance.syncMove(self.safe_position, timeout=30)
         except Exception:
             logging.getLogger("HWR").warning("Cannot move detector")
         else:
@@ -105,7 +105,7 @@ class BIOMAXPatches(HardwareObject):
                 raise RuntimeError(
                     "Not moving detector to pre-mount position, sample changer not powered"
                 )
-            HWR.beamline.detector.detector_distance.syncMove(self.curr_dtox_pos, timeout=30)
+            HWR.beamline.detector.distance.syncMove(self.curr_dtox_pos, timeout=30)
         except Exception:
             logging.getLogger("HWR").warning("Cannot move detector")
 

--- a/HardwareObjects/MAXIV/BIOMAXPatches.py
+++ b/HardwareObjects/MAXIV/BIOMAXPatches.py
@@ -30,10 +30,10 @@ class BIOMAXPatches(HardwareObject):
                     "Cannot load sample, sample changer cannot go to SOAK position: %s"
                     % str(ex)
                 )
-        self.curr_dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
+        self.curr_dtox_pos = HWR.beamline.resolution.detector_distance.getPosition()
         if (
-            HWR.beamline.detector.detector_distance is not None
-            and HWR.beamline.detector.detector_distance.getPosition() < self.safe_position
+            HWR.beamline.resolution.detector_distance is not None
+            and HWR.beamline.resolution.detector_distance.getPosition() < self.safe_position
         ):
             logging.getLogger("HWR").info(
                 "Moving detector to safe position before loading a sample."
@@ -42,9 +42,9 @@ class BIOMAXPatches(HardwareObject):
                 "Moving detector to safe position before loading a sample."
             )
 
-        self.wait_motor_ready(HWR.beamline.detector.detector_distance)
+        self.wait_motor_ready(HWR.beamline.resolution.detector_distance)
         try:
-            HWR.beamline.detector.detector_distance.syncMove(self.safe_position, timeout=30)
+            HWR.beamline.resolution.detector_distance.syncMove(self.safe_position, timeout=30)
         except Exception:
             logging.getLogger("HWR").warning("Cannot move detector")
         else:
@@ -105,7 +105,7 @@ class BIOMAXPatches(HardwareObject):
                 raise RuntimeError(
                     "Not moving detector to pre-mount position, sample changer not powered"
                 )
-            HWR.beamline.detector.detector_distance.syncMove(self.curr_dtox_pos, timeout=30)
+            HWR.beamline.resolution.detector_distance.syncMove(self.curr_dtox_pos, timeout=30)
         except Exception:
             logging.getLogger("HWR").warning("Cannot move detector")
 

--- a/HardwareObjects/MAXIV/BIOMAXResolution.py
+++ b/HardwareObjects/MAXIV/BIOMAXResolution.py
@@ -48,7 +48,7 @@ class BIOMAXResolution(Resolution.Resolution):
 
     def dist2res(self, dist=None):
         if dist is None:
-            dist = HWR.beamline.detector.detector_distance.getPosition()
+            dist = HWR.beamline.resolution.detector_distance.getPosition()
 
         return "%.3f" % self._calc_res(self.det_radius, dist)
 
@@ -56,7 +56,7 @@ class BIOMAXResolution(Resolution.Resolution):
         self.det_width = HWR.beamline.detector.get_x_pixels_in_detector()
         self.det_height = HWR.beamline.detector.get_y_pixels_in_detector()
         self.update_beam_centre(
-            HWR.beamline.detector.detector_distance.getPosition()
+            HWR.beamline.resolution.detector_distance.getPosition()
         )
         self.recalculateResolution()
 

--- a/HardwareObjects/MAXIV/BIOMAXResolution.py
+++ b/HardwareObjects/MAXIV/BIOMAXResolution.py
@@ -48,7 +48,7 @@ class BIOMAXResolution(Resolution.Resolution):
 
     def dist2res(self, dist=None):
         if dist is None:
-            dist = HWR.beamline.resolution.detector_distance.getPosition()
+            dist = HWR.beamline.detector.detector_distance.getPosition()
 
         return "%.3f" % self._calc_res(self.det_radius, dist)
 
@@ -56,7 +56,7 @@ class BIOMAXResolution(Resolution.Resolution):
         self.det_width = HWR.beamline.detector.get_x_pixels_in_detector()
         self.det_height = HWR.beamline.detector.get_y_pixels_in_detector()
         self.update_beam_centre(
-            HWR.beamline.resolution.detector_distance.getPosition()
+            HWR.beamline.detector.detector_distance.getPosition()
         )
         self.recalculateResolution()
 

--- a/HardwareObjects/MAXIV/BIOMAXResolution.py
+++ b/HardwareObjects/MAXIV/BIOMAXResolution.py
@@ -25,10 +25,10 @@ class BIOMAXResolution(Resolution.Resolution):
                 self.valid = False
                 logging.getLogger().exception("Cannot get detector size")
 
-        self.update_beam_centre(detector.detector_distance.getPosition())
-        self.connect(detector.detector_distance, "stateChanged", self.dtoxStateChanged)
+        self.update_beam_centre(detector.distance.getPosition())
+        self.connect(detector.distance, "stateChanged", self.dtoxStateChanged)
         self.connect(
-            detector.detector_distance, "positionChanged", self.dtoxPositionChanged
+            detector.distance, "positionChanged", self.dtoxPositionChanged
         )
         self.connect(HWR.beamline.energy, "valueChanged", self.energyChanged)
         self.connect(detector, "roiChanged", self.det_roi_changed)
@@ -48,7 +48,7 @@ class BIOMAXResolution(Resolution.Resolution):
 
     def dist2res(self, dist=None):
         if dist is None:
-            dist = HWR.beamline.detector.detector_distance.getPosition()
+            dist = HWR.beamline.detector.distance.getPosition()
 
         return "%.3f" % self._calc_res(self.det_radius, dist)
 
@@ -56,7 +56,7 @@ class BIOMAXResolution(Resolution.Resolution):
         self.det_width = HWR.beamline.detector.get_x_pixels_in_detector()
         self.det_height = HWR.beamline.detector.get_y_pixels_in_detector()
         self.update_beam_centre(
-            HWR.beamline.detector.detector_distance.getPosition()
+            HWR.beamline.detector.distance.getPosition()
         )
         self.recalculateResolution()
 

--- a/HardwareObjects/Microscope.py
+++ b/HardwareObjects/Microscope.py
@@ -1,0 +1,17 @@
+from HardwareRepository.BaseHardwareObjects import HardwareObject
+from HardwareRepository.HardwareObjects.abstract.AbstractMicroscope import (
+    AbstractMicroscope,
+)
+
+class Microscope(AbstractMicroscope, HardwareObject):
+    def __init__(self, name):
+        AbstractMicroscope.__init__(self)
+        HardwareObject.__init__(self, name)
+
+    def init(self):
+        self.camera_hwobj = self.getObjectByRole("camera")
+        self.shapes_hwobj = self.getObjectByRole("shapes")
+        self.focus_hwobj = self.getObjectByRole("focus")
+        self.zoom_hwobj = self.getObjectByRole("zoom")
+        self.frontlight_hwobj = self.getObjectByRole("frontlight")
+        self.backlight_hwobj = self.getObjectByRole("backlight")

--- a/HardwareObjects/Microscope.py
+++ b/HardwareObjects/Microscope.py
@@ -9,9 +9,9 @@ class Microscope(AbstractMicroscope, HardwareObject):
         HardwareObject.__init__(self, name)
 
     def init(self):
-        self.camera_hwobj = self.getObjectByRole("camera")
-        self.shapes_hwobj = self.getObjectByRole("shapes")
-        self.focus_hwobj = self.getObjectByRole("focus")
-        self.zoom_hwobj = self.getObjectByRole("zoom")
-        self.frontlight_hwobj = self.getObjectByRole("frontlight")
-        self.backlight_hwobj = self.getObjectByRole("backlight")
+        self._camera = self.getObjectByRole("camera")
+        self._shapes = self.getObjectByRole("shapes")
+        self._focus = self.getObjectByRole("focus")
+        self._zoom = self.getObjectByRole("zoom")
+        self._frontlight = self.getObjectByRole("frontlight")
+        self._backlight = self.getObjectByRole("backlight")

--- a/HardwareObjects/MiniDiff.py
+++ b/HardwareObjects/MiniDiff.py
@@ -651,7 +651,7 @@ class MiniDiff(Equipment):
         self.accept_centring()
 
     def start_manual_centring(self, sample_info=None):
-	beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position()
+        beam_pos_x, beam_pos_y = HWR.beamline.beam.get_beam_position()
         self.current_centring_procedure = sample_centring.start(
             {
                 "phi": self.centringPhi,
@@ -813,7 +813,7 @@ class MiniDiff(Equipment):
                     self.accept_centring()
 
     def start_auto_centring(self, sample_info=None, loop_only=False):
-	beam_pos_x,  beam_pos_y = HWR.beamline.beam.get_beam_position()
+        beam_pos_x,  beam_pos_y = HWR.beamline.beam.get_beam_position()
 
         self.current_centring_procedure = sample_centring.start_auto(
             self.camera,

--- a/HardwareObjects/MiniDiff.py
+++ b/HardwareObjects/MiniDiff.py
@@ -166,7 +166,7 @@ class MiniDiff(Equipment):
 
 
         # mh 2013-11-05:why is the channel read directly? disabled for the moment
-        # HWR.beamline.graphics.camera.addChannel({ 'type': 'tango', 'name': 'jpegImage' }, "JpegImage")
+        # HWR.beamline.microscope.camera.addChannel({ 'type': 'tango', 'name': 'jpegImage' }, "JpegImage")
 
         self.centringPhi = sample_centring.CentringMotor(self.phiMotor, direction=-1)
         self.centringPhiz = sample_centring.CentringMotor(
@@ -258,15 +258,15 @@ class MiniDiff(Equipment):
                 "MiniDiff: sampx motor is not defined in minidiff equipment %s",
                 str(self.name()),
             )
-        # if HWR.beamline.graphics.camera is None:
+        # if HWR.beamline.microscope.camera is None:
         #     logging.getLogger("HWR").error(
         #         "MiniDiff: camera is not defined in minidiff equipment %s",
         #         str(self.name()),
         #     )
         # else:
         #     self.imgWidth, self.imgHeight = (
-        #         HWR.beamline.graphics.camera.getWidth(),
-        #         HWR.beamline.graphics.camera.getHeight(),
+        #         HWR.beamline.microscope.camera.getWidth(),
+        #         HWR.beamline.microscope.camera.getHeight(),
         #     )
         if HWR.beamline.sample_changer is None:
             logging.getLogger("HWR").warning(
@@ -423,7 +423,7 @@ class MiniDiff(Equipment):
             and self.phiMotor is not None
             and self.phizMotor is not None
             and self.phiyMotor is not None
-            and HWR.beamline.graphics.camera is not None
+            and HWR.beamline.microscope.camera is not None
         )
 
     def in_plate_mode(self):
@@ -946,7 +946,7 @@ class MiniDiff(Equipment):
             time.sleep(0.1)
 
     def takeSnapshots(self, image_count, wait=False):
-        HWR.beamline.graphics.camera.forceUpdate = True
+        HWR.beamline.microscope.camera.forceUpdate = True
 
         snapshotsProcedure = gevent.spawn(
             take_snapshots,
@@ -966,7 +966,7 @@ class MiniDiff(Equipment):
             self.centringStatus["images"] = snapshotsProcedure.get()
 
     def snapshotsDone(self, snapshotsProcedure):
-        HWR.beamline.graphics.camera.forceUpdate = False
+        HWR.beamline.microscope.camera.forceUpdate = False
 
         try:
             self.centringStatus["images"] = snapshotsProcedure.get()

--- a/HardwareObjects/Pilatus.py
+++ b/HardwareObjects/Pilatus.py
@@ -1,12 +1,16 @@
-from HardwareRepository.BaseHardwareObjects import Device
+from HardwareRepository.BaseHardwareObjects import HardwareObject
+from HardwareRepository.HardwareObjects.abstract.AbstractDetector import (
+    AbstractDetector,
+)
 
-
-class Pilatus(Device):
+class Pilatus(HardwareObject, AbstractDetector):
     def __init__(self, name):
-        Device.__init__(self, name)
+        AbstractDetector.__init__(self)
+        HardwareObject.__init__(self, name)
+
 
     def init(self):
-        pass
+        self.distance_motor_hwobj = self.getObjectByRole("detector_distance")
 
     def has_shutterless(self):
         return True

--- a/HardwareObjects/Q315dist.py
+++ b/HardwareObjects/Q315dist.py
@@ -14,7 +14,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
 
         self.connect(self.detm, "stateChanged", self.detmStateChanged)
         self.connect(
-            HWR.beamline.detector.detector_distance,
+            HWR.beamline.resolution.detector_distance,
             "limitsChanged",
             self.dtoxLimitsChanged
         )
@@ -40,7 +40,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
                 return getattr(self.detm, attr)
             else:
                 # logging.getLogger().info("calling dtox %s", attr)
-                return getattr(HWR.beamline.detector.detector_distance, attr)
+                return getattr(HWR.beamline.resolution.detector_distance, attr)
         else:
             raise AttributeError(attr)
 

--- a/HardwareObjects/Q315dist.py
+++ b/HardwareObjects/Q315dist.py
@@ -14,7 +14,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
 
         self.connect(self.detm, "stateChanged", self.detmStateChanged)
         self.connect(
-            HWR.beamline.detector.detector_distance,
+            HWR.beamline.detector.distance,
             "limitsChanged",
             self.dtoxLimitsChanged
         )
@@ -40,7 +40,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
                 return getattr(self.detm, attr)
             else:
                 # logging.getLogger().info("calling dtox %s", attr)
-                return getattr(HWR.beamline.detector.detector_distance, attr)
+                return getattr(HWR.beamline.detector.distance, attr)
         else:
             raise AttributeError(attr)
 

--- a/HardwareObjects/Q315dist.py
+++ b/HardwareObjects/Q315dist.py
@@ -14,7 +14,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
 
         self.connect(self.detm, "stateChanged", self.detmStateChanged)
         self.connect(
-            HWR.beamline.resolution.detector_distance,
+            HWR.beamline.detector.detector_distance,
             "limitsChanged",
             self.dtoxLimitsChanged
         )
@@ -40,7 +40,7 @@ class Q315dist(BaseHardwareObjects.Equipment):
                 return getattr(self.detm, attr)
             else:
                 # logging.getLogger().info("calling dtox %s", attr)
-                return getattr(HWR.beamline.resolution.detector_distance, attr)
+                return getattr(HWR.beamline.detector.detector_distance, attr)
         else:
             raise AttributeError(attr)
 

--- a/HardwareObjects/RedisClient.py
+++ b/HardwareObjects/RedisClient.py
@@ -133,7 +133,7 @@ class RedisClient(HardwareObject):
                 HWR.beamline.queue_model.select_model(selected_model)
                 HWR.beamline.queue_model.load_queue_from_json_list(
                     eval(serialized_queue),
-                    snapshot=HWR.beamline.graphics.get_scene_snapshot(),
+                    snapshot=HWR.beamline.microscope.get_scene_snapshot(),
                 )
 
             self.active = True
@@ -147,7 +147,7 @@ class RedisClient(HardwareObject):
                 "RedisClient: Graphics saved at "
                 + "mxcube:%s:%s:graphics" % (self.proposal_id, self.beamline_name)
             )
-            graphic_objects = HWR.beamline.graphics.dump_shapes()
+            graphic_objects = HWR.beamline.microscope.dump_shapes()
             self.redis_client.set(
                 "mxcube:%s:%s:graphics" % (self.proposal_id, self.beamline_name),
                 jsonpickle.encode(graphic_objects),
@@ -160,7 +160,7 @@ class RedisClient(HardwareObject):
                 graphics_objects = self.redis_client.get(
                     "mxcube:%s:%s:graphics" % (self.proposal_id, self.beamline_name)
                 )
-                HWR.beamline.graphics.load_shapes(
+                HWR.beamline.microscope.load_shapes(
                     jsonpickle.decode(graphics_objects)
                 )
                 logging.getLogger("HWR").debug("RedisClient: Graphics loaded")

--- a/HardwareObjects/Resolution.py
+++ b/HardwareObjects/Resolution.py
@@ -151,7 +151,7 @@ class Resolution(AbstractMotor):
 
     def connectNotify(self, signal):
         if signal == "stateChanged":
-            self.dtoxStateChanged( HWR.beamline.detector.detector_distance.getState())
+            self.dtoxStateChanged(HWR.beamline.detector.detector_distance.getState())
 
     def dtoxStateChanged(self, state):
         self.emit("stateChanged", (state,))
@@ -175,7 +175,7 @@ class Resolution(AbstractMotor):
         if wait:
             HWR.beamline.detector.detector_distance.syncMove(self.res2dist(pos))
         else:
-             HWR.beamline.detector.detector_distance.move(self.res2dist(pos))
+            HWR.beamline.detector.detector_distance.move(self.res2dist(pos))
 
     def motorIsMoving(self):
         return HWR.beamline.detector.detector_distance.motorIsMoving()

--- a/HardwareObjects/Resolution.py
+++ b/HardwareObjects/Resolution.py
@@ -26,12 +26,12 @@ class Resolution(AbstractMotor):
             raise AttributeError("Cannot get detector properties")
 
         self.connect(
-            HWR.beamline.detector.detector_distance,
+            HWR.beamline.detector.distance,
             "stateChanged",
             self.dtoxStateChanged
         )
         self.connect(
-            HWR.beamline.detector.detector_distance,
+            HWR.beamline.detector.distance,
             "positionChanged",
             self.dtoxPositionChanged
         )
@@ -40,14 +40,14 @@ class Resolution(AbstractMotor):
     def isReady(self):
         if self.valid:
             try:
-                return HWR.beamline.detector.detector_distance.isReady()
+                return HWR.beamline.detector.distance.isReady()
             except BaseException:
                 return False
         return False
 
     def get_beam_centre(self, dist=None):
         if dist is None:
-            dist = HWR.beamline.detector.detector_distance.getPosition()
+            dist = HWR.beamline.detector.distance.getPosition()
         ax = float(HWR.beamline.detector["beam"].getProperty("ax"))
         bx = float(HWR.beamline.detector["beam"].getProperty("bx"))
         ay = float(HWR.beamline.detector["beam"].getProperty("ay"))
@@ -112,12 +112,12 @@ class Resolution(AbstractMotor):
 
     def dist2res(self, dist=None):
         if dist is None:
-            dist = HWR.beamline.detector.detector_distance.getPosition()
+            dist = HWR.beamline.detector.distance.getPosition()
 
         return self._calc_res(self.det_radius, dist)
 
     def recalculateResolution(self):
-        dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
+        dtox_pos = HWR.beamline.detector.distance.getPosition()
         self.update_beam_centre(dtox_pos)
         new_res = self.dist2res(dtox_pos)
         if new_res is None:
@@ -130,7 +130,7 @@ class Resolution(AbstractMotor):
         return self.currentResolution
 
     def get_value_at_corner(self):
-        dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
+        dtox_pos = HWR.beamline.detector.distance.getPosition()
         beam_x, beam_y = self.get_beam_centre(dtox_pos)
 
         distance_at_corners = [
@@ -147,15 +147,15 @@ class Resolution(AbstractMotor):
         self.emit("valueChanged", (res,))
 
     def getState(self):
-        return HWR.beamline.detector.detector_distance.getState()
+        return HWR.beamline.detector.distance.getState()
 
     def connectNotify(self, signal):
         if signal == "stateChanged":
-            self.dtoxStateChanged(HWR.beamline.detector.detector_distance.getState())
+            self.dtoxStateChanged(HWR.beamline.detector.distance.getState())
 
     def dtoxStateChanged(self, state):
         self.emit("stateChanged", (state,))
-        if state == HWR.beamline.detector.detector_distance.READY:
+        if state == HWR.beamline.detector.distance.READY:
             self.recalculateResolution()
 
     def dtoxPositionChanged(self, pos):
@@ -163,7 +163,7 @@ class Resolution(AbstractMotor):
         self.update_resolution(self.dist2res(pos))
 
     def getLimits(self):
-        low, high = HWR.beamline.detector.detector_distance.getLimits()
+        low, high = HWR.beamline.detector.distance.getLimits()
 
         return (self.dist2res(low), self.dist2res(high))
 
@@ -173,15 +173,15 @@ class Resolution(AbstractMotor):
         )
 
         if wait:
-            HWR.beamline.detector.detector_distance.syncMove(self.res2dist(pos))
+            HWR.beamline.detector.distance.syncMove(self.res2dist(pos))
         else:
-            HWR.beamline.detector.detector_distance.move(self.res2dist(pos))
+            HWR.beamline.detector.distance.move(self.res2dist(pos))
 
     def motorIsMoving(self):
-        return HWR.beamline.detector.detector_distance.motorIsMoving()
+        return HWR.beamline.detector.distance.motorIsMoving()
 
     def stop(self):
         try:
-            HWR.beamline.detector.detector_distance.stop()
+            HWR.beamline.detector.distance.stop()
         except BaseException:
             pass

--- a/HardwareObjects/Resolution.py
+++ b/HardwareObjects/Resolution.py
@@ -12,12 +12,10 @@ class Resolution(AbstractMotor):
         self.valid = True
         self.det_width = None
         self.det_height = None
-        self.detector_distance = None
 
     def init(self):
         self.currentResolution = None
         detector = HWR.beamline.detector
-        self.detector_distance = self.getObjectByRole("detector_distance")
 
         if detector:
             self.det_width = float(detector.getProperty("width"))
@@ -28,12 +26,12 @@ class Resolution(AbstractMotor):
             raise AttributeError("Cannot get detector properties")
 
         self.connect(
-            self.detector_distance,
+            HWR.beamline.detector.detector_distance,
             "stateChanged",
             self.dtoxStateChanged
         )
         self.connect(
-            self.detector_distance,
+            HWR.beamline.detector.detector_distance,
             "positionChanged",
             self.dtoxPositionChanged
         )
@@ -42,14 +40,14 @@ class Resolution(AbstractMotor):
     def isReady(self):
         if self.valid:
             try:
-                return self.detector_distance.isReady()
+                return HWR.beamline.detector.detector_distance.isReady()
             except BaseException:
                 return False
         return False
 
     def get_beam_centre(self, dist=None):
         if dist is None:
-            dist = self.detector_distance.getPosition()
+            dist = HWR.beamline.detector.detector_distance.getPosition()
         ax = float(HWR.beamline.detector["beam"].getProperty("ax"))
         bx = float(HWR.beamline.detector["beam"].getProperty("bx"))
         ay = float(HWR.beamline.detector["beam"].getProperty("ay"))
@@ -114,12 +112,12 @@ class Resolution(AbstractMotor):
 
     def dist2res(self, dist=None):
         if dist is None:
-            dist = self.detector_distance.getPosition()
+            dist = HWR.beamline.detector.detector_distance.getPosition()
 
         return self._calc_res(self.det_radius, dist)
 
     def recalculateResolution(self):
-        dtox_pos = self.detector_distance.getPosition()
+        dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
         self.update_beam_centre(dtox_pos)
         new_res = self.dist2res(dtox_pos)
         if new_res is None:
@@ -132,7 +130,7 @@ class Resolution(AbstractMotor):
         return self.currentResolution
 
     def get_value_at_corner(self):
-        dtox_pos = self.detector_distance.getPosition()
+        dtox_pos = HWR.beamline.detector.detector_distance.getPosition()
         beam_x, beam_y = self.get_beam_centre(dtox_pos)
 
         distance_at_corners = [
@@ -149,15 +147,15 @@ class Resolution(AbstractMotor):
         self.emit("valueChanged", (res,))
 
     def getState(self):
-        return self.detector_distance.getState()
+        return HWR.beamline.detector.detector_distance.getState()
 
     def connectNotify(self, signal):
         if signal == "stateChanged":
-            self.dtoxStateChanged(self.detector_distance.getState())
+            self.dtoxStateChanged( HWR.beamline.detector.detector_distance.getState())
 
     def dtoxStateChanged(self, state):
         self.emit("stateChanged", (state,))
-        if state == self.detector_distance.READY:
+        if state == HWR.beamline.detector.detector_distance.READY:
             self.recalculateResolution()
 
     def dtoxPositionChanged(self, pos):
@@ -165,7 +163,7 @@ class Resolution(AbstractMotor):
         self.update_resolution(self.dist2res(pos))
 
     def getLimits(self):
-        low, high = self.detector_distance.getLimits()
+        low, high = HWR.beamline.detector.detector_distance.getLimits()
 
         return (self.dist2res(low), self.dist2res(high))
 
@@ -175,15 +173,15 @@ class Resolution(AbstractMotor):
         )
 
         if wait:
-           self.detector_distance.syncMove(self.res2dist(pos))
+            HWR.beamline.detector.detector_distance.syncMove(self.res2dist(pos))
         else:
-            self.detector_distance.move(self.res2dist(pos))
+             HWR.beamline.detector.detector_distance.move(self.res2dist(pos))
 
     def motorIsMoving(self):
-        return self.detector_distance.motorIsMoving()
+        return HWR.beamline.detector.detector_distance.motorIsMoving()
 
     def stop(self):
         try:
-           self.detector_distance.stop()
+            HWR.beamline.detector.detector_distance.stop()
         except BaseException:
             pass

--- a/HardwareObjects/SOLEIL/PX1/PX1Collect.py
+++ b/HardwareObjects/SOLEIL/PX1/PX1Collect.py
@@ -432,7 +432,7 @@ class PX1Collect(AbstractCollect, HardwareObject):
         self.lightarm_hwobj.adjustLightLevel()
         time.sleep(0.3)  # allow time to refresh display after
 
-        HWR.beamline.graphics.save_scene_snapshot(filename)
+        HWR.beamline.microscope.save_scene_snapshot(filename)
         logging.getLogger("HWR").debug("PX1Collect:  - snapshot saved to %s" % filename)
 
     def generate_thumbnails(self, filename, jpeg_filename, thumbnail_filename):

--- a/HardwareObjects/SOLEIL/PX2/PX2Collect.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Collect.py
@@ -322,14 +322,14 @@ class PX2Collect(AbstractCollect, HardwareObject):
 
     @task
     def _take_crystal_snapshot(self, filename):
-        HWR.beamline.graphics.save_scene_snapshot(filename)
+        HWR.beamline.microscope.save_scene_snapshot(filename)
 
     @task
     def _take_crystal_animation(self, animation_filename, duration_sec):
         """Rotates sample by 360 and composes a gif file
            Animation is saved as the fourth snapshot
         """
-        HWR.beamline.graphics.save_scene_animation(
+        HWR.beamline.microscope.save_scene_animation(
             animation_filename, duration_sec
         )
 

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -410,7 +410,7 @@ class PX2Diffractometer(GenericDiffractometer):
             GenericDiffractometer.PHASE_TRANSFER,
             GenericDiffractometer.PHASE_BEAM,
         ):
-            detector_distance = HWR.beamline.detector.detector_distance.getPosition()
+            detector_distance = HWR.beamline.detector.distance.getPosition()
             logging.getLogger("HWR").debug(
                 "Diffractometer current phase: %s " % self.current_phase
                 + "selected phase: %s " % phase
@@ -418,7 +418,7 @@ class PX2Diffractometer(GenericDiffractometer):
             )
             if detector_distance < 350:
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                HWR.beamline.detector.detector_distance.move(350)
+                HWR.beamline.detector.distance.move(350)
                 self.detector.insert_protective_cover()
 
         if timeout is not None:

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -410,7 +410,7 @@ class PX2Diffractometer(GenericDiffractometer):
             GenericDiffractometer.PHASE_TRANSFER,
             GenericDiffractometer.PHASE_BEAM,
         ):
-            detector_distance = HWR.beamline.detector.detector_distance.getPosition()
+            detector_distance = HWR.beamline.resolution.detector_distance.getPosition()
             logging.getLogger("HWR").debug(
                 "Diffractometer current phase: %s " % self.current_phase
                 + "selected phase: %s " % phase
@@ -418,7 +418,7 @@ class PX2Diffractometer(GenericDiffractometer):
             )
             if detector_distance < 350:
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                HWR.beamline.detector.detector_distance.move(350)
+                HWR.beamline.resolution.detector_distance.move(350)
                 self.detector.insert_protective_cover()
 
         if timeout is not None:
@@ -637,7 +637,7 @@ class PX2Diffractometer(GenericDiffractometer):
         for k in range(n_clicks):
             self.user_clicked_event = gevent.event.AsyncResult()
             x, y = self.user_clicked_event.get()
-            image = HWR.beamline.graphics.camera.get_last_image()
+            image = HWR.beamline.microscope.camera.get_last_image()
             calibration = self.camera.get_calibration()
             omega = self.goniometer.get_omega_position()
 
@@ -1121,7 +1121,7 @@ class PX2Diffractometer(GenericDiffractometer):
         """
         Description:
         """
-        image_array = HWR.beamline.graphics.camera.get_snapshot(return_as_array=True)
+        image_array = HWR.beamline.microscope.get_snapshot(return_as_array=True)
         (info, x, y) = lucid.find_loop(image_array)
         surface_score = 10
         return x, y, surface_score

--- a/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Diffractometer.py
@@ -410,7 +410,7 @@ class PX2Diffractometer(GenericDiffractometer):
             GenericDiffractometer.PHASE_TRANSFER,
             GenericDiffractometer.PHASE_BEAM,
         ):
-            detector_distance = HWR.beamline.resolution.detector_distance.getPosition()
+            detector_distance = HWR.beamline.detector.detector_distance.getPosition()
             logging.getLogger("HWR").debug(
                 "Diffractometer current phase: %s " % self.current_phase
                 + "selected phase: %s " % phase
@@ -418,7 +418,7 @@ class PX2Diffractometer(GenericDiffractometer):
             )
             if detector_distance < 350:
                 logging.getLogger("GUI").info("Moving detector to safe distance")
-                HWR.beamline.resolution.detector_distance.move(350)
+                HWR.beamline.detector.detector_distance.move(350)
                 self.detector.insert_protective_cover()
 
         if timeout is not None:

--- a/HardwareObjects/SOLEIL/PX2/PX2Guillotine.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Guillotine.py
@@ -103,12 +103,12 @@ class PX2Guillotine(BaseHardwareObjects.Device):
             self.pss = self.getObjectByRole("pss")
 
             self.connect(
-                HWR.beamline.detector.detector_distance,
+                HWR.beamline.resolution.detector_distance,
                 "positionChanged",
                 self.shutterStateChanged
             )
             self.connect(
-                HWR.beamline.detector.detector_distance,
+                HWR.beamline.resolution.detector_distance,
                 "positionChanged",
                 self.updateDetectorDistance
             )
@@ -158,7 +158,7 @@ class PX2Guillotine(BaseHardwareObjects.Device):
         if state == "Transfer":
             self.goToSecurityDistance()
         if state == "Collect":
-            HWR.beamline.detector.detector_distance.move(180)
+            HWR.beamline.resolution.detector_distance.move(180)
 
     def updateGuillotine(self, value):
         # if open door close guillotine but test distance
@@ -182,15 +182,15 @@ class PX2Guillotine(BaseHardwareObjects.Device):
         )
         if self.isInsert():
             if not self.checkDistance():
-                HWR.beamline.detector.detector_distance.move(self._d_security)
+                HWR.beamline.resolution.detector_distance.move(self._d_security)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.resolution.detector_distance.motorIsMoving():
                     time.sleep(0.5)
                 self._Extract()
                 time.sleep(0.2)
-                HWR.beamline.detector.detector_distance.move(currentDistance)
+                HWR.beamline.resolution.detector_distance.move(currentDistance)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.resolution.detector_distance.motorIsMoving():
                     time.sleep(0.5)
             else:
                 self._Extract()
@@ -211,10 +211,10 @@ class PX2Guillotine(BaseHardwareObjects.Device):
 
     def goToSecurityDistance(self):
         if self._currentDistance < self._d_home:
-            HWR.beamline.detector.detector_distance.move(self._d_home)
+            HWR.beamline.resolution.detector_distance.move(self._d_home)
         if str(self.shutChannel.value) == "EXTRACT":
             self._Insert()
-        while HWR.beamline.detector.detector_distance.motorIsMoving():
+        while HWR.beamline.resolution.detector_distance.motorIsMoving():
             time.sleep(0.5)
 
     def isShutterOk(self):

--- a/HardwareObjects/SOLEIL/PX2/PX2Guillotine.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Guillotine.py
@@ -103,12 +103,12 @@ class PX2Guillotine(BaseHardwareObjects.Device):
             self.pss = self.getObjectByRole("pss")
 
             self.connect(
-                HWR.beamline.detector.detector_distance,
+                HWR.beamline.detector.distance,
                 "positionChanged",
                 self.shutterStateChanged
             )
             self.connect(
-                HWR.beamline.detector.detector_distance,
+                HWR.beamline.detector.distance,
                 "positionChanged",
                 self.updateDetectorDistance
             )
@@ -158,7 +158,7 @@ class PX2Guillotine(BaseHardwareObjects.Device):
         if state == "Transfer":
             self.goToSecurityDistance()
         if state == "Collect":
-            HWR.beamline.detector.detector_distance.move(180)
+            HWR.beamline.detector.distance.move(180)
 
     def updateGuillotine(self, value):
         # if open door close guillotine but test distance
@@ -182,15 +182,15 @@ class PX2Guillotine(BaseHardwareObjects.Device):
         )
         if self.isInsert():
             if not self.checkDistance():
-                HWR.beamline.detector.detector_distance.move(self._d_security)
+                HWR.beamline.detector.distance.move(self._d_security)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.distance.motorIsMoving():
                     time.sleep(0.5)
                 self._Extract()
                 time.sleep(0.2)
-                HWR.beamline.detector.detector_distance.move(currentDistance)
+                HWR.beamline.detector.distance.move(currentDistance)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.distance.motorIsMoving():
                     time.sleep(0.5)
             else:
                 self._Extract()
@@ -211,10 +211,10 @@ class PX2Guillotine(BaseHardwareObjects.Device):
 
     def goToSecurityDistance(self):
         if self._currentDistance < self._d_home:
-            HWR.beamline.detector.detector_distance.move(self._d_home)
+            HWR.beamline.detector.distance.move(self._d_home)
         if str(self.shutChannel.value) == "EXTRACT":
             self._Insert()
-        while HWR.beamline.detector.detector_distance.motorIsMoving():
+        while HWR.beamline.detector.distance.motorIsMoving():
             time.sleep(0.5)
 
     def isShutterOk(self):

--- a/HardwareObjects/SOLEIL/PX2/PX2Guillotine.py
+++ b/HardwareObjects/SOLEIL/PX2/PX2Guillotine.py
@@ -103,12 +103,12 @@ class PX2Guillotine(BaseHardwareObjects.Device):
             self.pss = self.getObjectByRole("pss")
 
             self.connect(
-                HWR.beamline.resolution.detector_distance,
+                HWR.beamline.detector.detector_distance,
                 "positionChanged",
                 self.shutterStateChanged
             )
             self.connect(
-                HWR.beamline.resolution.detector_distance,
+                HWR.beamline.detector.detector_distance,
                 "positionChanged",
                 self.updateDetectorDistance
             )
@@ -158,7 +158,7 @@ class PX2Guillotine(BaseHardwareObjects.Device):
         if state == "Transfer":
             self.goToSecurityDistance()
         if state == "Collect":
-            HWR.beamline.resolution.detector_distance.move(180)
+            HWR.beamline.detector.detector_distance.move(180)
 
     def updateGuillotine(self, value):
         # if open door close guillotine but test distance
@@ -182,15 +182,15 @@ class PX2Guillotine(BaseHardwareObjects.Device):
         )
         if self.isInsert():
             if not self.checkDistance():
-                HWR.beamline.resolution.detector_distance.move(self._d_security)
+                HWR.beamline.detector.detector_distance.move(self._d_security)
                 time.sleep(2.0)
-                while HWR.beamline.resolution.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.detector_distance.motorIsMoving():
                     time.sleep(0.5)
                 self._Extract()
                 time.sleep(0.2)
-                HWR.beamline.resolution.detector_distance.move(currentDistance)
+                HWR.beamline.detector.detector_distance.move(currentDistance)
                 time.sleep(2.0)
-                while HWR.beamline.resolution.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.detector_distance.motorIsMoving():
                     time.sleep(0.5)
             else:
                 self._Extract()
@@ -211,10 +211,10 @@ class PX2Guillotine(BaseHardwareObjects.Device):
 
     def goToSecurityDistance(self):
         if self._currentDistance < self._d_home:
-            HWR.beamline.resolution.detector_distance.move(self._d_home)
+            HWR.beamline.detector.detector_distance.move(self._d_home)
         if str(self.shutChannel.value) == "EXTRACT":
             self._Insert()
-        while HWR.beamline.resolution.detector_distance.motorIsMoving():
+        while HWR.beamline.detector.detector_distance.motorIsMoving():
             time.sleep(0.5)
 
     def isShutterOk(self):

--- a/HardwareObjects/SOLEIL/SOLEILGuillotine.py
+++ b/HardwareObjects/SOLEIL/SOLEILGuillotine.py
@@ -102,8 +102,8 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
 
             self.pss = self.getObjectByRole("pss")
 
-            self.connect(HWR.beamline.resolution.detector_distance, "positionChanged", self.shutterStateChanged)
-            self.connect(HWR.beamline.resolution.detector_distance, "positionChanged", self.updateDetectorDistance)
+            self.connect(HWR.beamline.detector.detector_distance, "positionChanged", self.shutterStateChanged)
+            self.connect(HWR.beamline.detector.detector_distance, "positionChanged", self.updateDetectorDistance)
 
             for command_name in ("_Insert", "_Extract"):
                 setattr(self, command_name, self.getCommandObject(command_name))
@@ -154,7 +154,7 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
         if state == "Transfer":
             self.goToSecurityDistance()
         if state == "Collect":
-            HWR.beamline.resolution.detector_distance.move(180)
+            HWR.beamline.detector.detector_distance.move(180)
 
     def updateGuillotine(self, value):
         # if open door close guillotine but test distance
@@ -179,16 +179,16 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
         if self.isInsert():
             if not self.checkDistance():
                 # self.detector.move(180)
-                HWR.beamline.resolution.detector_distance.move(self._d_security)
+                HWR.beamline.detector.detector_distance.move(self._d_security)
                 time.sleep(2.0)
-                while HWR.beamline.resolution.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.detector_distance.motorIsMoving():
                     time.sleep(0.5)
                 self._Extract()
                 time.sleep(0.2)
                 # self.detector.move(150)
-                HWR.beamline.resolution.detector_distance.move(currentDistance)
+                HWR.beamline.detector.detector_distance.move(currentDistance)
                 time.sleep(2.0)
-                while HWR.beamline.resolution.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.detector_distance.motorIsMoving():
                     time.sleep(0.5)
             else:
                 self._Extract()
@@ -209,10 +209,10 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
 
     def goToSecurityDistance(self):
         if self._currentDistance < self._d_home:
-            HWR.beamline.resolution.detector_distance.move(self._d_home)
+            HWR.beamline.detector.detector_distance.move(self._d_home)
         if str(self.shutChannel.value) == "EXTRACT":
             self._Insert()
-        while HWR.beamline.resolution.detector_distance.motorIsMoving():
+        while HWR.beamline.detector.detector_distance.motorIsMoving():
             time.sleep(0.5)
 
     def isShutterOk(self):

--- a/HardwareObjects/SOLEIL/SOLEILGuillotine.py
+++ b/HardwareObjects/SOLEIL/SOLEILGuillotine.py
@@ -102,8 +102,8 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
 
             self.pss = self.getObjectByRole("pss")
 
-            self.connect(HWR.beamline.detector.detector_distance, "positionChanged", self.shutterStateChanged)
-            self.connect(HWR.beamline.detector.detector_distance, "positionChanged", self.updateDetectorDistance)
+            self.connect(HWR.beamline.resolution.detector_distance, "positionChanged", self.shutterStateChanged)
+            self.connect(HWR.beamline.resolution.detector_distance, "positionChanged", self.updateDetectorDistance)
 
             for command_name in ("_Insert", "_Extract"):
                 setattr(self, command_name, self.getCommandObject(command_name))
@@ -154,7 +154,7 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
         if state == "Transfer":
             self.goToSecurityDistance()
         if state == "Collect":
-            HWR.beamline.detector.detector_distance.move(180)
+            HWR.beamline.resolution.detector_distance.move(180)
 
     def updateGuillotine(self, value):
         # if open door close guillotine but test distance
@@ -179,16 +179,16 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
         if self.isInsert():
             if not self.checkDistance():
                 # self.detector.move(180)
-                HWR.beamline.detector.detector_distance.move(self._d_security)
+                HWR.beamline.resolution.detector_distance.move(self._d_security)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.resolution.detector_distance.motorIsMoving():
                     time.sleep(0.5)
                 self._Extract()
                 time.sleep(0.2)
                 # self.detector.move(150)
-                HWR.beamline.detector.detector_distance.move(currentDistance)
+                HWR.beamline.resolution.detector_distance.move(currentDistance)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.resolution.detector_distance.motorIsMoving():
                     time.sleep(0.5)
             else:
                 self._Extract()
@@ -209,10 +209,10 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
 
     def goToSecurityDistance(self):
         if self._currentDistance < self._d_home:
-            HWR.beamline.detector.detector_distance.move(self._d_home)
+            HWR.beamline.resolution.detector_distance.move(self._d_home)
         if str(self.shutChannel.value) == "EXTRACT":
             self._Insert()
-        while HWR.beamline.detector.detector_distance.motorIsMoving():
+        while HWR.beamline.resolution.detector_distance.motorIsMoving():
             time.sleep(0.5)
 
     def isShutterOk(self):

--- a/HardwareObjects/SOLEIL/SOLEILGuillotine.py
+++ b/HardwareObjects/SOLEIL/SOLEILGuillotine.py
@@ -102,8 +102,8 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
 
             self.pss = self.getObjectByRole("pss")
 
-            self.connect(HWR.beamline.detector.detector_distance, "positionChanged", self.shutterStateChanged)
-            self.connect(HWR.beamline.detector.detector_distance, "positionChanged", self.updateDetectorDistance)
+            self.connect(HWR.beamline.detector.distance, "positionChanged", self.shutterStateChanged)
+            self.connect(HWR.beamline.detector.distance, "positionChanged", self.updateDetectorDistance)
 
             for command_name in ("_Insert", "_Extract"):
                 setattr(self, command_name, self.getCommandObject(command_name))
@@ -154,7 +154,7 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
         if state == "Transfer":
             self.goToSecurityDistance()
         if state == "Collect":
-            HWR.beamline.detector.detector_distance.move(180)
+            HWR.beamline.detector.distance.move(180)
 
     def updateGuillotine(self, value):
         # if open door close guillotine but test distance
@@ -179,16 +179,16 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
         if self.isInsert():
             if not self.checkDistance():
                 # self.detector.move(180)
-                HWR.beamline.detector.detector_distance.move(self._d_security)
+                HWR.beamline.detector.distance.move(self._d_security)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.distance.motorIsMoving():
                     time.sleep(0.5)
                 self._Extract()
                 time.sleep(0.2)
                 # self.detector.move(150)
-                HWR.beamline.detector.detector_distance.move(currentDistance)
+                HWR.beamline.detector.distance.move(currentDistance)
                 time.sleep(2.0)
-                while HWR.beamline.detector.detector_distance.motorIsMoving():
+                while HWR.beamline.detector.distance.motorIsMoving():
                     time.sleep(0.5)
             else:
                 self._Extract()
@@ -209,10 +209,10 @@ class SOLEILGuillotine(BaseHardwareObjects.Device):
 
     def goToSecurityDistance(self):
         if self._currentDistance < self._d_home:
-            HWR.beamline.detector.detector_distance.move(self._d_home)
+            HWR.beamline.detector.distance.move(self._d_home)
         if str(self.shutChannel.value) == "EXTRACT":
             self._Insert()
-        while HWR.beamline.detector.detector_distance.motorIsMoving():
+        while HWR.beamline.detector.distance.motorIsMoving():
             time.sleep(0.5)
 
     def isShutterOk(self):

--- a/HardwareObjects/SOLEIL/SOLEILqueue_entry.py
+++ b/HardwareObjects/SOLEIL/SOLEILqueue_entry.py
@@ -55,7 +55,7 @@ class PX2DataCollectionQueueEntry(DataCollectionQueueEntry):
                 if cpos != empty_cpos:
                     log.info("Moving sample to given position ...")
                     list_item.setText(1, "Moving sample")
-                    HWR.beamline.graphics.select_shape_with_cpos(cpos)
+                    HWR.beamline.microscope.shapes.select_shape_with_cpos(cpos)
                     self.centring_task = HWR.beamline.diffractometer.moveToCentredPosition(
                         cpos, wait=False
                     )
@@ -63,7 +63,7 @@ class PX2DataCollectionQueueEntry(DataCollectionQueueEntry):
                 else:
                     pos_dict = HWR.beamline.diffractometer.getPositions()
                     cpos = queue_model_objects.CentredPosition(pos_dict)
-                    snapshot = HWR.beamline.graphics.get_snapshot([])
+                    snapshot = HWR.beamline.microscope.get_snapshot([])
                     acq_1.acquisition_parameters.centred_position = cpos
                     acq_1.acquisition_parameters.centred_position.snapshot_image = (
                         snapshot

--- a/HardwareObjects/TacoMarDetector.py
+++ b/HardwareObjects/TacoMarDetector.py
@@ -106,7 +106,7 @@ class Mar225:
         self, frame_number, start, filename, jpeg_full_path, jpeg_thumbnail_full_path
     ):
         self.header["xtal_to_detector"] = (
-            HWR.beamline.resolution.detector_distance.getPosition()
+            HWR.beamline.detector.detector_distance.getPosition()
         )
         self.header["source_wavelength"] = HWR.beamline.energy.get_wavelength()
         bx, by = HWR.beamline.detector.get_beam_centre()

--- a/HardwareObjects/TacoMarDetector.py
+++ b/HardwareObjects/TacoMarDetector.py
@@ -106,7 +106,7 @@ class Mar225:
         self, frame_number, start, filename, jpeg_full_path, jpeg_thumbnail_full_path
     ):
         self.header["xtal_to_detector"] = (
-            HWR.beamline.detector.detector_distance.getPosition()
+            HWR.beamline.resolution.detector_distance.getPosition()
         )
         self.header["source_wavelength"] = HWR.beamline.energy.get_wavelength()
         bx, by = HWR.beamline.detector.get_beam_centre()

--- a/HardwareObjects/TacoMarDetector.py
+++ b/HardwareObjects/TacoMarDetector.py
@@ -106,7 +106,7 @@ class Mar225:
         self, frame_number, start, filename, jpeg_full_path, jpeg_thumbnail_full_path
     ):
         self.header["xtal_to_detector"] = (
-            HWR.beamline.detector.detector_distance.getPosition()
+            HWR.beamline.detector.distance.getPosition()
         )
         self.header["source_wavelength"] = HWR.beamline.energy.get_wavelength()
         bx, by = HWR.beamline.detector.get_beam_centre()

--- a/HardwareObjects/XMLRPCServer.py
+++ b/HardwareObjects/XMLRPCServer.py
@@ -443,7 +443,7 @@ class XMLRPCServer(HardwareObject):
          'angle': float}
 
         """
-        grid_dict = HWR.beamline.graphics.get_grid()
+        grid_dict = HWR.beamline.microscope.shapes.get_grid()
         # self.shape_history_set_grid_data(grid_dict['id'], {})
 
         return grid_dict
@@ -453,7 +453,7 @@ class XMLRPCServer(HardwareObject):
         for result in result_data.items():
             int_based_result[int(result[0])] = result[1]
 
-        HWR.beamline.graphics.set_grid_data(key, int_based_result)
+        HWR.beamline.microscope.shapes.set_grid_data(key, int_based_result)
         return True
 
     def get_cp(self):
@@ -461,7 +461,7 @@ class XMLRPCServer(HardwareObject):
         :returns: a json encoded list with all centred positions
         """
         cplist = []
-        points = HWR.beamline.graphics.get_points()
+        points = HWR.beamline.microscope.shapes.get_points()
 
         for point in points:
             cp = point.get_centred_positions()[0].as_dict()

--- a/HardwareObjects/abstract/AbstractMicroscope.py
+++ b/HardwareObjects/abstract/AbstractMicroscope.py
@@ -1,0 +1,98 @@
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube.
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU General Lesser Public License
+#  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
+__copyright__ = """ Copyright © 2019 by the MXCuBE collaboration """
+__license__ = "LGPLv3+"
+
+import abc
+
+
+class AbstractMicroscope(object):
+    """ Abstract Mictoscope Class """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self):
+        self.camera_hwobj = None
+        self.shapes_hwobj = None
+        self.focus_hwobj = None
+        self.zoom_hwobj = None
+        self.frontlight_hwobj  = None
+        self.backlight_hwobj  = None
+
+    def get_snapshot(self, num=4):
+        """ Get snappshot(s)
+        Args:
+            num(int): Number of snapshots to take.
+        """
+        pass
+
+    def save_snapshot(self, filename):
+        """ Save a snapshot to file.
+        Args:
+            filename (str): The filename.
+        """
+        pass
+
+    def save_scene_animation(self, filename, duration=1):
+        """ Take snapshots and create an animation.
+        Args:
+            filename (str): Filename.
+            duration (int): Duration time [s].
+        """
+        pass
+
+    @property
+    def camera(self):
+        """ Get camera object.
+        Returns:
+            (AbstractCamera): Camera hardware object.
+        """
+        return self.camera_hwobj
+
+    @property
+    def shapes(self):
+        """ Get shapes object.
+        Returns:
+            (AbstractShapes): Shapes hardware object.
+        """
+        return self.shapes_hwobj
+
+    @property
+    def zoom(self):
+        """ Get zoom object.
+        Returns:
+            (AbstractZoom): Zoom gardware object.
+        """
+        return self.zoom_hwobj
+
+    @property
+    def frontlight(self):
+        """ Get Front light object
+        Returns:
+            (AbstractLight): Front light hardware object.
+        """
+        return self.frontlight_hwobj
+
+    @property
+    def backlight(self):
+        """ Get Back light object.
+        Returns:
+            (AbstractLight): Back light hardware object.
+        """
+        return self.backlight_hwobj

--- a/HardwareObjects/abstract/AbstractMicroscope.py
+++ b/HardwareObjects/abstract/AbstractMicroscope.py
@@ -28,12 +28,12 @@ class AbstractMicroscope(object):
     __metaclass__ = abc.ABCMeta
 
     def __init__(self):
-        self.camera_hwobj = None
-        self.shapes_hwobj = None
-        self.focus_hwobj = None
-        self.zoom_hwobj = None
-        self.frontlight_hwobj  = None
-        self.backlight_hwobj  = None
+        self._camera_hwobj = None
+        self._shapes_hwobj = None
+        self._focus_hwobj = None
+        self._zoom_hwobj = None
+        self._frontlight_hwobj  = None
+        self._backlight_hwobj  = None
 
     def get_snapshot(self, num=4):
         """ Get snappshot(s)
@@ -63,7 +63,7 @@ class AbstractMicroscope(object):
         Returns:
             (AbstractCamera): Camera hardware object.
         """
-        return self.camera_hwobj
+        return self._camera
 
     @property
     def shapes(self):
@@ -71,7 +71,7 @@ class AbstractMicroscope(object):
         Returns:
             (AbstractShapes): Shapes hardware object.
         """
-        return self.shapes_hwobj
+        return self._shapes
 
     @property
     def zoom(self):
@@ -79,7 +79,7 @@ class AbstractMicroscope(object):
         Returns:
             (AbstractZoom): Zoom gardware object.
         """
-        return self.zoom_hwobj
+        return self._zoom
 
     @property
     def frontlight(self):
@@ -87,7 +87,7 @@ class AbstractMicroscope(object):
         Returns:
             (AbstractLight): Front light hardware object.
         """
-        return self.frontlight_hwobj
+        return self._frontlight
 
     @property
     def backlight(self):
@@ -95,4 +95,4 @@ class AbstractMicroscope(object):
         Returns:
             (AbstractLight): Back light hardware object.
         """
-        return self.backlight_hwobj
+        return self._backlight

--- a/HardwareObjects/mockup/CollectEmulator.py
+++ b/HardwareObjects/mockup/CollectEmulator.py
@@ -179,7 +179,7 @@ class CollectEmulator(CollectMockup):
         if not detector_distance:
             resolution = data_collect_parameters["resolution"]["upper"]
             self.set_resolution(resolution)
-            detector_distance = HWR.beamline.detector.detector_distance.getPosition()
+            detector_distance = HWR.beamline.detector.distance.getPosition()
         # Add sweeps
         sweeps = []
         for osc in data_collect_parameters["oscillation_sequence"]:

--- a/HardwareObjects/mockup/CollectEmulator.py
+++ b/HardwareObjects/mockup/CollectEmulator.py
@@ -179,7 +179,7 @@ class CollectEmulator(CollectMockup):
         if not detector_distance:
             resolution = data_collect_parameters["resolution"]["upper"]
             self.set_resolution(resolution)
-            detector_distance = HWR.beamline.resolution.detector_distance.getPosition()
+            detector_distance = HWR.beamline.detector.detector_distance.getPosition()
         # Add sweeps
         sweeps = []
         for osc in data_collect_parameters["oscillation_sequence"]:

--- a/HardwareObjects/mockup/CollectEmulator.py
+++ b/HardwareObjects/mockup/CollectEmulator.py
@@ -179,7 +179,7 @@ class CollectEmulator(CollectMockup):
         if not detector_distance:
             resolution = data_collect_parameters["resolution"]["upper"]
             self.set_resolution(resolution)
-            detector_distance = HWR.beamline.detector.detector_distance.getPosition()
+            detector_distance = HWR.beamline.resolution.detector_distance.getPosition()
         # Add sweeps
         sweeps = []
         for osc in data_collect_parameters["oscillation_sequence"]:

--- a/HardwareObjects/mockup/CollectMockup.py
+++ b/HardwareObjects/mockup/CollectMockup.py
@@ -154,14 +154,14 @@ class CollectMockup(AbstractCollect.AbstractCollect):
 
     @task
     def _take_crystal_snapshot(self, filename):
-        HWR.beamline.graphics.save_scene_snapshot(filename)
+        HWR.beamline.microscope.save_scene_snapshot(filename)
 
     @task
     def _take_crystal_animation(self, animation_filename, duration_sec=1):
         """Rotates sample by 360 and composes a gif file
            Animation is saved as the fourth snapshot
         """
-        HWR.beamline.graphics.save_scene_animation(
+        HWR.beamline.microscope.save_scene_animation(
             animation_filename, duration_sec
         )
 

--- a/HardwareObjects/mockup/ResolutionMockup.py
+++ b/HardwareObjects/mockup/ResolutionMockup.py
@@ -16,11 +16,11 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         self.detmState = None
         self.state = 2
         self.connect(
-            HWR.beamline.detector.detector_distance,
+            HWR.beamline.resolution.detector_distance,
             "positionChanged",
             self.dtoxPositionChanged
         )
-        HWR.beamline.detector.detector_distance.move(
+        HWR.beamline.resolution.detector_distance.move(
             self.res2dist(self.currentResolution)
         )
 
@@ -81,7 +81,7 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
 
     def recalculateResolution(self):
         self.currentResolution = self.dist2res(
-            HWR.beamline.detector.detector_distance.getPosition()
+            HWR.beamline.resolution.detector_distance.getPosition()
         )
 
     def equipmentReady(self):
@@ -123,13 +123,13 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         return (0, 20)
 
     def set_position(self, pos, wait=True):
-        HWR.beamline.detector.detector_distance.move(self.res2dist(pos), wait=wait)
+        HWR.beamline.resolution.detector_distance.move(self.res2dist(pos), wait=wait)
 
     move = set_position
 
     def motorIsMoving(self):
         return (
-            HWR.beamline.detector.detector_distance.motorIsMoving()
+            HWR.beamline.resolution.detector_distance.motorIsMoving()
             or HWR.beamline.energy.moving
         )
 
@@ -137,4 +137,4 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         pass
 
     def stop(self):
-        HWR.beamline.detector.detector_distance.stop()
+        HWR.beamline.resolution.detector_distance.stop()

--- a/HardwareObjects/mockup/ResolutionMockup.py
+++ b/HardwareObjects/mockup/ResolutionMockup.py
@@ -16,11 +16,11 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         self.detmState = None
         self.state = 2
         self.connect(
-            HWR.beamline.detector.detector_distance,
+            HWR.beamline.detector.distance,
             "positionChanged",
             self.dtoxPositionChanged
         )
-        HWR.beamline.detector.detector_distance.move(
+        HWR.beamline.detector.distance.move(
             self.res2dist(self.currentResolution)
         )
 
@@ -81,7 +81,7 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
 
     def recalculateResolution(self):
         self.currentResolution = self.dist2res(
-            HWR.beamline.detector.detector_distance.getPosition()
+            HWR.beamline.detector.distance.getPosition()
         )
 
     def equipmentReady(self):
@@ -123,13 +123,13 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         return (0, 20)
 
     def set_position(self, pos, wait=True):
-        HWR.beamline.detector.detector_distance.move(self.res2dist(pos), wait=wait)
+        HWR.beamline.detector.distance.move(self.res2dist(pos), wait=wait)
 
     move = set_position
 
     def motorIsMoving(self):
         return (
-            HWR.beamline.detector.detector_distance.motorIsMoving()
+            HWR.beamline.detector.distance.motorIsMoving()
             or HWR.beamline.energy.moving
         )
 
@@ -137,4 +137,4 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         pass
 
     def stop(self):
-        HWR.beamline.detector.detector_distance.stop()
+        HWR.beamline.detector.distance.stop()

--- a/HardwareObjects/mockup/ResolutionMockup.py
+++ b/HardwareObjects/mockup/ResolutionMockup.py
@@ -16,11 +16,11 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         self.detmState = None
         self.state = 2
         self.connect(
-            HWR.beamline.resolution.detector_distance,
+            HWR.beamline.detector.detector_distance,
             "positionChanged",
             self.dtoxPositionChanged
         )
-        HWR.beamline.resolution.detector_distance.move(
+        HWR.beamline.detector.detector_distance.move(
             self.res2dist(self.currentResolution)
         )
 
@@ -81,7 +81,7 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
 
     def recalculateResolution(self):
         self.currentResolution = self.dist2res(
-            HWR.beamline.resolution.detector_distance.getPosition()
+            HWR.beamline.detector.detector_distance.getPosition()
         )
 
     def equipmentReady(self):
@@ -123,13 +123,13 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         return (0, 20)
 
     def set_position(self, pos, wait=True):
-        HWR.beamline.resolution.detector_distance.move(self.res2dist(pos), wait=wait)
+        HWR.beamline.detector.detector_distance.move(self.res2dist(pos), wait=wait)
 
     move = set_position
 
     def motorIsMoving(self):
         return (
-            HWR.beamline.resolution.detector_distance.motorIsMoving()
+            HWR.beamline.detector.detector_distance.motorIsMoving()
             or HWR.beamline.energy.moving
         )
 
@@ -137,4 +137,4 @@ class ResolutionMockup(BaseHardwareObjects.Equipment):
         pass
 
     def stop(self):
-        HWR.beamline.resolution.detector_distance.stop()
+        HWR.beamline.detector.detector_distance.stop()

--- a/HardwareObjects/queue_entry.py
+++ b/HardwareObjects/queue_entry.py
@@ -521,7 +521,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
         self.get_queue_controller().pause(True)
         pos = None
 
-        shapes = list(HWR.beamline.graphics.get_selected_shapes())
+        shapes = list(HWR.beamline.microscope.shapes.get_selected_shapes())
         if shapes:
             pos = shapes[0]
             if hasattr(pos, "get_centred_position"):
@@ -533,7 +533,7 @@ class SampleCentringQueueEntry(BaseQueueEntry):
             log.info(msg)
 
             # Create a centred positions of the current position
-            pos_dict = HWR.beamline.diffractometer.getPositions()
+            pos_dict = HWR.beamline.diffractometer.get_positions()
             cpos = queue_model_objects.CentredPosition(pos_dict)
 
         self._data_model.set_centring_result(cpos)
@@ -575,7 +575,7 @@ class DataCollectionQueueEntry(BaseQueueEntry):
         d["collect_task"] = None
         d["centring_task"] = None
         d["shape_history"] = (
-            HWR.beamline.graphics.name() if HWR.beamline.graphics else None
+            HWR.beamline.microscope.name() if HWR.beamline.microscope else None
         )
         d["session"] = (
             HWR.beamline.session.name() if HWR.beamline.session else None
@@ -600,15 +600,15 @@ class DataCollectionQueueEntry(BaseQueueEntry):
                     self.get_view(),
                     HWR.beamline.diffractometer,
                     self.get_queue_controller(),
-                    HWR.beamline.graphics,
+                    HWR.beamline.microscope,
                 )
 
                 acq_params.centred_position = _p
 
             self.collect_dc(data_collection, self.get_view())
 
-        if HWR.beamline.graphics:
-            HWR.beamline.graphics.de_select_all()
+        if HWR.beamline.microscope:
+            HWR.beamline.microscope.shapes.de_select_all()
 
     def pre_execute(self):
         BaseQueueEntry.pre_execute(self)
@@ -738,17 +738,17 @@ class DataCollectionQueueEntry(BaseQueueEntry):
                 empty_cpos = queue_model_objects.CentredPosition()
 
                 if cpos != empty_cpos:
-                    HWR.beamline.graphics.select_shape_with_cpos(cpos)
+                    HWR.beamline.microscope.shapes.select_shape_with_cpos(cpos)
                 else:
-                    pos_dict = HWR.beamline.diffractometer.getPositions()
+                    pos_dict = HWR.beamline.diffractometer.get_positions()
                     cpos = queue_model_objects.CentredPosition(pos_dict)
-                    snapshot = HWR.beamline.graphics.get_snapshot()
+                    snapshot = HWR.beamline.microscope.get_snapshot()
                     acq_1.acquisition_parameters.centred_position = cpos
                     acq_1.acquisition_parameters.centred_position.snapshot_image = (
                         snapshot
                     )
 
-                HWR.beamline.graphics.inc_used_for_collection(cpos)
+                HWR.beamline.microscope.shapes.inc_used_for_collection(cpos)
 
                 param_list = queue_model_objects.to_collect_dict(
                     dc,
@@ -1540,7 +1540,7 @@ class XrayCenteringQueueEntry(BaseQueueEntry):
         xray_centering = self.get_data_model()
         reference_image_collection = xray_centering.reference_image_collection
         reference_image_collection.grid = (
-            HWR.beamline.graphics.create_auto_grid()
+            HWR.beamline.microscope.shapes.reate_auto_grid()
         )
         reference_image_collection.acquisitions[
             0
@@ -1642,7 +1642,7 @@ class AdvancedConnectorQueueEntry(BaseQueueEntry):
 
                 gevent.sleep(2)
                 auto_line, cpos_one, cpos_two = (
-                    HWR.beamline.graphics.create_auto_line()
+                    HWR.beamline.microscope.shapes.create_auto_line()
                 )
                 helical_model.acquisitions[
                     0
@@ -1693,7 +1693,7 @@ class OpticalCentringQueueEntry(BaseQueueEntry):
 
 def mount_sample(view, data_model, centring_done_cb, async_result):
     view.setText(1, "Loading sample")
-    HWR.beamline.graphics.clear_all()
+    HWR.beamline.microscope.shapes.clear_all()
     log = logging.getLogger("queue_exec")
 
     loc = data_model.location

--- a/HardwareObjects/queue_entry.py
+++ b/HardwareObjects/queue_entry.py
@@ -1540,7 +1540,7 @@ class XrayCenteringQueueEntry(BaseQueueEntry):
         xray_centering = self.get_data_model()
         reference_image_collection = xray_centering.reference_image_collection
         reference_image_collection.grid = (
-            HWR.beamline.microscope.shapes.reate_auto_grid()
+            HWR.beamline.microscope.shapes.create_auto_grid()
         )
         reference_image_collection.acquisitions[
             0


### PR DESCRIPTION
Dear all,

So me and Antonia spent bigger part of Monday and Tuesday to get the Beamline object to work. We have finally arrived at something that at least superficially seems to work like before :)

When we did this we had to adapt a few things to make it work for us, roughly what we did:

There were a few settings missing that we added:
- available_methods 
- click_centrings_num_click

We also added access to the following HardwareObjects:
- Beamstop
- Capilary
- Cryostream
- SampleChangerMaintnance
- Workflow
- XMLRPCServer

The last one should eventually become a part of the SampleChanger HardwareObject in our opinions.

We renamed Graphics to Microscope as we briefly discussed previously. Microscope contains Shapes (Regions of interest), Camera, Focus, Zoom and Lights. It further contains utility methods related to the microscope view like taking snapshots. Its in this way not very different from the Qt4GraphicsManager object except for that certain things are delegated to shapes directly.

We did the corresponding updates to the rest of the site specific parts of the code as well. We did not change all the Graphics to Microscope calls entirely since it was difficult to know what parts could be delegated to a corresponding Shapes object for the Qt version.

We have added AbstractMicroscope class that needs to be completed with the necessary methods. We have no strong opinions about the name Microscope so this can be changed if someone has a more appropriate suggestion.

We also moved get_default_characterisation_parameters to DataAnalysis, these are the default parameters for EDNA. The Bemline object was missing this but it was moved from the BeamlineSetup object, that now will become obsolete. 

Finally, detector_distance was moved from Detector to Resolution

Cheers,
Marcus and Antonia
