### PR TITLE
Added support for procedures

### DIFF
--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -26,6 +26,14 @@ class ConfiguredObject(object):
 
         self._objects = OrderedDict((role, None) for role in self.all_roles)
 
+    def _init(self):
+        """Object initialisation - executed *before* loading contents"""
+        pass
+
+    def init(self):
+        """Object initialisation - executed *after* loading contents"""
+        pass
+
     def replace_object(self, role, new_object):
         """Replace already defined Object with a new one - for runtime use
 

--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -15,6 +15,11 @@ class ConfiguredObject(object):
     # NB the double underscore is deliberate - attribute must be hidden from subclasses
     __content_roles = []
 
+    # Procedure names - placeholder.
+    # Will be replaced by a set in any subclasses that can contain procedures
+    # Note that _procedure_names may *not* be set if it is already set in a superclass
+    _procedure_names = None
+
     def __init__(self, name):
 
         self.name = name
@@ -57,6 +62,17 @@ class ConfiguredObject(object):
         """
         return self._objects.copy()
 
+    @property
+    def procedures(self):
+        procedure_names = self.__class__._procedure_names
+        result = {}
+        if procedure_names:
+            for name in procedure_names:
+                procedure = getattr(self, name)
+                if procedure is not None:
+                    result[name] = procedure
+        #
+        return result
 
 class PropertySet(dict):
     def __init__(self):

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -48,6 +48,11 @@ class Beamline(ConfiguredObject):
     # NB the double underscore is deliberate - attribute must be hidden from subclasses
     __content_roles = []
 
+    # Names of procedures under Beamline - set of sttrings.
+    # NB subclasses must add additional parocedures to this set,
+    # and may NOT override _procdeure_names
+    _procedure_names = set()
+
     # NBNB these should be accessed ONLY as beamline.SUPPORTED_..._PARAMETERS
     # NBNB Subclasses may add local parameters but may NOT remove any
     #
@@ -523,6 +528,29 @@ class Beamline(ConfiguredObject):
         return self._objects.get("image_tracking")
 
     __content_roles.append("image_tracking")
+
+    # Procedures
+
+    # NB this is just an example of a globally shared procedure description
+    @property
+    def manual_centring(self):
+        """ Manual centring Procedure
+
+        NB AbstractManualCentring serves to define the parameters for manual centring
+        The actual implementation is set by configuration,
+        and can be given as an AbstractManualCentring subclass on each beamline
+
+        Returns:
+            Optional[AbstractManualCentring]
+        """
+        return self._objects.get("manual_centring")
+    __content_roles.append("manual_centring")
+    # Registers this object as a procedure:
+    _procedure_names.add("manual_centring")
+
+
+    # Additional functions
+
 
     # NB Objects need not be HardwareObjects
     # We still categorise them as'hardware' if they are not procedures, though

--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -112,10 +112,6 @@ class Beamline(ConfiguredObject):
         # int Starting run number for path_template
         self.run_number = 1
 
-    def _init(self):
-        """Objetc initialisation - executed *before* loading contents"""
-        pass
-
     def init(self):
         """Object initialisation - executed *after* loading contents"""
 

--- a/HardwareObjects/EMBL/EMBLBeamline.py
+++ b/HardwareObjects/EMBL/EMBLBeamline.py
@@ -82,3 +82,20 @@ class EMBLBeamline(Beamline):
         """
         return self._objects.get("ppu_control")
     __content_roles.append("ppu_control")
+
+    # Additional procedures
+
+    # NB this is just an example of a beamline-specific procedure description
+    @property
+    def xray_centring(self):
+        """ X-ray Centring Procedure
+
+        NB EMBLXrayCentring is defined in EMBL-specific code, like EMBLBeamline
+
+        Returns:
+            Optional[EMBLXrayCentring]
+        """
+        return self._objects.get("xray_centring")
+    __content_roles.append("xray_centring")
+    # Registers this object as a procedure:
+    Beamline._procedure_names.add("xray_centring")


### PR DESCRIPTION
With this PR, you can set up and configure procedures in the same way as any other hardware object.
To register the object as a procedure you add its name to
Beamline._procedure_names.

The ConfiguredObject.procedures property will give you a dictionary of all configured procedures - notice that the resulting dictionary is a copy and modifying it will not modify the object internals. 

The same machinery could be used to add procedures to other classes (like DIffractometer?) if desired.