### PR TITLE
WIP Abstract classes clarifications - for discussion at code camp

### DIFF
--- a/BaseHardwareObjects.py
+++ b/BaseHardwareObjects.py
@@ -382,9 +382,9 @@ class HardwareObjectMixin(CommandContainer):
         self.connect_dict = {}
 
         # event to handle waiting for object to be ready
-        self._ready_event = event.Event()
-        self._state = self.STATES.UNKNOWN
-        self._specific_state = None
+        self.__ready_event = event.Event()
+        self.__state = self.STATES.UNKNOWN
+        self.__specific_state = None
 
     def __bool__(self):
         return True
@@ -418,7 +418,7 @@ class HardwareObjectMixin(CommandContainer):
         Returns:
             HardwareObjectState
         """
-        return self._state
+        return self.__state
 
     def get_specific_state(self):
         """ Getter for specific_state attribute. Override if needed.
@@ -426,7 +426,7 @@ class HardwareObjectMixin(CommandContainer):
         Returns:
             HardwareObjectSpecificState or None
         """
-        return self._specific_state
+        return self.__specific_state
 
     def wait_ready(self, timeout=None):
         """Wait timeout seconds till object is ready.
@@ -439,7 +439,7 @@ class HardwareObjectMixin(CommandContainer):
         Returns:
         """
         with Timeout(timeout, RuntimeError("Timeout waiting for status ready")):
-            self._ready_event.wait(timeout=timeout)
+            self.__ready_event.wait(timeout=timeout)
 
     def is_ready(self):
         """Convenience function: Check if the object state is READY.
@@ -447,7 +447,7 @@ class HardwareObjectMixin(CommandContainer):
         Returns:
             (bool): True if ready, otherwise False.
         """
-        return self._ready_event.is_set()
+        return self.__ready_event.is_set()
 
     def update_state(self, state=None):
         """Check if the state has changed. Emits signal stateChanged.
@@ -456,16 +456,16 @@ class HardwareObjectMixin(CommandContainer):
         """
         if state is None:
             state = self.get_state()
-        if state != self._state:
+        if state != self.__state:
             if state == self.STATES.READY:
-                self._ready_event.set()
+                self.__ready_event.set()
             elif not isinstance(state, self.STATES):
                 raise ValueError("Attempt to update to illegal state: %s" % state)
             else:
-                self._ready_event.clear()
+                self.__ready_event.clear()
 
-            self._state = state
-            self.emit("stateChanged", (self._state,))
+            self.__state = state
+            self.emit("stateChanged", (self.__state,))
 
     def update_specific_state(self, state=None):
         """Check if the specific state has changed. Emits signal stateChanged.
@@ -474,11 +474,11 @@ class HardwareObjectMixin(CommandContainer):
         """
         if state is None:
             state = self.get_specific_state()
-        if state != self._specific_state:
+        if state != self.__specific_state:
             if not isinstance(state, self.SPECIFIC_STATES):
                 raise ValueError("Attempt to update to illegal specific state: %s" % state)
 
-            self._specific_state = state
+            self.__specific_state = state
             self.emit("specificStateChanged", (state,))
 
     def update_values(self):

--- a/HardwareObjects/BlissMotor.py
+++ b/HardwareObjects/BlissMotor.py
@@ -104,9 +104,9 @@ class BlissMotor(AbstractMotor):
                 state = "UNKNOWN"
 
         try:
-            self._specific_state = BlissMotorStates.__members__[state]
+            self.update_specific_state(BlissMotorStates.__members__[state])
         except:
-            self._specific_state = BlissMotorStates.__members__["UNKNOWN"]
+            self.update_specific_state(BlissMotorStates.__members__["UNKNOWN"])
 
         AbstractMotor.update_state(
             self, self.SPECIFIC_TO_HWR_STATE.get(state, HardwareObjectState.UNKNOWN)

--- a/HardwareObjects/ExporterMotor.py
+++ b/HardwareObjects/ExporterMotor.py
@@ -167,8 +167,9 @@ class ExporterMotor(AbstractMotor):
         Returns:
             (float): Motor position.
         """
-        self._nominal_value = self.motor_position.get_value()
-        return self._nominal_value
+        value = self.motor_position.get_value()
+        self.update_value(value)
+        return value
 
     def __get_limits(self, cmd):
         """Returns motor low and high limits.

--- a/HardwareObjects/abstract/AbstractEnergy.py
+++ b/HardwareObjects/abstract/AbstractEnergy.py
@@ -124,9 +124,8 @@ class AbstractEnergy(AbstractActuator):
 
         if value is None:
             value = self.get_value()
-        self._nominal_value = value
 
         if not self._wavelength_value:
             self._wavelength_value = self._calculate_wavelength(value)
+        super(AbstractEnergy, self).update_value(value)
         self.emit("energyChanged", (value, self._wavelength_value))
-        self.emit("valueChanged", (value,))

--- a/HardwareObjects/abstract/AbstractMotor.py
+++ b/HardwareObjects/abstract/AbstractMotor.py
@@ -102,7 +102,7 @@ class AbstractMotor(AbstractActuator):
         """
         if math.isnan(value) or math.isinf(value):
             return False
-        limits = self._nominal_limits
+        limits = self.get_limits()
         if None in limits:
             return True
         return limits[0] <= value <= limits[1]
@@ -112,15 +112,13 @@ class AbstractMotor(AbstractActuator):
         Args:
             value (float): value
         """
-        if self._nominal_value is None:
-            self._nominal_value = self.get_value()
 
         if value is None:
             value = self.get_value()
 
-        if self._tolerance:
-            if abs(value - self._nominal_value) <= self._tolerance:
+        nominal_value = self.get_nominal_value()
+        if self._tolerance and value is not None and nominal_value is not None:
+            if abs(value - nominal_value) <= self._tolerance:
                 return
 
-        self._nominal_value = value
-        self.emit("valueChanged", (self._nominal_value,))
+        super(AbstractMotor, self).update_value(value)

--- a/HardwareObjects/abstract/AbstractTransmission.py
+++ b/HardwareObjects/abstract/AbstractTransmission.py
@@ -38,7 +38,6 @@ class AbstractTransmission(AbstractMotor):
 
         self._value = None
         self._limits = [0, 100]
-        self._state = None
 
     @abc.abstractmethod
     def _set_value(self, value):

--- a/HardwareObjects/mockup/MotorMockup.py
+++ b/HardwareObjects/mockup/MotorMockup.py
@@ -48,6 +48,7 @@ class MotorMockup(AbstractMotor):
 
     def __init__(self, name):
         AbstractMotor.__init__(self, name)
+        self.get_value = self.get_nominal_value
 
     def init(self):
         """
@@ -95,13 +96,6 @@ class MotorMockup(AbstractMotor):
         """Imediately halt movement. By default self.stop = self.abort"""
         if self.__move_task is not None:
             self.__move_task.kill()
-
-    def get_value(self):
-        """Read the actuator position.
-        Returns:
-            float: Actuator position.
-        """
-        return self._nominal_value
 
     def _set_value(self, value):
         """

--- a/HardwareObjects/mockup/ResolutionMockup.py
+++ b/HardwareObjects/mockup/ResolutionMockup.py
@@ -7,4 +7,4 @@ class ResolutionMockup(Resolution):
 
     def init(self):
         super(ResolutionMockup, self).init()
-        self._nominal_value = self.default_value
+        self.update_value(self.default_value)

--- a/HardwareObjects/mockup/ShutterMockup.py
+++ b/HardwareObjects/mockup/ShutterMockup.py
@@ -41,21 +41,19 @@ class ShutterMockup(AbstractActuator.AbstractActuator):
     def __init__(self, name):
         super(ShutterMockup, self).__init__(name)
         # self.current_state = ShutterMockup.STATE.OPEN
+        self.get_value = self.get_nominal_value
 
     def init(self):
         super(ShutterMockup, self).init()
         if self.default_value is None:
             raise Exception("Ka-BOOM!")
-        self._nominal_value = getattr(self.VALUES, self.default_value)
-        self._state = self.STATES.READY
-
-    def get_value(self):
-        return self._nominal_value
+        self.update_value(getattr(self.VALUES, self.default_value))
+        self.update_state(self.STATES.READY)
 
     def _set_value(self, value):
         self.update_state(self.STATES.BUSY)
         time.sleep(random.uniform(0.1, 1.0))
-        self._nominal_value = value
+        self.update_value(value)
         self.update_state(self.STATES.READY)
 
     def validate_value(self, value):


### PR DESCRIPTION
This WIP changes AbstractActuator, AbstractMotor, and  HardwareObjectMixin. I have made the consequential changes in a number of other classes, to show how this would work, but if we agreed on this we would have to extend it to many other classes. The PR is applied on top of PR #495.


Currently it it is not always clear (certainly to me) which function and which class a certain behaviour belongs in. These changes should make the resulting code more uniform and so easier to maintain, which could be important, since we are now about to make a major refactoring. This is to some extent going back on changes I insisted on earlier, for which I apologise.


The general idea is that:

 - The internal attribtues should be managed *only* in AbstractActuator and HardwareObjectMicxin, where they are defined.
 - Subclasses should have *sole* responsibility for implementing get_value and \_set_value, 
 - Internal attributes are modified only by caliling the update_something functions, and it is the responsibility of the subclasses to call those when needed.

Specifically the changes are:
- Make the following attribute '__double_underscore:
   - HardwareObjectMixin.__ready_event
   - HardwareObjectMixin.__state
   - HardwareObjectMixin.__specific_state
   - AbstractActuator.__nominal_value
   - AbstractActuator.__nominal_limits

 - Remove the call to self.update_value() from AbstractActuator.set_value()

 - Add AbstractActuator.get_nominal_value

 - Replace direct access to internal attributes with function calls