### PR TITLE
Minor update to ISPyBClientMockup

### DIFF
--- a/HardwareObjects/mockup/ISPyBClientMockup.py
+++ b/HardwareObjects/mockup/ISPyBClientMockup.py
@@ -33,11 +33,13 @@ class ISPyBClientMockup(HardwareObject):
         self.__test_proposal = None
         self.loginType = None
         self.base_result_url = None
+        self.lims_rest = None
 
     def init(self):
         """
         Init method declared by HardwareObject.
         """
+        self.lims_rest = self.getObjectByRole("lims_rest")
         self.authServerType = self.getProperty("authServerType") or "ldap"
         if self.authServerType == "ldap":
             # Initialize ldap


### PR DESCRIPTION
Making the necessary changes to ISPyBClientMockup so that it corresponds to the real object (now containing a ISPYBRestClient reference as lims_rest)

Marcus