### PR TITLE
Detector radius fix

### DIFF
--- a/HardwareObjects/abstract/AbstractDetector.py
+++ b/HardwareObjects/abstract/AbstractDetector.py
@@ -150,14 +150,14 @@ class AbstractDetector(HardwareObject):
         """
 
     def get_roi_mode(self):
-        """Read the current ROI mode.
+        """Get the current ROI mode.
         Returns:
             (str): current ROI mode
         """
         return self._roi_mode
 
     def set_roi_mode(self, roi_mode):
-        """
+        """Set the current ROI mode.
         Args:
             roi_mode (int): ROI mode to set.
         """
@@ -179,7 +179,7 @@ class AbstractDetector(HardwareObject):
         return tuple(self._roi_modes_list)
 
     def get_exposure_time_limits(self):
-        """Get the Exposure time lower and upper limits.
+        """Get the exposure time lower and upper limits.
         Returns:
             (tuple): Two floats (lower and upper limit) [s]
         """

--- a/HardwareObjects/abstract/AbstractDetector.py
+++ b/HardwareObjects/abstract/AbstractDetector.py
@@ -241,8 +241,10 @@ class AbstractDetector(HardwareObject):
         Returns:
             (float): Detector radius [mm]
         """
-        if distance is None:
-            return min(self.get_width() / 2.0, self.get_height() / 2.0)
+        try:
+            distance = distance or self._distance_motor_hwobj.get_value()
+        except AttributeError:
+            raise RuntimeError("Cannot calculate radius, distance unknown")
 
         beam_x, beam_y = self.get_beam_position(distance)
         pixel_x, pixel_y = self.get_pixel_size()

--- a/HardwareObjects/abstract/AbstractResolution.py
+++ b/HardwareObjects/abstract/AbstractResolution.py
@@ -150,8 +150,11 @@ class AbstractResolution(AbstractMotor):
         _wavelength = HWR.beamline.energy.get_wavelength()
 
         try:
+            distance = self._hwr_detector.get_radius() / (
+                tan(2 * asin(_wavelength / (2 * resolution)))
+            )
             return round(
-                self._hwr_detector.get_radius()
+                self._hwr_detector.get_radius(distance)
                 / (tan(2 * asin(_wavelength / (2 * resolution)))),
                 2,
             )


### PR DESCRIPTION
Fix the detector radius to be the min(width/2, height/2) if no distance argument in get_radius. The  get_radius with no argument is used to calculate resolution to distance.
Raise RuntimeError if no distance for outer radius -  cannot calculate the radius if both distance argument and distance motor are None.
Fixed bug in force_emit_signals.
Run black. Add documentation.
