### PR TITLE
[WIP] Simplified version of AbstractNState

### DIFF
--- a/HardwareObjects/Microdiff.py
+++ b/HardwareObjects/Microdiff.py
@@ -430,7 +430,7 @@ class Microdiff(MiniDiff.MiniDiff):
             "phiz": float(self.phizMotor.get_value()),
             "sampx": float(self.sampleXMotor.get_value()),
             "sampy": float(self.sampleYMotor.get_value()),
-            "zoom": self.zoomMotor.get_value(),
+            "zoom": self.zoomMotor.get_value().value,
             "kappa": float(self.kappaMotor.get_value())
             if self.in_kappa_mode()
             else None,


### PR DESCRIPTION
Dear all,

This is a simplified version of the AbstractNState object, it simply provides the means to define
N discrete states that needs to be defined in the subclass. I've made an example implementation for the micro diffractometer zoom (testing with the BZoom). 

It's not as flexible and configurable as the original version but is simpler and provides perhaps a more well defined interface. Objects like shutters or beam stops then have to be implemented as separate objects with clearly defined open/closed in/out states the values however needs to be mapped to the actual hardware.

Marcus

