### PR TITLE
Using QGraphicsScene coordinates rather than QGraphicsView ones

### DIFF
--- a/HardwareObjects/QtGraphicsLib.py
+++ b/HardwareObjects/QtGraphicsLib.py
@@ -2759,7 +2759,7 @@ class GraphicsCameraFrame(QtImport.QGraphicsPixmapItem):
         :param event:
         :return:
         """
-        position = QtImport.QPointF(event.pos())
+        position = QtImport.QPointF(event.scenePos())
         self.scene().mouseClickedSignal.emit(
             position.x(), position.y(), event.button() == QtImport.Qt.LeftButton
         )
@@ -2771,7 +2771,7 @@ class GraphicsCameraFrame(QtImport.QGraphicsPixmapItem):
         :param event:
         :return:
         """
-        position = QtImport.QPointF(event.pos())
+        position = QtImport.QPointF(event.scenePos())
         self.scene().mouseDoubleClickedSignal.emit(position.x(), position.y())
         self.update()
 
@@ -2781,6 +2781,6 @@ class GraphicsCameraFrame(QtImport.QGraphicsPixmapItem):
         :param event:
         :return:
         """
-        position = QtImport.QPointF(event.pos())
+        position = QtImport.QPointF(event.scenePos())
         self.scene().mouseReleasedSignal.emit(position.x(), position.y())
         self.update()


### PR DESCRIPTION
Bug discovered using CameraBrick.py
If HWR.beamline.microscope <=> QtGraphicsManager then
The widget to display images is :
QtGraphicsManager.graphics_view and the scene, the GraphicsView.graphics_scene 

When the widget is 'small' and fits the scene surface (and not more), their coordinates ( QGraphicsView's and QGraphicScene's ) are visually the same, but if the view is bigger than the scene, there's a delta between them ( ex: GraphicsItemCentringLines drawn far from the mouse position ).
One solution to fix this: all the positions related to scene's coordinates