### PR TITLE
MicrodiffAperture inherit from ExporterNState instead of ExporterMotor.

### DIFF
--- a/HardwareObjects/MicrodiffAperture.py
+++ b/HardwareObjects/MicrodiffAperture.py
@@ -65,6 +65,16 @@ class MicrodiffAperture(ExporterNState):
         if self.inout_obj:
             self._initialise_inout()
 
+    def _set_value(self, value):
+        """Set device to value
+        Args:
+            value (str, int, float or enum): Value to be set.
+        """
+        if value.name in ("IN", "OUT"):
+            self.inout_obj.set_value(value, timeout=60)
+        else:
+            super(MicrodiffAperture, self)._set_value(value)
+
     def _initialise_inout(self):
         """Add IN and OUT to the values Enum"""
         values_dict = {item.name: item.value for item in self.inout_obj.VALUES}

--- a/HardwareObjects/MicrodiffAperture.py
+++ b/HardwareObjects/MicrodiffAperture.py
@@ -28,7 +28,7 @@ Example xml file:
   <state_channel_name>State</state_channel_name>
   <-- either only factor -->
   <factor>(0.15, 0.3, 0.63, 0.9, 0.96)</factor>
-  <!-- or complete, corresponding to label: (index, size[mm], factor) -->
+  <!-- or complete, corresponding to label: (index, size[um], factor) -->
   <values>{"A10": (0, 10, 0.15), "A20": (1, 20, 0.3), "A30": (2, 30, 0.63), "A50": (3, 50, 0.9), "A75": (4, 75, 0.96)}</values>
 </object>
 """
@@ -44,7 +44,7 @@ __license__ = "LGPLv3+"
 class MicrodiffAperture(ExporterNState):
     """MicrodiffAperture class"""
 
-    unit = "mm"
+    unit = "um"
 
     def __init__(self, name):
         ExporterNState.__init__(self, name)

--- a/HardwareObjects/abstract/AbstractShutter.py
+++ b/HardwareObjects/abstract/AbstractShutter.py
@@ -25,8 +25,6 @@ import abc
 from enum import Enum, unique
 from HardwareRepository.HardwareObjects.abstract.AbstractNState import AbstractNState
 
-from HardwareRepository.BaseHardwareObjects import HardwareObjectState
-
 __copyright__ = """ Copyright 2020 by the MXCuBE collaboration """
 __license__ = "LGPLv3+"
 
@@ -40,22 +38,10 @@ class BaseValueEnum(Enum):
     UNKNOWN = "UNKNOWN"
 
 
-@unique
-class ShutterStates(Enum):
-    """Shutter states definitions."""
-
-    OPEN = HardwareObjectState.READY, 6
-    CLOSED = HardwareObjectState.READY, 7
-    MOVING = HardwareObjectState.BUSY, 8
-    DISABLED = HardwareObjectState.WARNING, 9
-    AUTOMATIC = HardwareObjectState.READY, 10
-
-
 class AbstractShutter(AbstractNState):
     """Abstract base class for N state objects."""
 
     __metaclass__ = abc.ABCMeta
-    SPECIFIC_STATES = ShutterStates
     VALUES = BaseValueEnum
 
     def __init__(self, name):

--- a/HardwareObjects/mockup/ShutterMockup.py
+++ b/HardwareObjects/mockup/ShutterMockup.py
@@ -17,28 +17,46 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-from HardwareRepository.HardwareObjects.abstract. AbstractNState import AbstractNState
+""" Mockup shutter implementation"""
+
+from enum import Enum, unique
+from HardwareRepository.HardwareObjects.abstract.AbstractShutter import AbstractShutter
+from HardwareRepository.BaseHardwareObjects import HardwareObjectState
 from HardwareRepository.HardwareObjects.mockup.ActuatorMockup import ActuatorMockup
 
 
-class ShutterMockup(ActuatorMockup, AbstractNState):
+@unique
+class ShutterStates(Enum):
+    """Shutter states definitions."""
+
+    OPEN = HardwareObjectState.READY, 6
+    CLOSED = HardwareObjectState.READY, 7
+    MOVING = HardwareObjectState.BUSY, 8
+    DISABLED = HardwareObjectState.WARNING, 9
+    AUTOMATIC = HardwareObjectState.READY, 10
+
+
+class ShutterMockup(ActuatorMockup, AbstractShutter):
     """
     ShutterMockup for simulating a simple open/close shutter.
     """
 
+    SPECIFIC_STATES = ShutterStates
+
     def init(self):
+        """Initialisation"""
         super(ShutterMockup, self).init()
-        self.update_value(self.VALUES.CLOSED)
+        self.update_value(self.VALUES.CLOSE)
         self.update_state(self.STATES.READY)
 
     def is_open(self):
         return self.get_value() is self.VALUES.OPEN
 
     def is_closed(self):
-        return self.get_value() is self.VALUES.CLOSED
+        return self.get_value() is self.VALUES.CLOSE
 
     def open(self):
         self.set_value(self.VALUES.OPEN, timeout=None)
 
     def close(self):
-        self.set_value(self.VALUES.CLOSED, timeout=None)
+        self.set_value(self.VALUES.CLOSE, timeout=None)


### PR DESCRIPTION
Change the MicrodiffAperture to inherit from ExporterNstate rather than ExporterMotor.
I want to ask @all if aperture in/out action should in this class, or treated by a separate class.
Being a separate class is easier as it will be a simple ExporterNState, with the standard set/get_value methods. If we put it here, we would need an extra set/get_in.