### PR TITLE
[WIP] Abstract Actuator - updated

### DIFF
--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -197,7 +197,6 @@ class HardwareObjectNode:
     def resolveReferences(self):
         # NB Must be here - importing at top level leads to circular imports
         from .HardwareRepository import getHardwareRepository
-
         while len(self.__references) > 0:
             reference, name, role, objectsNamesIndex, objectsIndex, objectsIndex2 = (
                 self.__references.pop()
@@ -314,23 +313,6 @@ class HardwareObjectNode:
     def getProperties(self):
         return self._propertySet
 
-    def update_values(self):
-        """Method called from Qt bricks to ensure that bricks have values
-           after the initialization.
-           Problem arrise when a hardware object is used by several bricks.
-           If first brick connects to some signal emited by a brick then
-           other bricks connecting to the same signal will no receive the
-           values on the startup.
-           The easiest solution is to call update_values method directly
-           after getHardwareObject and connect.
-
-           Normaly this method would emit all values
-        """
-        return
-
-    def clear_gevent(self):
-        pass
-
     def print_log(self, log_type="HWR", level="debug", msg=""):
         if hasattr(logging.getLogger(log_type), level):
             getattr(logging.getLogger(log_type), level)(msg)
@@ -357,7 +339,6 @@ class HardwareObjectMixin(HardwareObjectNode, CommandContainer):
     def __setstate__(self, name):
         # NB Must be here - importing at top level leads to circular imports
         from .HardwareRepository import getHardwareRepository
-
         o = getHardwareRepository().getHardwareObject(name)
         self.__dict__.update(o.__dict__)
 
@@ -463,15 +444,36 @@ class HardwareObjectMixin(HardwareObjectNode, CommandContainer):
         """Rewrite XML file"""
         # NB Must be here - importing at top level leads to circular imports
         from .HardwareRepository import getHardwareRepository
-
         getHardwareRepository().rewrite_xml(self.name(), xml)
 
     def xml_source(self):
         """Get XML source code"""
         # NB Must be here - importing at top level leads to circular imports
         from .HardwareRepository import getHardwareRepository
-
         return getHardwareRepository().xml_source[self.name()]
+
+    # Moved from HardwareObjectNode
+    def clear_gevent(self):
+        """Clear gevent tasks
+
+        Returns:
+
+        """
+        pass
+
+    def update_values(self):
+        """Method called from Qt bricks to ensure that bricks have values
+           after the initialization.
+           Problem arrise when a hardware object is used by several bricks.
+           If first brick connects to some signal emited by a brick then
+           other bricks connecting to the same signal will no receive the
+           values on the startup.
+           The easiest solution is to call update_values method directly
+           after getHardwareObject and connect.
+
+           Normaly this method would emit all values
+        """
+        return
 
 class HardwareObject(HardwareObjectMixin, HardwareObjectNode, CommandContainer):
     """Xml-configured hardware object"""
@@ -559,7 +561,30 @@ class DeviceContainer:
 
 
 class DeviceContainerNode(HardwareObjectNode, DeviceContainer):
-    pass
+
+    # Moved from HardwareObjectNode
+
+    def clear_gevent(self):
+        """Clear gevent tasks
+
+        Returns:
+
+        """
+        pass
+
+    def update_values(self):
+        """Method called from Qt bricks to ensure that bricks have values
+           after the initialization.
+           Problem arrise when a hardware object is used by several bricks.
+           If first brick connects to some signal emited by a brick then
+           other bricks connecting to the same signal will no receive the
+           values on the startup.
+           The easiest solution is to call update_values method directly
+           after getHardwareObject and connect.
+
+           Normaly this method would emit all values
+        """
+        return
 
 
 class Equipment(HardwareObject, DeviceContainer):

--- a/CommandContainer.py
+++ b/CommandContainer.py
@@ -358,18 +358,6 @@ class CommandContainer:
     def get_channel_value(self, channel_name):
         return self.__channels[channel_name].getValue()
 
-    def setValue(self, channelName, value):
-        warn(
-            "setValue is deprecated. Use set_channel_value instead", DeprecationWarning
-        )
-        self.set_channel_value(channelName, value)
-
-    def getValue(self, channelName):
-        warn(
-            "getValue is deprecated. Use get_channel_value instead", DeprecationWarning
-        )
-        return self.get_channel_value(channelName)
-
     def getChannels(self):
         for chan in self.__channels.values():
             yield chan
@@ -386,10 +374,6 @@ class CommandContainer:
 
     def getCommandNamesList(self):
         return list(self.__commands.keys())
-
-    def addCommand(self, arg1, arg2=None, addNow=True):
-        warn("addCommand is deprecated. Use add_command instead", DeprecationWarning)
-        return self.add_command(arg1, arg2, addNow)
 
     def add_command(self, arg1, arg2=None, addNow=True):
         if not addNow:

--- a/HardwareObjects/BlissActuator.py
+++ b/HardwareObjects/BlissActuator.py
@@ -9,15 +9,15 @@ Example xml file:
 """
 import logging
 
-from HardwareRepository.HardwareObjects.abstract.AbstractActuator import (
-    AbstractActuator
+from HardwareRepository.HardwareObjects.abstract.AbstractTwoState import (
+    AbstractTwoState
 )
 from HardwareRepository.TaskUtils import task
 
 
-class BlissActuator(AbstractActuator):
+class BlissActuator(AbstractTwoState):
     def __init__(self, name):
-        AbstractActuator.__init__(self, name)
+        AbstractTwoState.__init__(self, name)
 
     def init(self):
         self.username = self.getProperty("username")
@@ -29,9 +29,9 @@ class BlissActuator(AbstractActuator):
     def get_actuator_state(self, read=False):
         if read is True:
             value = self._actuator.state()
-            self.actuator_state = self.states.get(value, AbstractActuator.UNKNOWN)
+            self.actuator_state = self.states.get(value, AbstractTwoState.UNKNOWN)
         else:
-            if self.actuator_state == AbstractActuator.UNKNOWN:
+            if self.actuator_state == AbstractTwoState.UNKNOWN:
                 self.connectNotify("actuatorStateChanged")
 
         logging.getLogger().debug("%s state: %s" % (self.username, self.actuator_state))

--- a/HardwareObjects/ExporterMotorExample.py
+++ b/HardwareObjects/ExporterMotorExample.py
@@ -1,0 +1,180 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Example of using StandardHardwareObject: ExporterMotorExample (from ExporterMotor)
+"""
+
+from HardwareRepository.HardwareObjects.abstract import AbstractActuator
+
+"""
+Example xml file:
+<device class="MicrodiffMotor">
+  <username>phiy</username>
+  <exporter_address>wid30bmd2s:9001</exporter_address>
+  <motor_name>AlignmentY</motor_name>
+  <GUIstep>1.0</GUIstep>
+  <unit>-1e-3</unit>
+  <resolution>1e-2</resolution>
+</device>
+"""
+
+
+class ExporterMotorExample(AbstractActuator.AbstractActuator):
+    def __init__(self, name):
+        super(ExporterMotorExample, self).__init__(name)
+
+        self.motor_name = None
+        self.motor_pos_attr_suffix = None
+        self.state_mapping = {}
+
+    def init(self):
+        self.motor_name = self.getProperty("motor_name")
+        self.value_resolution = self.getProperty("resolution")
+        if self.value_resolution is None:
+            self.value_resolution = 0.0001
+        self.motor_pos_attr_suffix = "Position"
+
+        self.chan_position = self.add_channel(
+            {"type": "exporter", "name": "%sPosition" % self.motor_name},
+            self.motor_name + self.motor_pos_attr_suffix,
+        )
+        self.chan_position.connectSignal("update", self.value_changed)
+
+        self.chan_state = self.add_channel(
+            {"type": "exporter", "name": "state"}, "State"
+        )
+        self.chan_all_motor_states = self.add_channel(
+            {"type": "exporter", "name": "motor_states"}, "MotorStates"
+        )
+        self.chan_all_motor_states.connectSignal(
+            "update", self.all_motor_states_changed
+        )
+
+        self.cmd_abort = self.add_command({"type": "exporter", "name": "abort"}, "abort")
+        self.cmd_get_dynamic_limits = self.add_command(
+            {"type": "exporter", "name": "get%sDynamicLimits" % self.motor_name},
+            "getMotorDynamicLimits",
+        )
+        self.cmd_get_limits = self.add_command(
+            {"type": "exporter", "name": "get_limits"}, "getMotorLimits"
+        )
+        self.cmd_get_max_speed = self.add_command(
+            {"type": "exporter", "name": "get_max_speed"}, "getMotorMaxSpeed"
+        )
+        self.cmd_home = self.add_command(
+            {"type": "exporter", "name": "homing"}, "startHomingMotor"
+        )
+
+        # Map of state strings returned from channel to self.STATE
+        # NB this is only an short example
+        STATE = self.STATE
+        self.state_mapping = {
+            "Initializing": STATE.INITIALIZING,
+            "Ready": STATE.READY,
+            "Busy": STATE.BUSY,
+            "Unknown": STATE.UNKNOWN,
+            "NotInitialized": STATE.NOTINITIALIZED,
+        }
+
+        # Initialise values from channel
+        self.set_state(self.STATE.READY)
+
+    def connectNotify(self, signal):
+        if signal == "valueChanged":
+            self.emit("valueChanged", (self.get_value(),))
+        elif signal == "stateChanged":
+            self.emit("stateChanged", (self.get_state(),))
+        elif signal == "limitsChanged":
+            self.emit("limitsChanged", (self.get_limits(),))
+
+    def all_motor_states_changed(self, all_motor_states):
+        """Get state for all known motors"""
+
+        dd0 = dict([x.split("=") for x in all_motor_states])
+        # Some are like motors but have no state
+        # we set them to ready
+        if dd0.get(self.motor_name) is None:
+            new_state = self.STATE.READY
+        else:
+            new_state = self.state_mapping.get(dd0[self.motor_name], self.STATE.UNKNOWN)
+
+        self.state = new_state
+
+    def get_limits(self):
+        """ Get current limits, dynamic or static
+
+        Returns:
+            Tuple[float,float]
+
+        """
+        dynamic_limits = self.get_dynamic_limits()
+        if dynamic_limits == (-1e4, 1e4):
+            try:
+                low_lim, hi_lim = map(float, self.cmd_get_limits(self.motor_name))
+                if low_lim == float(1e999) or hi_lim == float(1e999):
+                    raise ValueError
+                return low_lim, hi_lim
+            except BaseException:
+                return (-1e4, 1e4)
+        else:
+            return dynamic_limits
+
+    def get_max_speed(self):
+        """Maximum change speed in relevant units / s
+
+        Returns:
+            Optional[float]
+        """
+        return self.cmd_get_max_speed(self.motor_name)
+
+    def get_value(self):
+        """Get current value
+
+        Returns:
+            Optional[float]
+        """
+        return self.chan_position.getValue()
+
+    def _set_value(self, value):
+        self.set_state(self.STATE.BUSY)
+        self.chan_position.setValue(value)
+
+    def get_dynamic_limits(self):
+        try:
+            low_lim, hi_lim = map(float, self.cmd_get_dynamic_limits(self.motor_name))
+            if low_lim == float(1e999) or hi_lim == float(1e999):
+                raise ValueError
+            return low_lim, hi_lim
+        except BaseException:
+            return (-1e4, 1e4)
+
+    def stop(self):
+        if self.get_state() != self.STATE.NOTINITIALIZED:
+            self.cmd_abort()
+
+    def home(self, timeout=None):
+        if not isinstance(timeout, (int, float)) or timeout < 0:
+            raise ValueError("Invalid value for timeout: %s" % timeout)
+        self.cmd_home(self.motor_name)
+        self.wait_ready(timeout)
+
+    def value_changed(self, value, private={}):
+        self.emit("valueChanged", (value,))

--- a/HardwareObjects/MAXIV/BIOMAXEiger.py
+++ b/HardwareObjects/MAXIV/BIOMAXEiger.py
@@ -164,7 +164,7 @@ class BIOMAXEiger(Equipment):
         )
 
         for channel_name in attr_list:
-            self.addChannel(
+            self.add_channel(
                 {
                     "type": "tango",
                     "name": channel_name,
@@ -178,7 +178,7 @@ class BIOMAXEiger(Equipment):
         # get any of the channels for that.
 
         for channel_name in fw_list:
-            self.addChannel(
+            self.add_channel(
                 {"type": "tango", "name": channel_name, "tangoname": filewriter_device},
                 channel_name,
             )
@@ -311,6 +311,8 @@ class BIOMAXEiger(Equipment):
     #  STATUS END
 
     #  GET INFORMATION
+    def get_channel_value(self, name):
+        return self.getChannelObject(name).getValue()
 
     def set_channel_value(self, name, value):
         try:

--- a/HardwareObjects/MAXIV/BIOMAXTransmission.py
+++ b/HardwareObjects/MAXIV/BIOMAXTransmission.py
@@ -34,14 +34,13 @@ class BIOMAXTransmission(Equipment):
         curr_pos = float(self.get_value())
         return abs(curr_pos - setpoint) < 5
 
-    def set_value(self, value, wait=False):
+    def set_value(self, value, timeout=30):
         if value < self.limits[0] or value > self.limits[1]:
             raise Exception("Transmssion out of limits.")
         HWR.beamline.transmission.move(value)
-        if wait:
-            with gevent.Timeout(30, Exception("Timeout waiting for device ready")):
-                while not self.setpoint_reached(value):
-                    gevent.sleep(0.1)
+        with gevent.Timeout(timeout, Exception("Timeout waiting for device ready")):
+            while not self.setpoint_reached(value):
+                gevent.sleep(0.1)
 
         self._update()
 

--- a/HardwareObjects/MicrodiffActuator.py
+++ b/HardwareObjects/MicrodiffActuator.py
@@ -13,15 +13,15 @@ Example xml file:
 
 import logging
 import time
-from HardwareRepository.HardwareObjects.abstract.AbstractActuator import (
-    AbstractActuator
+from HardwareRepository.HardwareObjects.abstract.AbstractTwoState import (
+    AbstractTwoState
 )
 from HardwareRepository.TaskUtils import task
 
 
-class MicrodiffActuator(AbstractActuator):
+class MicrodiffActuator(AbstractTwoState):
     def __init__(self, name):
-        AbstractActuator.__init__(self, name)
+        AbstractTwoState.__init__(self, name)
         self._hwstate_attr = None
 
     def init(self):
@@ -92,10 +92,10 @@ class MicrodiffActuator(AbstractActuator):
     def get_actuator_state(self, read=False):
         if read is True:
             value = self.state_attr.getValue()
-            self.actuator_state = self.states.get(value, AbstractActuator.UNKNOWN)
+            self.actuator_state = self.states.get(value, AbstractTwoState.UNKNOWN)
             # self.connectNotify("actuatorStateChanged")
         else:
-            if self.actuator_state == AbstractActuator.UNKNOWN:
+            if self.actuator_state == AbstractTwoState.UNKNOWN:
                 self.connectNotify("actuatorStateChanged")
         return self.actuator_state
 

--- a/HardwareObjects/abstract/AbstractActuator.py
+++ b/HardwareObjects/abstract/AbstractActuator.py
@@ -1,0 +1,262 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Standard abstract HardwareObject with a'value' (e.g. motor, transmission, ...)
+"""
+
+from __future__ import division, absolute_import
+from __future__ import print_function, unicode_literals
+
+import logging
+from abc import ABCMeta, abstractmethod
+import gevent.event
+
+from HardwareRepository.BaseHardwareObjects import HardwareObject, HardwareObjectNode
+
+# We should make a standard set of states and use that wherever possible
+from somewhere import GeneralState
+
+__credits__ = [" Copyright © 2019 by MXCuBE collaboration. All rights reserved"]
+__license__ = "LGPLv3+"
+__category__ = "General"
+__author__ = "rhfogh"
+__date__ = "20190607"
+
+
+class AbstractActuator(HardwareObject, HardwareObjectNode):
+    """Abstract base class for Abstract actuators"""
+
+    # NB we should separate HardwareObjectNode and HardwareObject for future refactoring
+
+    __metaclass__ = ABCMeta
+
+    # Stete enumeration
+    STATE = GeneralState
+
+    # Tuple of states that count as ready
+    READY_STATES = (STATE.READY,)
+
+    # Default lower, upper limits
+    # Limit handling can be overridden in subclasses
+    _limits = (None, None)
+
+    def __init__(self, name):
+        super(AbstractActuator, self).__init__(name)
+
+        # event to handle waiting for object to be ready
+        self._ready_event = None
+        self._state = self.STATE.NOTINITIALIZED
+
+        # Tolerance to discriminate values as being different
+        self.value_resolution = None
+
+    def init(self):
+        super(AbstractActuator, self).init()
+        self._ready_event = gevent.event.Event()
+
+    @abstractmethod
+    def get_value(self):
+        """Get current value
+
+        Returns:
+            Optional[float]
+        """
+        return None
+
+    @abstractmethod
+    def _set_value(self, value):
+        """Internal value setter, called by set_value
+
+        Must ensure stateChanged sand valueChanged signals are sent as appropriate
+
+        Asynchronous, should return without waiting for object to be ready
+
+        Must cope sensibly with value None
+
+        Args:
+            value (Optional[float]): new value to set
+
+        Returns:
+
+        """
+        pass
+
+    def set_value(self, value, timeout=None):
+        """Set value, checking for minimum change and timeout
+
+        Args:
+            value (float): New value for object
+            timeout (Optional[float]): If set waits up to timeout seconds before return
+
+        Returns:
+
+        """
+
+        if not self.is_valid_value(value):
+            raise ValueError("Invalid value %s" % value)
+        tol = self.value_resolution
+        if tol is not None and value is not None:
+            current_value = self.get_value()
+            if current_value is not None and abs(current_value - value) < tol:
+                return
+        if timeout:
+            if not isinstance(timeout, (int, float)):
+                raise TypeError("Invalid data type for timeout: %s" % timeout)
+            elif timeout < 0:
+                raise ValueError("Negative value for timeout: %s" % timeout)
+        self._set_value(value)
+        self.wait_ready(timeout)
+
+    def set_value_relative(self, increment, timeout=None):
+        """Sets value relative to current value.
+
+        If timeout is set, waits up to timeout for completion.
+
+        Args:
+            increment (float): increment to value
+            timeout (Optional[float]):  non-negative timeout in seconds
+
+        Returns:
+
+        """
+        current_value = self.get_value()
+        if current_value is None:
+            raise ValueError("Cannot increment %s value None" % self.__class__.__name__)
+        self.set_value(current_value + increment, timeout)
+
+    def is_valid_value(self, value):
+        """
+
+        Args:
+            value (Optional[float]): Value to validate
+
+        Returns:
+            bool
+        """
+        if value is not None:
+            lower, upper = self.get_limits()
+            if (lower is not None and value < lower) or (
+                upper is not None and value > upper
+            ):
+                logging.getLogger("HWR").warning(
+                    "%s value %s not in range %s to %s",
+                    self.__class__.__name__,
+                    value,
+                    lower,
+                    upper,
+                )
+                return False
+        return True
+
+    def get_state(self):
+        """Get object state
+
+        Returns:
+            STATE
+        """
+        return self._state
+
+    def set_state(self, state):
+        """Set objetc state and is_ready.
+
+        Any operation (channel, ...) that changes state must call this function
+        as appropriate
+
+        Args:
+            state (STATE): new state
+
+        Returns:
+
+        """
+        previous_state = self._state
+        self._state = state
+        if state != previous_state:
+            self.emit("stateChanged", state)
+            if state in self.READY_STATES:
+                self._ready_event.set()
+            else:
+                self._ready_event.clear()
+
+    def get_limits(self):
+        """Optional value limits
+
+        NB the abstract class will always return limit (None, None)
+
+        Returns:
+            Tuple[Optional[float],Optional[float]]
+        """
+        return self._limits
+
+    def set_limits(self, limits):
+        """ Set limits. Input is as pair of limits, lowerbound, upperbound
+        either of which may be None.
+
+        NB set_limits will raise an error unless a _set_limits function is implemented
+
+        Args:
+            limits Tuple[Optional[float], Optional[float]]:
+
+        Returns:
+            None
+        """
+        self._set_limits(limits)
+        self.emit("limitsChanged", (limits,)
+
+    def _set_limits(self, limits):
+        """ Actual limit-setting function. Raises NotImplementedError unless overwritten
+        Args:
+            limits Tuple[Optional[float], Optional[float]]:
+
+        Returns:
+            None
+        """
+        raise NotImplementedError(
+            "Limis setting not implemented for class %s"
+            % self.__class__.__name__
+        )
+
+    def is_ready(self):
+        """
+        Is HardwareObject ready?
+        :return: bool
+        """
+        return self._ready_event.is_set()
+
+    def wait_ready(self, timeout=None):
+        """
+
+        :param timeout: Optional[float] timeout in seconds. If None wait forever
+        :return:
+        """
+        if timeout or timeout is None:
+            # NB if timeout is 0 do not wait
+            success = self._ready_event.wait(timeout=timeout)
+            if not success:
+                raise RuntimeError("Timeout waiting for status ready")
+
+    def update_values(self):
+        """
+        Reemits all signals
+        :return:
+        """
+        self.emit("limitsChanged", (self.get_limits(),))
+        self.emit("valueChanged", (self.get_value(),))
+        self.emit("stateChanged", (self.get_state(),))

--- a/HardwareObjects/abstract/AbstractTwoState.py
+++ b/HardwareObjects/abstract/AbstractTwoState.py
@@ -8,13 +8,13 @@ from HardwareRepository.BaseHardwareObjects import Device
 from HardwareRepository.TaskUtils import task
 
 
-class AbstractActuator(Device):
+class AbstractTwoState(Device):
 
     (UNKNOWN, IN, OUT, MOVING) = ("unknown", "in", "out", "moving")
 
     def __init__(self, name):
         Device.__init__(self, name)
-        self.actuator_state = AbstractActuator.UNKNOWN
+        self.actuator_state = AbstractTwoState.UNKNOWN
         self.username = "unknown"
         # default timeout - 3 sec
         self._timeout = 3
@@ -25,7 +25,7 @@ class AbstractActuator(Device):
             self.value_changed(self.get_actuator_state(read=True))
 
     def value_changed(self, value):
-        self.actuator_state = self.states.get(value, AbstractActuator.UNKNOWN)
+        self.actuator_state = self.states.get(value, AbstractTwoState.UNKNOWN)
         self.emit("actuatorStateChanged", (self.actuator_state.lower(),))
 
     def get_actuator_state(self, read=False):
@@ -63,9 +63,9 @@ class AbstractActuator(Device):
              wait (bool): wait for the movement to finish
              timeout (float): movement expires after timeout [s]
         """
-        if self.actuator_state == AbstractActuator.IN:
+        if self.actuator_state == AbstractTwoState.IN:
             self.actuator_out(wait, timeout)
-        elif self.actuator_state == AbstractActuator.OUT:
+        elif self.actuator_state == AbstractTwoState.OUT:
             self.actuator_in(wait, timeout)
 
     def getActuatorState(self, read=False):

--- a/HardwareObjects/mockup/AbstractMockActuator.py
+++ b/HardwareObjects/mockup/AbstractMockActuator.py
@@ -1,0 +1,92 @@
+#! /usr/bin/env python
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Example of Transmission HardwareObject using new StandardHardwareObject
+Based on existing HardwarObjects.Transmission
+"""
+
+from __future__ import division, absolute_import
+from __future__ import print_function, unicode_literals
+
+import gevent
+
+from HardwareRepository.HardwareObjects.abstract import AbstractActuator
+
+__credits__ = [" Copyright © 2019 - by MXCuBE collaboration. All rights reserved"]
+__license__ = "LGPLv3+"
+__category__ = "General"
+__author__ = "rhfogh"
+__date__ = "17/05/2019"
+
+
+class AbstractMockActuator(AbstractActuator.AbstractActuator):
+    """MockActuator implementation using new AbstractActuator
+
+    Mock actuators using this superclass require alomost no extra code
+    """
+
+    def __init__(self, name):
+        super(AbstractMockActuator, self).__init__(name)
+
+        self._value = None
+        self._limits = (None, None)
+        self._value_set_delay = 1.0
+
+    def get_value(self):
+        """Get current value
+
+        Returns:
+            Optional[float]
+        """
+        return self._value
+
+    def _set_value(self, value):
+
+        gevent.spawn(self._delayed_set_value, value, self._value_set_delay)
+
+    def _set_limits(self, limits):
+        """Set value limits to (lowerbound, upperlound)
+
+        Args:
+            limits (Tuple[Optional[float], Optional[float]]): limits to set
+
+        Returns:
+
+        """
+        self._limits = tuple(limits)
+        self.emit("limitsChanged", (limits,))
+
+    def _delayed_set_value(self, value, delay):
+        """Set value after delay, to mimick hardware operation
+
+        Args:
+            value (Optional[float]): New value
+            delay (float): delay time in seconds.
+
+        Returns:
+
+        """
+        self.set_state(self.STATE.BUSY)
+        gevent.sleep(delay)
+        self._value = value
+        self.set_state(self.STATE.READY)
+        self.emit("valueChanged", self.value)

--- a/HardwareObjects/mockup/MockupActuator.py
+++ b/HardwareObjects/mockup/MockupActuator.py
@@ -14,13 +14,13 @@ from HardwareRepository.TaskUtils import task
 import logging
 
 from HardwareRepository.TaskUtils import task
-from HardwareRepository.HardwareObjects.abstract.AbstractActuator import (
-    AbstractActuator
+from HardwareRepository.HardwareObjects.abstract.AbstractTwoState import (
+    AbstractTwoState
 )
 
-class MockupActuator(AbstractActuator):
+class MockupActuator(AbstractTwoState):
     def __init__(self, name):
-        AbstractActuator.__init__(self, name)
+        AbstractTwoState.__init__(self, name)
 
     def init(self):
         self.username = self.getProperty("username")

--- a/HardwareObjects/mockup/TransmissionMockup.py
+++ b/HardwareObjects/mockup/TransmissionMockup.py
@@ -1,46 +1,51 @@
-from HardwareRepository.BaseHardwareObjects import Device
+#! /usr/bin/env python
+# encoding: utf-8
+#
+#  Project: MXCuBE
+#  https://github.com/mxcube
+#
+#  This file is part of MXCuBE software.
+#
+#  MXCuBE is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  MXCuBE is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Example of Transmission HardwareObject using new StandardHardwareObject
+Based on existing HardwarObjects.Transmission
+"""
+
+from __future__ import division, absolute_import
+from __future__ import print_function, unicode_literals
+
+from HardwareRepository.HardwareObjects.mockup import AbstractMockActuator
+
+__credits__ = [" Copyright © 2019 -  by MXCuBE collaboration. All rights reserved"]
+__license__ = "LGPLv3+"
+__category__ = "General"
+__author__ = "rhfogh"
+__date__ = "17/05/2019"
 
 
-class TransmissionMockup(Device):
-    def __init__(self, name):
-        Device.__init__(self, name)
+class TransmissionMockup(AbstractMockActuator.AbstractMockActuator):
+    """MockTransmission implementation using new AbstractMockActuator
+    """
 
-        self.labels = []
-        self.bits = []
-        self.attno = 0
-        self.getValue = self.get_value
-        self.value = 100
+    # Note that all the rest of the code is in the superclass!
 
     def init(self):
-        pass
-
-    def getAttState(self):
-        return 0
-
-    def getAttFactor(self):
-        return self.value
-
-    def setAttFactor(self, value):
-        self.value = value
-        self.emit("valueChanged", self.value)
-
-    def get_value(self):
-        return self.getAttFactor()
-
-    def set_value(self, value):
-        self.setAttFactor(value)
-
-    def connected(self):
-        self.setIsReady(True)
-
-    def disconnected(self):
-        self.setIsReady(False)
-
-    def attStateChanged(self, channelValue):
-        pass
-
-    def attFactorChanged(self, channelValue):
-        pass
-
-    def isReady(self):
-        return True
+        # NB should be set from configuration
+        self.value_resolution = 0.01
+        self._limits = (0, 100)
+        self._value_set_delay = 2.0
+        self._value = 100
+        self._state = self.STATE.READY


### PR DESCRIPTION
Replaces the previous AbstractActuator PR.

- The previous AbstractActuator class has been renamed AbstractTwoState, with subclasses modified accordingly. It should be refactored by someone in the longer term, probably based on AbstractNState

- AbstractActuator is now the new supercalass for aall motors and objects with a value. It still needs to be given a set of generally aspplicable states - can anyone help?

- AbstractMockActuator is an abstract mock object that contains all necessary code for a mock actuator except for setting the mock initial values. Transmission Mockup shows how that will look in practice

- ExporterMotorExample is a proposal for  how ExporterMotor could be written with the new superclass, as an example. I  am not competent to rewrite such a hardware-linked class, and I have no way of testing it. Could someone please help out? 

- There is some minor refactoring in BaseHardwareObjects to facilitate use of ConfiguredObject in the future.