### PR TITLE
Changed AbstractProcedure so that it uses data classes in Python3 and dictionaries in Python2

### DIFF
--- a/HardwareObjects/Beamline.py
+++ b/HardwareObjects/Beamline.py
@@ -50,7 +50,7 @@ class Beamline(ConfiguredObject):
 
     # Names of procedures under Beamline - set of sttrings.
     # NB subclasses must add additional parocedures to this set,
-    # and may NOT override _procdeure_names
+    # and may NOT override _procedure_names
     _procedure_names = set()
 
     # NBNB these should be accessed ONLY as beamline.SUPPORTED_..._PARAMETERS
@@ -529,6 +529,14 @@ class Beamline(ConfiguredObject):
     __content_roles.append("image_tracking")
 
     # Procedures
+
+    @property
+    def mock_procedure(self):
+        """
+        """
+        return self._objects.get("mock_procedure")
+
+    __content_roles.append("mock_procedure")
 
     # NB this is just an example of a globally shared procedure description
     @property

--- a/HardwareObjects/abstract/AbstractProcedure.py
+++ b/HardwareObjects/abstract/AbstractProcedure.py
@@ -17,10 +17,14 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE. If not, see <http://www.gnu.org/licenses/>.
 import logging
-import gevent
+from enum import IntEnum, unique
+
+import gevent.event
 
 from HardwareRepository.BaseHardwareObjects import ConfiguredObject
 from HardwareRepository.dispatcher import dispatcher
+
+#import HardwareRepository.HardwareObjects.datamodel
 
 # Using jsonschma for validating the JSCONSchemas
 # https://json-schema.org/
@@ -32,38 +36,58 @@ from jsonschema import (validate, ValidationError)
 __credits__ = ["MXCuBE collaboration"]
 
 
+# Temporary definition should use common denfinition from
+# HardwareObject
 @unique
 class ProcedureState(IntEnum):
     """
     Defines the valid Procedure states
     """
-    FAILED = 0
-    RUNNING = 1
-    SUCCESFUL = 2
-    IDLE = 3
+    ERROR = 0
+    BUSY = 1
+    READY = 3
 
 
 class AbstractProcedure(ConfiguredObject):
-
     __content_roles = []
 
-    _ALLOW_PARALLEL = False
+    _ARGS_CLASS = ()
+    _KWARGS_CLASS = {}
+    _RESULT_CLASS = ()
 
-    # JSONSchema used for input and output validation and possibly
-    # form generation.
-    # https://json-schema.org/
-    # Needs to be defined by each subclass
-    _ARG_SCHEMA = None
-    _RESULT_SCHEMA = None
+    @staticmethod
+    def set_args_class(args_class, kwargs_class):
+        """
+        Sets the types of the data models used as arguments, cane be used to
+        set the argument classes runtime if the models are built dynamically,
+        i.e based on configuration not known before
+
+        Args:
+            args_class (tuple[BaseModel]) tuple of classes for args
+            kwargs_class (dict[[str]: [BaseModel]]) dictionary containing BaseModels
+        """
+        AbstractProcedure._ARGS_CLASS = args_class
+        AbstractProcedure._KWARGS_CLASS = kwargs_class
+
+    @staticmethod
+    def set_result_class(_result_class):
+        """
+        Sets the types of the data models returned by the Procedure, can
+        be used to set the result model runtime of the data model is built
+        dynamically, i.e based on configuration not known before
+
+        Returns:
+            (tuple[BaseModel]) tuple of classes for args
+        """
+        AbstractProcedure._RESULT_CLASS = _result_class
 
     def __init__(self, name):
         super(AbstractProcedure, self).__init__(name)
-
         self._msg=None
         self._results=None
         self._ready_event = gevent.event.Event()
         self._task=None
-        self._state = ProcedureState.IDLE
+        self._state = ProcedureState.READY
 
         # YML configuration options
         # Category that the Procedure belongs to, configurable through
@@ -82,9 +106,9 @@ class AbstractProcedure(ConfiguredObject):
         Override to implement main task logic
 
         Args:
-            data_model: Immutable data model, frozen dict in
-            Python 2.7 and Data class in Python 3.7. Input validated
-            by schema defined in _ARG_SCHEMA
+            data_model: sub class of HardwareRepository.HardwareObjects.datamodel
+            dict in Python 2.7 and Data class in Python 3.7. Data is validated
+            by the data_model object
 
         Returns:
         """
@@ -95,9 +119,9 @@ class AbstractProcedure(ConfiguredObject):
         Override to implement pre execute task logic
 
         Args:
-            data_model: Immutable data model, frozen dict in
-            Python 2.7 and Data class in Python 3.7. Input validated
-            by schema defined in _ARG_SCHEMA
+            data_model: sub class of HardwareRepository.HardwareObjects.datamodel
+            dict in Python 2.7 and Data class in Python 3.7. Data is validated
+            by the data_model object
 
         Returns:
         """
@@ -108,9 +132,9 @@ class AbstractProcedure(ConfiguredObject):
         Override to implement post execute task logic
 
         Args:
-            data_model: Immutable data model, frozen dict in
-            Python 2.7 and Data class in Python 3.7. Input validated
-            by schema defined in _ARG_SCHEMA
+            data_model: sub class of HardwareRepository.HardwareObjects.datamodel
+            dict in Python 2.7 and Data class in Python 3.7. Data is validated
+            by the data_model object
 
         Returns:
         """
@@ -122,7 +146,7 @@ class AbstractProcedure(ConfiguredObject):
         Returns:
 
         """
-        self._state = ProcedureState.RUNNING
+        self._state = ProcedureState.BUSY
         dispatcher.send(self, "procedureStarted")
 
     def _set_successful(self):
@@ -131,17 +155,17 @@ class AbstractProcedure(ConfiguredObject):
         Returns:
 
         """
-        self._state = ProcedureState.SUCCESFUL
+        self._state = ProcedureState.READY
         dispatcher.send(self, "procedureSuccessful", self.results)
 
-    def _set_failed(self):
+    def _set_error(self):
         """
-        Emits procedureFailed signal
+        Emits procedure error signal
         Returns:
 
         """
-        self._state = ProcedureState.FAILED
-        dispatcher.send(self, "procedureFailed", self.msg)
+        self._state = ProcedureState.ERROR
+        dispatcher.send(self, "procedureError", self.msg)
 
     def _set_stopped(self):
         """
@@ -149,7 +173,7 @@ class AbstractProcedure(ConfiguredObject):
         Returns:
 
         """
-        self._state = ProcedureState.FAILED
+        self._state = ProcedureState.READY
         dispatcher.send(self, "procedureStopped", self.results)
 
     def _start(self, data_model):
@@ -157,46 +181,48 @@ class AbstractProcedure(ConfiguredObject):
         Internal start, for the moment executed in greenlet
         """
         try:
-            # The _pre_execute have been removed and can be done within
-            # execute if needed
+            self._set_started()
             self._pre_execute(data_model)
             self._execute(data_model)
         except Exception as ex:
-            self._state = ProcedureState.FAILED
-            self._msg = "Procedure execution failed (%s)" % str(ex)
-            logging.getLogger("HWR").error(self._msg)
+            self._state = ProcedureState.ERROR
+            self._msg = "Procedure execution error (%s)" % str(ex)
+            logging.getLogger("HWR").exception(self._msg)
         finally:
             try:
                 self._post_execute(data_model)
             except Exception as ex:
-                self._state = ProcedureState.FAILED
-                self._msg = "Procedure post_execute failed (%s)" % str(ex)
-                logging.getLogger("HWR").error(self._msg)
+                self._state = ProcedureState.ERROR
+                self._msg = "Procedure post_execute error (%s)" % str(ex)
+                logging.getLogger("HWR").exception(self._msg)
 
-            self.ready_event.set()
+            self._ready_event.set()
 
-            if self._state ==  ProcedureState.FAILED:
-                self._set_failed()
+            if self._state == ProcedureState.ERROR:
+                self._set_error()
             else:
                 self._set_successful()
 
     @property
     def argument_schema(self):
         """
-        Schema for argument passed to start
+        Schema for arguments passed to start
         Returns:
-            str (JSONSchema)
+            dict{"args": tuple[JSONSchema], "kwargs": key: [JSONSchema]}
         """
-        return self._ARG_SCHEMA
+        return {
+            "args": tuple([s.schema_json() for s in self._ARGS_CLASS]),
+            "kwargs": {key:value.schema_json() for (key, value) in self._KWARGS_CLASS.items()}
+        }
 
     @property
     def result_schema(self):
         """
         Schema for result
         Returns:
-            str (JSONSchema)
+            tuple[JSONSchema]
         """
-        return self._RESULT_SCHEMA
+        return (s.schema_json() for s in self._RESULT_CLASS)
 
     @property
     def msg(self):
@@ -225,8 +251,6 @@ class AbstractProcedure(ConfiguredObject):
         Returns:
             DataClass or frozendict
         """
-        if self._RESULT_SCHEMA:
-            validate(self._results, schema=self._RESULT_SCHEMA)
 
         return self._results
 
@@ -234,22 +258,20 @@ class AbstractProcedure(ConfiguredObject):
         """
         Starts procedure
         Args:
-            data_model: Immutable data model, frozen dict in
-            Python 2.7 and Data class in Python 3.7. Input validated
-            by schema defined in _ARG_SCHEMA
+            data_model: sub class of HardwareRepository.HardwareObjects.datamodel
+            dict in Python 2.7 and Data class in Python 3.7. Data is validated
+            by the data_model object
 
         Returns:
-            None
+            (Greenlet) The gevent task
         """
-        # This raises a ValidationException if validation fails
-        if self._ARG_SCHEMA:
-            validate(instance=data_model, schema=self._ARG_SCHEMA)
-
-        if not self._ALLOW_PARALLEL and self.is_running:
+        if self._state != ProcedureState.READY:
             self._msg = "Procedure (%s) is already running" % str(self)
             logging.getLogger("HWR").error(self._msg)
         else:
             self._task = gevent.spawn(self._start, data_model)
+
+        return self._task
 
     def stop(self):
         """
@@ -258,4 +280,14 @@ class AbstractProcedure(ConfiguredObject):
             None
         """
         gevent.kill(self._task)
-        self._set_procedure_stopped()
+        self._set_stopped()
+
+
+    def wait(self):
+        """
+        Waits for procedure to finish execution
+
+        Returns:
+            None
+        """
+        self._ready_event.wait()

--- a/HardwareObjects/datamodel/__init__.py
+++ b/HardwareObjects/datamodel/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+import sys
+import pkgutil
+
+if sys.version_info <= (2, 8):
+    from . data_model_py2 import *
+else:
+    from . data_model_py3 import *

--- a/HardwareObjects/datamodel/common.py
+++ b/HardwareObjects/datamodel/common.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+class ValidationError(Exception):
+    pass

--- a/HardwareObjects/datamodel/data_model_py2.py
+++ b/HardwareObjects/datamodel/data_model_py2.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import jsonschema
+
+from . common import ValidationError
+
+class BaseModel(dict):
+    _SCHEMA = ""
+
+    def __init__(self, *args, **kwargs):
+        super(BaseModel, self).__init__(*args, **kwargs)
+
+        if self._SCHEMA:
+            try:
+                jsonschema.validate(instance=self, schema=self._SCHEMA)
+            except jsonschema.exceptions.ValidationError as ex:
+                raise ValidationError(ex)
+
+    __getattr__ = dict.__getitem__
+
+    @property
+    def schema_json(self):
+        return self._SCHEMA
+
+
+class MockDataModel(BaseModel):
+    """
+    Example DataModel used by the MockProcedure (for testing)
+    """
+    # Not defining any attributes as it is a dictionary
+    # but it needs to exist so that the type exists

--- a/HardwareObjects/datamodel/data_model_py3.py
+++ b/HardwareObjects/datamodel/data_model_py3.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from enum import Enum
+from . common import ValidationError
+
+import pydantic
+from pydantic import Field
+
+
+class BaseModel(pydantic.BaseModel):
+    def __init__(self, *args, **kwargs):
+        try:
+            super(BaseModel, self).__init__(*args, **kwargs)
+        except Exception as ex:
+            raise ValidationError(ex)
+
+
+class MockDataModel(BaseModel):
+    """
+    Example DataModel used by the MockProcedure (for testing)
+    """
+    transmission: float = Field(0)
+    energy: float = Field(0)
+    resolution: float = Field(0)
+    exposure_time: float = Field(0)
+    number_of_images: float = Field(0)

--- a/HardwareObjects/mockup/MockProcedure.py
+++ b/HardwareObjects/mockup/MockProcedure.py
@@ -1,0 +1,18 @@
+import gevent
+import HardwareRepository.HardwareObjects.datamodel
+
+from HardwareRepository.HardwareObjects.abstract.AbstractProcedure import (
+    AbstractProcedure
+)
+
+import HardwareRepository.HardwareObjects.datamodel as datamodel
+
+class MockProcedure(AbstractProcedure):
+    _ARGS_CLASS = (datamodel.MockDataModel, )
+
+    def __init__(self, name):
+        super(MockProcedure, self).__init__(name)
+
+    def _execute(self, data_model):
+        print(f"Procedure will sleep for {data_model.exposure_time}")
+        gevent.sleep(data_model.exposure_time)

--- a/configuration/test/beamline_config.yml
+++ b/configuration/test/beamline_config.yml
@@ -55,6 +55,7 @@ _objects:
     #- online_processing: parallel-processing.xml
     #- characterisation: data-analysis.xml
     # - beam_realign: # Skipped - optional
+    - mock_procedure: mock_procedure.yml
 # Non-object attributes:
 advanced_methods:
   - MeshScan
@@ -69,7 +70,7 @@ default_acquisition_parameters:
         # Default values, also used for standard acquisition.
         # Values not given in other dictionaries are taken from here
         exp_time: 0.04              # (s) exposure time
-        osc_start: 0.0            # (degrees) Only used if no current angle found
+        osc_start: 0.0              # (degrees) Only used if no current angle found
         osc_range: 0.1              # (degrees)
         num_passes: 1               # (int)
         first_image: 1              # (int)

--- a/configuration/test/mock_procedure.yml
+++ b/configuration/test/mock_procedure.yml
@@ -1,0 +1,3 @@
+# The class to initialise, and init parameters
+_initialise_class:
+    class: HardwareRepository.HardwareObjects.mockup.MockProcedure.MockProcedure

--- a/requirements_python3.txt
+++ b/requirements_python3.txt
@@ -9,6 +9,8 @@ scipy
 matplotlib
 Pillow
 pylint
+jsonschema
+pydantic
 # f90nml, mgen, and py4j are required for GPhL Workflow and emulation
 # f90nml
 # mgen

--- a/test/pytest/conftest.py
+++ b/test/pytest/conftest.py
@@ -10,10 +10,10 @@ sys.path.insert(0, MXCUBE_DIR)
 
 from HardwareRepository import HardwareRepository as HWR
 
-hwr_qt_path = os.path.join(HWR_DIR, "configuration/test")
-HWR.init_hardware_repository(hwr_qt_path)
-hwr_qt = HWR.getHardwareRepository()
-hwr_qt.connect()
+hwr_path = os.path.join(HWR_DIR, "configuration/test")
+HWR.init_hardware_repository(hwr_path)
+hwr = HWR.getHardwareRepository()
+hwr.connect()
 
 @pytest.fixture(scope="session")
 def beamline():

--- a/test/pytest/test_procedure.py
+++ b/test/pytest/test_procedure.py
@@ -1,0 +1,28 @@
+import gevent
+from HardwareRepository.HardwareObjects import datamodel
+from HardwareRepository.HardwareObjects.abstract.AbstractProcedure import ProcedureState
+
+
+def test_procedure_init(beamline):
+    assert beamline.mock_procedure is not None, "MockProcedure hardware objects is None (not initialized)"
+    # The methods are defined with abc.abstractmethod which will raise
+    # an exception if the method is not defined. So there is no need to test for
+    # the presence of each method
+
+
+def test_procedure_start(beamline):
+    data = datamodel.MockDataModel(**{"exposure_time": 5})
+    beamline.mock_procedure.start(data)
+    gevent.sleep(1)
+    assert beamline.mock_procedure.state == ProcedureState.BUSY
+    beamline.mock_procedure.wait()
+    assert beamline.mock_procedure.state == ProcedureState.READY
+
+
+def test_procedure_stop(beamline):
+    data = datamodel.MockDataModel(**{"exposure_time": 5})
+    beamline.mock_procedure.start(data)
+    gevent.sleep(1)
+    assert beamline.mock_procedure.state == ProcedureState.BUSY
+    beamline.mock_procedure.stop()
+    assert beamline.mock_procedure.state == ProcedureState.READY


### PR DESCRIPTION
Dear all,

Updated the AbstractProcedure according to the conclusions of the developers meeting.

- Mainly making it possible to user either data classes (for Python 3) or using dictionaries                
  (for Python 2)
- Using the commonly agreed names for the states defined as ProcedureState. ProcedureState will disappear as the state definition is inherited from HardwareObject, but that PR is not merged yet so ProcedureState serves as a placeholder.

The data models are stored in the datamodels sub folder and the correct module is imported depending on python version. The data models are for simplicity kept in two separate files with the _py[version] suffix but this could be changed to folders if one would like some hierarchical structure.

The Python 2 data model is simply a dict with the possibility access keys with the "." operator and the possibility to define a JSON schema that describes the data.

Cheers,
Marcus