### PR TITLE
Bug fixes to make detector.distance and microscope links work

### DIFF
--- a/HardwareObjects/QtGraphicsManager.py
+++ b/HardwareObjects/QtGraphicsManager.py
@@ -82,6 +82,13 @@ class QtGraphicsManager(HardwareObject):
         """
         HardwareObject.__init__(self, name)
 
+        # FIXME! HORROR! HACK!
+        # After recent refactorings functions from this class are sometimes
+        # referenced as beamline.microscope, sometimes as
+        # beamline.microscope.shapes, This hack is NECESSARY to get te program to run
+        # FIXME FIXME
+        self.shapes = self
+
         self.camera_hwobj = None
 
         self.graphics_config_filename = None

--- a/HardwareObjects/abstract/AbstractDetector.py
+++ b/HardwareObjects/abstract/AbstractDetector.py
@@ -168,10 +168,10 @@ class AbstractDetector(object):
 
 
     @property
-    def detector_distance(self):
+    def distance(self):
         """Property for contained detector_distance hwobj
 
-        NBNB Temnporary hack. This should eb configured pro[perly
+        NBNB Temnporary hack. This should be configured properly
 
         Returns:
             AbstratctActuator

--- a/configuration/xml-qt/beamline_config.yml
+++ b/configuration/xml-qt/beamline_config.yml
@@ -38,7 +38,7 @@ _objects:
     # NBNB TODO remove plate_manipulater and treat as another smaple changer
     - plate_manipulator: plate-manipulator.xml
     - diffractometer: mini-diff-mockup.xml
-    - graphics: graphics.xml
+    - microscope: graphics.xml
     - lims: lims-client-mockup.xml
     - queue_manager: queue.xml
     - queue_model: queue-model.xml


### PR DESCRIPTION
Bug fixes - changes required to make program run under Qt with recent changes (graphics->microscope and detector.detector_distance -> detector,distance).
Goes together with parallel PR in mxcube

WARNING - access to microscope and microscope.shapes is *inconsistent*!
Functions that live in QtGraphics manager are sometimes addressed through HWR.beamline.microscope, sometimes through HWR.beamline.microscope.shapes. 
This needs REFACTORING, so that the HWO organisation is the same in the Qt and Web branches, and so that the functions can be accessed in a uniform manner for both UIs.

For now the PR contains a TEMPORARY UGLY HACK, setting
QtGraphicsManager.shapes = self.