### PR TITLE
Protect from nested raise exception

### DIFF
--- a/HardwareObjects/InstanceServer.py
+++ b/HardwareObjects/InstanceServer.py
@@ -65,9 +65,13 @@ class InstanceServer(Procedure):
 
     def initialize_instance(self):
         for widget in QtImport.QApplication.allWidgets():
-            if hasattr(widget, "configuration"):
-                self.guiConfiguration = widget.configuration
-                break
+            try:
+                if hasattr(widget, "configuration"):
+                    self.guiConfiguration = widget.configuration
+                    break
+            except NameError:
+                logging.getLogger().warning("Widget {} has no attribute {}"
+                                            .format(widget, "configuration"))
 
         self.emit("instanceInitializing", ())
         if self.isLocal():


### PR DESCRIPTION
If widget is an objectof type pyqtgraph.widgets.PlotWidget.PlotWidget
and the target attribute in hasattr does not exists a NameError exception
is raised.